### PR TITLE
feat(core): add structured focus serialization

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -21,6 +21,7 @@ describe('createAskableContext', () => {
     expect(typeof ctx.on).toBe('function');
     expect(typeof ctx.off).toBe('function');
     expect(typeof ctx.toPromptContext).toBe('function');
+    expect(typeof (ctx as any).serializeFocus).toBe('function');
     expect(typeof ctx.destroy).toBe('function');
     ctx.destroy();
   });
@@ -46,6 +47,72 @@ describe('createAskableContext', () => {
     expect(focus!.text).toBe('Revenue Chart');
     expect(typeof focus!.timestamp).toBe('number');
     expect(focus!.element).toBe(el);
+
+    ctx.destroy();
+    cleanup(el);
+  });
+
+  it('serializeFocus() returns null when nothing is focused', () => {
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    expect((ctx as any).serializeFocus()).toBeNull();
+    ctx.destroy();
+  });
+
+  it('serializeFocus() returns structured focused data', () => {
+    const el = makeEl({ metric: 'churn', value: '4.2%' }, 'Churn Rate');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    el.click();
+
+    expect((ctx as any).serializeFocus()).toEqual({
+      meta: { metric: 'churn', value: '4.2%' },
+      text: 'Churn Rate',
+      timestamp: expect.any(Number),
+    });
+
+    ctx.destroy();
+    cleanup(el);
+  });
+
+  it('serializeFocus() respects includeText and maxTextLength', () => {
+    const el = makeEl({ metric: 'churn' }, 'ABCDEFGHIJ');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    el.click();
+
+    expect((ctx as any).serializeFocus({ includeText: false })).toEqual({
+      meta: { metric: 'churn' },
+      timestamp: expect.any(Number),
+    });
+
+    expect((ctx as any).serializeFocus({ maxTextLength: 5 })).toEqual({
+      meta: { metric: 'churn' },
+      text: 'ABCDE',
+      timestamp: expect.any(Number),
+    });
+
+    ctx.destroy();
+    cleanup(el);
+  });
+
+  it('serializeFocus() respects excludeKeys and keyOrder', () => {
+    const el = makeEl({ z: 1, metric: 'churn', secret: 'x', value: '4.2%' }, 'Churn Rate');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    el.click();
+
+    expect((ctx as any).serializeFocus({
+      excludeKeys: ['secret'],
+      keyOrder: ['metric', 'value'],
+      includeText: false,
+    })).toEqual({
+      meta: { metric: 'churn', value: '4.2%', z: 1 },
+      timestamp: expect.any(Number),
+    });
 
     ctx.destroy();
     cleanup(el);

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -7,6 +7,7 @@ import type {
   AskableFocus,
   AskableObserveOptions,
   AskablePromptContextOptions,
+  AskableSerializedFocus,
 } from './types.js';
 
 export class AskableContextImpl implements AskableContext {
@@ -49,16 +50,12 @@ export class AskableContextImpl implements AskableContext {
     }
   }
 
-  toPromptContext(options?: AskablePromptContextOptions): string {
+  serializeFocus(options?: AskablePromptContextOptions): AskableSerializedFocus | null {
     const focus = this.currentFocus;
-    const format = options?.format ?? 'natural';
-
-    if (!focus) return format === 'json' ? 'null' : 'No UI element is currently focused.';
+    if (!focus) return null;
 
     const includeText = options?.includeText ?? true;
     const maxTextLength = options?.maxTextLength;
-    const textLabel = options?.textLabel ?? 'value';
-    const prefix = options?.prefix ?? 'User is focused on:';
 
     const meta = typeof focus.meta === 'string'
       ? focus.meta
@@ -66,21 +63,33 @@ export class AskableContextImpl implements AskableContext {
 
     const text = includeText ? this.normalizeText(focus.text, maxTextLength) : '';
 
+    return {
+      meta,
+      ...(text ? { text } : {}),
+      timestamp: focus.timestamp,
+    };
+  }
+
+  toPromptContext(options?: AskablePromptContextOptions): string {
+    const format = options?.format ?? 'natural';
+    const serialized = this.serializeFocus(options);
+
+    if (!serialized) return format === 'json' ? 'null' : 'No UI element is currently focused.';
+
     if (format === 'json') {
-      return JSON.stringify({
-        meta,
-        text: text || undefined,
-        timestamp: focus.timestamp,
-      });
+      return JSON.stringify(serialized);
     }
 
-    const metaStr = typeof meta === 'string'
-      ? meta
-      : Object.entries(meta).map(([k, v]) => `${k}: ${String(v)}`).join(', ');
+    const textLabel = options?.textLabel ?? 'value';
+    const prefix = options?.prefix ?? 'User is focused on:';
+
+    const metaStr = typeof serialized.meta === 'string'
+      ? serialized.meta
+      : Object.entries(serialized.meta).map(([k, v]) => `${k}: ${String(v)}`).join(', ');
 
     const parts: string[] = [prefix];
     if (metaStr) parts.push(metaStr);
-    if (text) parts.push(`${textLabel} "${text}"`);
+    if (serialized.text) parts.push(`${textLabel} "${serialized.text}"`);
 
     return parts.join(' — ');
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type {
   AskableFocus,
   AskablePromptContextOptions,
   AskablePromptFormat,
+  AskableSerializedFocus,
 } from './types.js';
 
 import { AskableContextImpl } from './context.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,6 +45,12 @@ export interface AskablePromptContextOptions {
   textLabel?: string;
 }
 
+export interface AskableSerializedFocus {
+  meta: Record<string, unknown> | string;
+  text?: string;
+  timestamp: number;
+}
+
 export interface AskableContext {
   /** Observe a DOM subtree for [data-askable] elements */
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void;
@@ -58,6 +64,8 @@ export interface AskableContext {
   off<K extends AskableEventName>(event: K, handler: AskableEventHandler<K>): void;
   /** Programmatically select an element — use for explicit "Ask AI" buttons */
   select(element: HTMLElement): void;
+  /** Serialize current focus to structured prompt-ready data */
+  serializeFocus(options?: AskablePromptContextOptions): AskableSerializedFocus | null;
   /** Serialize current focus to a prompt-ready string */
   toPromptContext(options?: AskablePromptContextOptions): string;
   /** Clean up all listeners and observers */


### PR DESCRIPTION
## Summary
- add serializeFocus() to core
- share serialization logic between structured and string output
- add TDD coverage for structured focus serialization

## Testing
- npm test -- --runInBand
- npm run build