### PR TITLE
feat: deploy VitePress docs to /docs/ on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,10 +26,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build VitePress docs
+        run: npm install && npm run build
+        working-directory: site/docs
+
+      - name: Copy docs into www
+        run: cp -r site/docs/.vitepress/dist site/www/docs
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
-      - name: Upload marketing site
+      - name: Upload site
         uses: actions/upload-pages-artifact@v3
         with:
           path: site/www

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
+  base: '/docs/',
   title: 'askable-ui',
   description: 'UI context your LLM can actually use. Annotate elements with data-askable and feed structured focus context into any AI assistant.',
   head: [
@@ -15,7 +16,7 @@ export default defineConfig({
       { text: 'API Reference', link: '/api/core', activeMatch: '/api/' },
       { text: 'Examples', link: '/examples/ai-sdk', activeMatch: '/examples/' },
       {
-        text: 'v0.1.4',
+        text: 'v0.2.0',
         items: [
           { text: 'Changelog', link: 'https://github.com/askable-ui/askable/releases' },
           { text: 'npm', link: 'https://www.npmjs.com/package/@askable-ui/core' },


### PR DESCRIPTION
The VitePress docs were being built in CI but never deployed. This PR:

- Sets `base: '/docs/'` in VitePress config so all assets resolve correctly under that path
- Updates the version badge in the nav from `v0.1.4` → `v0.2.0`
- Updates `pages.yml` to build the docs, copy them into `site/www/docs/`, then deploy the combined directory

After merging the pages workflow will deploy and the site will be available at:

- **Marketing site:** `https://askable-ui.github.io/askable/`
- **Docs:** `https://askable-ui.github.io/askable/docs/`