### PR TITLE
fix: correct VitePress base path for GitHub Pages

### DIFF
--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
-  base: '/docs/',
+  base: '/askable/docs/',
   title: 'askable-ui',
   description: 'UI context your LLM can actually use. Annotate elements with data-askable and feed structured focus context into any AI assistant.',
   head: [


### PR DESCRIPTION
**Problem:** No CSS/JS on the docs site. `base: '/docs/'` generates asset URLs like `/docs/assets/app.js`, but GitHub Pages serves the repo under `/askable/`, so the browser looks for `/docs/assets/app.js` (404) instead of `/askable/docs/assets/app.js`.

**Fix:** Change `base` to `'/askable/docs/'` to match the full GitHub Pages path for this repo.