### PR TITLE
feat(examples): add initial CopilotKit React example scaffold

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+This directory contains runnable or in-progress example apps for Askable.
+
+- `copilotkit-react/` — scaffold for the React-based Askable integration example

--- a/examples/copilotkit-react/README.md
+++ b/examples/copilotkit-react/README.md
@@ -1,0 +1,18 @@
+# CopilotKit + Askable example (scaffold)
+
+This example is the starting point for a first-class Askable integration app.
+
+## Goal
+
+Show how Askable can provide UI-aware context to an AI chat / copilot flow in a realistic React app.
+
+## Planned pieces
+
+- React UI with askable cards/widgets
+- explicit `Ask AI` button flow using `ctx.select()`
+- a simple side-panel chat shell
+- a clear place to wire CopilotKit / AI SDK message flow
+
+## Current status
+
+This scaffold PR establishes the example app directory and starter files so follow-up implementation can land incrementally in reviewable PRs.

--- a/examples/copilotkit-react/index.html
+++ b/examples/copilotkit-react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Askable CopilotKit Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/copilotkit-react/package.json
+++ b/examples/copilotkit-react/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@askable-ui/example-copilotkit-react",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build"
+  },
+  "dependencies": {
+    "@askable-ui/core": "^0.1.0",
+    "@askable-ui/react": "^0.1.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.4.5",
+    "vite": "^5.4.19"
+  }
+}

--- a/examples/copilotkit-react/src/main.tsx
+++ b/examples/copilotkit-react/src/main.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Askable, useAskable } from '@askable-ui/react';
+
+function App() {
+  const { promptContext, ctx } = useAskable({ events: ['click'] });
+
+  return (
+    <div style={{ fontFamily: 'Inter, system-ui, sans-serif', padding: 24, maxWidth: 960, margin: '0 auto' }}>
+      <h1>Askable example scaffold</h1>
+      <p>This example will become the first-class CopilotKit / AI app integration demo.</p>
+
+      <Askable meta={{ widget: 'revenue-card', period: 'Q3', value: '$2.3M' }}>
+        <div style={{ border: '1px solid #ddd', borderRadius: 12, padding: 16, marginBottom: 16 }}>
+          <h2>Revenue</h2>
+          <p>$2.3M</p>
+          <button onClick={(e) => {
+            const target = (e.currentTarget as HTMLButtonElement).closest('[data-askable]') as HTMLElement | null;
+            if (target) ctx.select(target);
+          }}>
+            Ask AI about this card
+          </button>
+        </div>
+      </Askable>
+
+      <section style={{ border: '1px solid #ddd', borderRadius: 12, padding: 16, background: '#fafafa' }}>
+        <h2>Prompt context</h2>
+        <pre style={{ whiteSpace: 'pre-wrap' }}>{promptContext}</pre>
+      </section>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/copilotkit-react/tsconfig.json
+++ b/examples/copilotkit-react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add an `examples/` directory to the repo
- add an initial `copilotkit-react/` example scaffold
- include a minimal Askable React example showing an explicit `Ask AI` / `select()` flow
- establish a reviewable base for follow-up CopilotKit / AI SDK integration work

## Why
Askable needs a first-class example app lane, not just package-level docs. This PR starts that work with a concrete in-repo scaffold that can be expanded incrementally.

## Testing
- scaffold only
- not yet wired into the root workspace build/test pipeline

## Related
- #48
- #49
- #50
- #52
