### PR TITLE
fix: remove wordmark from logo SVGs — icon only

### DIFF
--- a/site/docs/public/logo-dark.svg
+++ b/site/docs/public/logo-dark.svg
@@ -1,5 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="8" fill="#ffffff" fill-opacity="0.12"/>
   <text x="16" y="22" font-family="system-ui,sans-serif" font-size="18" font-weight="900" fill="white" text-anchor="middle">✦</text>
-  <text x="44" y="22" font-family="system-ui,sans-serif" font-size="16" font-weight="700" fill="#ffffff" dominant-baseline="auto">askable</text>
 </svg>

--- a/site/docs/public/logo-light.svg
+++ b/site/docs/public/logo-light.svg
@@ -1,5 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="8" fill="#111317"/>
   <text x="16" y="22" font-family="system-ui,sans-serif" font-size="18" font-weight="900" fill="white" text-anchor="middle">✦</text>
-  <text x="44" y="22" font-family="system-ui,sans-serif" font-size="16" font-weight="700" fill="#111317" dominant-baseline="auto">askable</text>
 </svg>


### PR DESCRIPTION
The logo SVGs included an "askable" wordmark, causing the header to read "askable askable-ui" (logo text + VitePress siteTitle). Strips the wordmark from both SVGs — the ✦ icon only. VitePress renders the site title text separately.