### PR TITLE
fix(observer): detach removed askable subtrees

### DIFF
--- a/packages/core/src/__tests__/observer.test.ts
+++ b/packages/core/src/__tests__/observer.test.ts
@@ -115,6 +115,33 @@ describe('Observer', () => {
     expect(onFocus).toHaveBeenCalledOnce();
   });
 
+  it('detaches nested [data-askable] descendants when a subtree is removed', async () => {
+    const parent = attach(makeEl({ id: 'parent' }, 'Parent'));
+    const child = makeEl({ id: 'child' }, 'Child');
+    const grandchild = makeEl({ id: 'grandchild' }, 'Grandchild');
+    child.appendChild(grandchild);
+    parent.appendChild(child);
+    elements.push(child, grandchild);
+
+    const onFocus = vi.fn();
+    const obs = new Observer(onFocus);
+    obs.observe(document);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect((obs as { boundElements: Set<HTMLElement> }).boundElements.size).toBe(3);
+
+    parent.remove();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect((obs as { boundElements: Set<HTMLElement> }).boundElements.size).toBe(0);
+
+    child.click();
+    grandchild.click();
+    expect(onFocus).not.toHaveBeenCalled();
+
+    obs.unobserve();
+  });
+
   it('nested elements: innermost [data-askable] wins on click', () => {
     const outer = attach(makeEl({ level: 'outer' }, ''));
     const inner = makeEl({ level: 'inner' }, 'Inner text');

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -81,7 +81,7 @@ export class Observer {
           node.querySelectorAll<HTMLElement>('[data-askable]').forEach((el) => this.attach(el));
         });
         mutation.removedNodes.forEach((node) => {
-          if (node instanceof HTMLElement) this.detach(node);
+          if (node instanceof HTMLElement) this.detachTree(node);
         });
       }
     });
@@ -139,6 +139,11 @@ export class Observer {
     if (this.boundElements.has(el)) return;
     this.activeEvents.forEach((e) => el.addEventListener(EVENT_MAP[e], this.handleInteraction));
     this.boundElements.add(el);
+  }
+
+  private detachTree(root: HTMLElement): void {
+    this.detach(root);
+    root.querySelectorAll<HTMLElement>('[data-askable]').forEach((el) => this.detach(el));
   }
 
   private detach(el: HTMLElement): void {


### PR DESCRIPTION
## Summary
- detach removed askable roots and any nested `[data-askable]` descendants
- add a regression test covering parent subtree removal with nested askable children

## Why
Fixes #45. Removing a subtree previously detached only the removed root node, which could leave descendant askable elements in `boundElements` with stale listener bookkeeping.

## Testing
- `npx vitest run --environment jsdom packages/core/src/__tests__/observer.test.ts`
- `npx vitest run --environment jsdom packages/core/src/__tests__/*.test.ts`
- `npm run build --workspace @askable-ui/core`

