### PR TITLE
fix: add missing logo SVGs for VitePress docs header

### DIFF
--- a/site/docs/public/logo-dark.svg
+++ b/site/docs/public/logo-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32">
+  <rect width="32" height="32" rx="8" fill="#ffffff" fill-opacity="0.12"/>
+  <text x="16" y="22" font-family="system-ui,sans-serif" font-size="18" font-weight="900" fill="white" text-anchor="middle">✦</text>
+  <text x="44" y="22" font-family="system-ui,sans-serif" font-size="16" font-weight="700" fill="#ffffff" dominant-baseline="auto">askable</text>
+</svg>

--- a/site/docs/public/logo-light.svg
+++ b/site/docs/public/logo-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32">
+  <rect width="32" height="32" rx="8" fill="#111317"/>
+  <text x="16" y="22" font-family="system-ui,sans-serif" font-size="18" font-weight="900" fill="white" text-anchor="middle">✦</text>
+  <text x="44" y="22" font-family="system-ui,sans-serif" font-size="16" font-weight="700" fill="#111317" dominant-baseline="auto">askable</text>
+</svg>


### PR DESCRIPTION
The VitePress config referenced `/logo-light.svg` and `/logo-dark.svg` but no files existed — the `public/` directory was missing entirely.

Adds `site/docs/public/logo-light.svg` and `logo-dark.svg` with the same ✦ icon style as the favicon, plus the "askable" wordmark. Light variant uses a dark icon on white; dark variant uses white text on a semi-transparent background.