### PR TITLE
fix(adapters): make React/Vue/Svelte bindings SSR-safe

### DIFF
--- a/packages/react/src/__tests__/useAskable.ssr.test.tsx
+++ b/packages/react/src/__tests__/useAskable.ssr.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { useAskable } from '../useAskable.js';
+
+function Consumer() {
+  const { promptContext } = useAskable();
+  return React.createElement('div', null, promptContext);
+}
+
+describe('useAskable SSR', () => {
+  it('renders without touching document during SSR', () => {
+    expect(() => renderToString(React.createElement(Consumer))).not.toThrow();
+  });
+});

--- a/packages/react/src/useAskable.ts
+++ b/packages/react/src/useAskable.ts
@@ -5,10 +5,9 @@ import type { AskableEvent, AskableFocus, AskableContext } from '@askable-ui/cor
 let globalCtx: AskableContext | null = null;
 let refCount = 0;
 
-function getGlobalCtx(events?: AskableEvent[]): AskableContext {
+function getGlobalCtx(): AskableContext {
   if (!globalCtx) {
     globalCtx = createAskableContext();
-    globalCtx.observe(document, { events });
   }
   return globalCtx;
 }
@@ -24,7 +23,7 @@ export function useAskable(options?: {
   ctx?: AskableContext;
 }): UseAskableResult {
   const usesProvidedCtx = Boolean(options?.ctx);
-  const ctx = useRef<AskableContext>(options?.ctx ?? getGlobalCtx(options?.events));
+  const ctx = useRef<AskableContext>(options?.ctx ?? getGlobalCtx());
   const [focus, setFocus] = useState<AskableFocus | null>(() => ctx.current.getFocus());
 
   useEffect(() => {
@@ -32,6 +31,9 @@ export function useAskable(options?: {
 
     if (!usesProvidedCtx) {
       refCount++;
+      if (typeof document !== 'undefined') {
+        current.observe(document, { events: options?.events });
+      }
     }
 
     const handler = (f: AskableFocus) => setFocus(f);
@@ -50,7 +52,7 @@ export function useAskable(options?: {
         }
       }
     };
-  }, [usesProvidedCtx]);
+  }, [options?.events, usesProvidedCtx]);
 
   return {
     focus,

--- a/packages/svelte/src/__tests__/store.ssr.test.ts
+++ b/packages/svelte/src/__tests__/store.ssr.test.ts
@@ -1,0 +1,15 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { get } from 'svelte/store';
+import { createAskableStore } from '../askable.js';
+
+describe('createAskableStore SSR', () => {
+  it('can be created without document', () => {
+    expect(() => {
+      const store = createAskableStore();
+      expect(get(store.focus)).toBeNull();
+      expect(get(store.promptContext)).toBe('No UI element is currently focused.');
+      store.destroy();
+    }).not.toThrow();
+  });
+});

--- a/packages/svelte/src/askable.ts
+++ b/packages/svelte/src/askable.ts
@@ -11,7 +11,9 @@ export interface AskableStore {
 
 export function createAskableStore(options?: { events?: AskableEvent[] }) {
   const ctx = createAskableContext();
-  ctx.observe(document, { events: options?.events });
+  if (typeof document !== 'undefined') {
+    ctx.observe(document, { events: options?.events });
+  }
 
   const _focus = writable<AskableFocus | null>(null);
   ctx.on('focus', (f) => _focus.set(f));

--- a/packages/vue/src/__tests__/useAskable.ssr.test.ts
+++ b/packages/vue/src/__tests__/useAskable.ssr.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import { useAskable } from '../useAskable.js';
+
+const Consumer = defineComponent({
+  setup() {
+    const { promptContext } = useAskable();
+    return () => h('div', promptContext.value);
+  },
+});
+
+describe('useAskable SSR (Vue)', () => {
+  it('renders without touching document during SSR', async () => {
+    await expect(renderToString(h(Consumer))).resolves.toContain('No UI element is currently focused.');
+  });
+});

--- a/packages/vue/src/useAskable.ts
+++ b/packages/vue/src/useAskable.ts
@@ -5,10 +5,9 @@ import type { AskableEvent, AskableFocus, AskableContext } from '@askable-ui/cor
 let globalCtx: AskableContext | null = null;
 let refCount = 0;
 
-function getGlobalCtx(events?: AskableEvent[]): AskableContext {
+function getGlobalCtx(): AskableContext {
   if (!globalCtx) {
     globalCtx = createAskableContext();
-    globalCtx.observe(document, { events });
   }
   return globalCtx;
 }
@@ -20,7 +19,7 @@ export interface UseAskableResult {
 }
 
 export function useAskable(options?: { events?: AskableEvent[] }) {
-  const ctx = getGlobalCtx(options?.events);
+  const ctx = getGlobalCtx();
   const focus = ref<AskableFocus | null>(ctx.getFocus());
   // Reference focus.value so Vue tracks it as a reactive dependency;
   // ctx.toPromptContext() is a plain method and not itself reactive.
@@ -38,6 +37,9 @@ export function useAskable(options?: { events?: AskableEvent[] }) {
 
   onMounted(() => {
     refCount++;
+    if (typeof document !== 'undefined') {
+      ctx.observe(document, { events: options?.events });
+    }
     ctx.on('focus', handler);
     ctx.on('clear', clearHandler);
   });


### PR DESCRIPTION
## Summary
- defer React Askable observation to `useEffect()`
- defer Vue Askable observation to `onMounted()`
- guard Svelte store observation behind a browser check
- add SSR smoke tests for React, Vue, and Svelte bindings

## Why
Fixes the adapter-side SSR issues where bindings could touch `document` during server-side rendering or setup.

## Testing
- `npm run build --workspace @askable-ui/core`
- `npm test --workspace @askable-ui/react`
- `npm test --workspace @askable-ui/vue`
- `npm test --workspace @askable-ui/svelte`

## Related
- #32
- #41
- #42
- #43
- #44
