### PR TITLE
feat(core): add hover throttle option

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -58,7 +58,7 @@ const ctx = createAskableContext();
 
 The main interface for interacting with Askable.
 
-#### `observe(root: HTMLElement | Document, options?: { events?: AskableEvent[] }): void`
+#### `observe(root: HTMLElement | Document, options?: { events?: AskableEvent[]; hoverDebounce?: number; hoverThrottle?: number }): void`
 
 Start observing a DOM subtree for `[data-askable]` elements. By default listens for `click`, `focus`, and `hover` events. Pass `events` to restrict which interactions trigger a context update.
 
@@ -75,6 +75,12 @@ ctx.observe(document, { events: ['focus'] });
 // Or observe a specific subtree
 const panel = document.getElementById('main-panel');
 ctx.observe(panel, { events: ['click', 'hover'] });
+
+// Debounce hover updates until the pointer settles
+ctx.observe(document, { events: ['hover'], hoverDebounce: 75 });
+
+// Or throttle hover updates for dense UIs
+ctx.observe(document, { events: ['hover'], hoverThrottle: 100 });
 ```
 
 #### `unobserve(): void`

--- a/packages/core/src/__tests__/observer.test.ts
+++ b/packages/core/src/__tests__/observer.test.ts
@@ -164,4 +164,39 @@ describe('Observer', () => {
 
     obs.unobserve();
   });
+
+  it('hover throttle: fires immediately, then suppresses rapid repeats inside the window', async () => {
+    const el = attach(makeEl({ id: 'throttle-hover' }, 'Throttle'));
+    const onFocus = vi.fn();
+    const obs = new Observer(onFocus);
+    obs.observe(document, ['hover'], 0, 50);
+
+    el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    expect(onFocus).toHaveBeenCalledOnce();
+
+    el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    expect(onFocus).toHaveBeenCalledOnce();
+
+    await new Promise((r) => setTimeout(r, 60));
+    el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    expect(onFocus).toHaveBeenCalledTimes(2);
+
+    obs.unobserve();
+  });
+
+  it('hover debounce takes precedence when debounce and throttle are both provided', async () => {
+    const el = attach(makeEl({ id: 'hover-precedence' }, 'Priority'));
+    const onFocus = vi.fn();
+    const obs = new Observer(onFocus);
+    obs.observe(document, ['hover'], 40, 5);
+
+    el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    expect(onFocus).not.toHaveBeenCalled();
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onFocus).toHaveBeenCalledOnce();
+
+    obs.unobserve();
+  });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -28,7 +28,12 @@ export class AskableContextImpl implements AskableContext {
   }
 
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void {
-    this.observer.observe(root, options?.events, options?.hoverDebounce ?? 0);
+    this.observer.observe(
+      root,
+      options?.events,
+      options?.hoverDebounce ?? 0,
+      options?.hoverThrottle ?? 0
+    );
   }
 
   unobserve(): void {

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -48,18 +48,27 @@ export class Observer {
   private onFocus: FocusCallback;
   private activeEvents: AskableEvent[] = ALL_EVENTS;
   private hoverDebounce = 0;
+  private hoverThrottle = 0;
   private hoverTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastHoverTimestamp = 0;
 
   constructor(onFocus: FocusCallback) {
     this.onFocus = onFocus;
   }
 
-  observe(root: HTMLElement | Document, events: AskableEvent[] = ALL_EVENTS, hoverDebounce = 0): void {
+  observe(
+    root: HTMLElement | Document,
+    events: AskableEvent[] = ALL_EVENTS,
+    hoverDebounce = 0,
+    hoverThrottle = 0
+  ): void {
     if (!isBrowser()) return;
     if (this.root) this.unobserve();
     this.root = root;
     this.activeEvents = events;
     this.hoverDebounce = hoverDebounce;
+    this.hoverThrottle = hoverThrottle;
+    this.lastHoverTimestamp = 0;
 
     const rootEl = root instanceof Document ? root.documentElement : root;
     rootEl.querySelectorAll<HTMLElement>('[data-askable]').forEach((el) => this.attach(el));
@@ -114,6 +123,12 @@ export class Observer {
         if (focus) this.onFocus(focus);
       }, this.hoverDebounce);
       return;
+    }
+
+    if (isHover && this.hoverThrottle > 0) {
+      const now = Date.now();
+      if (now - this.lastHoverTimestamp < this.hoverThrottle) return;
+      this.lastHoverTimestamp = now;
     }
 
     const focus = buildFocus(el);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,8 +30,15 @@ export interface AskableObserveOptions {
    * Debounce delay in ms applied to hover (mouseenter) events.
    * Prevents rapid context switches when the user moves the cursor across many elements.
    * Defaults to 0 (no debounce).
+   * When both hoverDebounce and hoverThrottle are provided, debounce takes precedence.
    */
   hoverDebounce?: number;
+  /**
+   * Throttle window in ms applied to hover (mouseenter) events.
+   * Emits at most one hover focus update per window, which can be useful for large dashboards.
+   * Defaults to 0 (no throttle).
+   */
+  hoverThrottle?: number;
 }
 
 export type AskablePromptFormat = 'natural' | 'json';


### PR DESCRIPTION
## Summary
- add a `hoverThrottle` observe option for hover-driven focus updates
- keep `hoverDebounce` behavior intact and make debounce take precedence if both are set
- document the new hover rate-limiting options and add coverage for the new behavior

Closes #36

## Testing
- npm test
- npm run build