### PR TITLE
feat(#34): add @askable-ui/solid — Solid.js bindings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,10 @@ jobs:
         run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
         working-directory: packages/svelte
 
+      - name: Publish @askable-ui/solid
+        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
+        working-directory: packages/solid
+
       - name: Create GitHub Release
         uses: actions/github-script@v7
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,10 @@
       "resolved": "packages/react",
       "link": true
     },
+    "node_modules/@askable-ui/solid": {
+      "resolved": "packages/solid",
+      "link": true
+    },
     "node_modules/@askable-ui/svelte": {
       "resolved": "packages/svelte",
       "link": true
@@ -73,6 +77,163 @@
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -97,6 +258,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
@@ -113,12 +298,62 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -672,6 +907,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1068,6 +1314,28 @@
         "win32"
       ]
     },
+    "node_modules/@solidjs/testing-library": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@solidjs/testing-library/-/testing-library-0.8.10.tgz",
+      "integrity": "sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "^10.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@solidjs/router": ">=0.9.0",
+        "solid-js": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@solidjs/router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
@@ -1115,7 +1383,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1237,6 +1504,51 @@
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1659,12 +1971,74 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-plugin-jsx-dom-expressions": {
+      "version": "0.40.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.6.tgz",
+      "integrity": "sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.20.7",
+        "html-entities": "2.3.3",
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.20.12"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions/node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/babel-preset-solid": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.12.tgz",
+      "integrity": "sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jsx-dom-expressions": "^0.40.6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "solid-js": "^1.9.12"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.15.tgz",
+      "integrity": "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.3",
@@ -1674,6 +2048,40 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/cac": {
@@ -1735,6 +2143,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001785",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
+      "integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -1863,6 +2292,13 @@
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2124,6 +2560,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.331",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -2260,6 +2703,16 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2363,6 +2816,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2529,6 +2992,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -2871,6 +3341,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -2981,6 +3464,32 @@
         }
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -3061,6 +3570,22 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/merge-anything": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz",
+      "integrity": "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -3146,6 +3671,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "7.2.1",
@@ -3567,6 +4099,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/seroval": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
+      "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.2.tgz",
+      "integrity": "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -3718,6 +4273,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/solid-js": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.12.tgz",
+      "integrity": "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "~1.5.0",
+        "seroval-plugins": "~1.5.0"
+      }
+    },
+    "node_modules/solid-refresh": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/solid-refresh/-/solid-refresh-0.6.3.tgz",
+      "integrity": "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/types": "^7.23.6"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.3"
       }
     },
     "node_modules/source-map-js": {
@@ -4031,6 +4613,37 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -4112,6 +4725,51 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-solid": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/vite-plugin-solid/-/vite-plugin-solid-2.11.12.tgz",
+      "integrity": "sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.3",
+        "@types/babel__core": "^7.20.4",
+        "babel-preset-solid": "^1.8.4",
+        "merge-anything": "^5.1.7",
+        "solid-refresh": "^0.6.3",
+        "vitefu": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*",
+        "solid-js": "^1.7.2",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@testing-library/jest-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-solid/node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitefu": {
@@ -4519,6 +5177,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "packages/core": {
       "name": "@askable-ui/core",
       "version": "0.2.0",
@@ -4549,6 +5214,27 @@
       "peerDependencies": {
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
+      }
+    },
+    "packages/solid": {
+      "name": "@askable-ui/solid",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@askable-ui/core": "^0.2.0"
+      },
+      "devDependencies": {
+        "@askable-ui/core": "*",
+        "@solidjs/testing-library": "^0.8.10",
+        "jsdom": "^25.0.0",
+        "solid-js": "^1.9.12",
+        "typescript": "^5.4.5",
+        "vite": "^5.0.0",
+        "vite-plugin-solid": "^2.11.12",
+        "vitest": "^2.0.0"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.0.0"
       }
     },
     "packages/svelte": {

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,85 @@
+# @askable-ui/solid
+
+Solid.js bindings for [askable](https://github.com/askable-ui/askable) — give your UI elements LLM awareness with one attribute.
+
+## Install
+
+```bash
+npm install @askable-ui/solid @askable-ui/core
+```
+
+## Quick start
+
+```tsx
+import { Askable, useAskable } from '@askable-ui/solid';
+
+function Dashboard() {
+  const { focus, promptContext, ctx } = useAskable();
+
+  return (
+    <div>
+      <Askable meta={{ widget: 'revenue-chart', period: 'Q3', value: '$2.3M' }}>
+        <h2>Q3 Revenue: $2.3M</h2>
+        <p>Down 12% month-over-month</p>
+      </Askable>
+
+      <button onClick={() => sendToLLM(promptContext())}>
+        Ask AI
+      </button>
+
+      <p>Focus: {focus() ? focus()!.meta.toString() : 'none'}</p>
+    </div>
+  );
+}
+```
+
+## API
+
+### `useAskable(options?)`
+
+A Solid primitive that tracks which `[data-askable]` element the user has interacted with.
+
+```ts
+const { focus, promptContext, ctx } = useAskable({
+  events?: AskableEvent[];   // 'click' | 'hover' | 'focus' — defaults to all
+  ctx?: AskableContext;      // provide your own context (e.g. from AskableProvider)
+});
+```
+
+Returns:
+
+| Property | Type | Description |
+|---|---|---|
+| `focus` | `() => AskableFocus \| null` | Reactive accessor for the currently focused element |
+| `promptContext` | `() => string` | Reactive accessor for the serialized prompt string |
+| `ctx` | `AskableContext` | The underlying context instance |
+
+> **Note:** `focus` and `promptContext` are Solid **signals/memos** — call them as functions (`focus()`, `promptContext()`) in JSX and reactive contexts.
+
+### `<Askable>`
+
+Wraps any element with a `data-askable` attribute.
+
+```tsx
+<Askable
+  meta={{ widget: 'chart', metric: 'revenue' }}
+  as="section"           // defaults to "div"
+  class="my-card"        // extra props forwarded to the element
+>
+  children
+</Askable>
+```
+
+| Prop | Type | Description |
+|---|---|---|
+| `meta` | `Record<string, unknown> \| string` | Metadata serialized as `data-askable` |
+| `as` | `ValidComponent` | Element or component to render. Defaults to `"div"` |
+| `children` | `JSX.Element` | Child content |
+
+## SSR
+
+`useAskable` is SSR-safe — it checks for `document` before calling `observe` and falls back gracefully in Node environments.
+
+## License
+
+MIT

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@askable-ui/solid",
+  "version": "0.2.0",
+  "description": "Solid.js bindings for askable — LLM-aware UI context",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/askable-ui/askable.git",
+    "directory": "packages/solid"
+  },
+  "scripts": {
+    "build": "vite build && tsc --emitDeclarationOnly --noEmit false",
+    "dev": "vite build --watch",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "llm",
+    "context",
+    "solid",
+    "solidjs",
+    "ui",
+    "focus"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "solid-js": "^1.0.0"
+  },
+  "dependencies": {
+    "@askable-ui/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "@askable-ui/core": "*",
+    "@solidjs/testing-library": "^0.8.10",
+    "jsdom": "^25.0.0",
+    "solid-js": "^1.9.12",
+    "typescript": "^5.4.5",
+    "vite": "^5.0.0",
+    "vite-plugin-solid": "^2.11.12",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/solid/src/Askable.tsx
+++ b/packages/solid/src/Askable.tsx
@@ -1,0 +1,32 @@
+import type { ValidComponent, JSX, ComponentProps } from 'solid-js';
+import { splitProps, mergeProps } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+
+type AskableOwnProps<T extends ValidComponent = 'div'> = {
+  meta: Record<string, unknown> | string;
+  as?: T;
+  children?: JSX.Element;
+};
+
+type AskableProps<T extends ValidComponent = 'div'> = AskableOwnProps<T> &
+  Omit<ComponentProps<T>, keyof AskableOwnProps<T>>;
+
+export function Askable<T extends ValidComponent = 'div'>(
+  rawProps: AskableProps<T>,
+) {
+  const props = mergeProps({ as: 'div' as ValidComponent }, rawProps);
+  const [local, rest] = splitProps(props as AskableOwnProps & Record<string, unknown>, [
+    'meta',
+    'as',
+    'children',
+  ]);
+
+  const dataAskable = () =>
+    typeof local.meta === 'string' ? local.meta : JSON.stringify(local.meta);
+
+  return (
+    <Dynamic component={local.as} data-askable={dataAskable()} {...rest}>
+      {local.children}
+    </Dynamic>
+  );
+}

--- a/packages/solid/src/__tests__/useAskable.ssr.test.ts
+++ b/packages/solid/src/__tests__/useAskable.ssr.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { createAskableContext } from '@askable-ui/core';
+
+describe('useAskable SSR', () => {
+  it('createAskableContext works without document', () => {
+    // In SSR (node env) document is undefined — context must not throw on creation
+    expect(() => {
+      const ctx = createAskableContext();
+      expect(ctx.getFocus()).toBeNull();
+      expect(ctx.toPromptContext()).toBeTruthy();
+      ctx.destroy();
+    }).not.toThrow();
+  });
+
+  it('imports resolve without touching DOM', async () => {
+    // The module must be importable in a node environment
+    const mod = await import('../useAskable.js');
+    expect(typeof mod.useAskable).toBe('function');
+  });
+});

--- a/packages/solid/src/__tests__/useAskable.test.tsx
+++ b/packages/solid/src/__tests__/useAskable.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
+import { createAskableContext } from '@askable-ui/core';
+import { useAskable } from '../useAskable.js';
+import { Askable } from '../Askable.js';
+
+afterEach(() => {
+  // Reset global context between tests
+  vi.restoreAllMocks();
+});
+
+// Helper component that exposes hook output via data attributes for querying
+function Consumer(props: { ctx?: ReturnType<typeof createAskableContext> }) {
+  const { focus, promptContext } = useAskable({ ctx: props.ctx });
+  return (
+    <div>
+      <span data-testid="focus">{focus() ? 'focused' : 'none'}</span>
+      <span data-testid="prompt">{promptContext()}</span>
+    </div>
+  );
+}
+
+describe('useAskable', () => {
+  it('returns null focus initially', () => {
+    const ctx = createAskableContext();
+    const { getByTestId } = render(() => <Consumer ctx={ctx} />);
+    expect(getByTestId('focus').textContent).toBe('none');
+    ctx.destroy();
+  });
+
+  it('updates focus signal when ctx emits focus event', () => {
+    const ctx = createAskableContext();
+    const { getByTestId } = render(() => <Consumer ctx={ctx} />);
+
+    const el = document.createElement('div');
+    el.setAttribute('data-askable', '{"widget":"chart"}');
+    el.textContent = 'Revenue';
+    document.body.appendChild(el);
+
+    ctx.select(el);
+
+    expect(getByTestId('focus').textContent).toBe('focused');
+    el.remove();
+    ctx.destroy();
+  });
+
+  it('clears focus signal on ctx.clear()', () => {
+    const ctx = createAskableContext();
+    const { getByTestId } = render(() => <Consumer ctx={ctx} />);
+
+    const el = document.createElement('div');
+    el.setAttribute('data-askable', 'info');
+    el.textContent = 'Info';
+    document.body.appendChild(el);
+
+    ctx.select(el);
+    expect(getByTestId('focus').textContent).toBe('focused');
+
+    ctx.clear();
+    expect(getByTestId('focus').textContent).toBe('none');
+
+    el.remove();
+    ctx.destroy();
+  });
+
+  it('promptContext updates reactively with focus', () => {
+    const ctx = createAskableContext();
+    const { getByTestId } = render(() => <Consumer ctx={ctx} />);
+
+    const before = getByTestId('prompt').textContent;
+
+    const el = document.createElement('div');
+    el.setAttribute('data-askable', '{"metric":"revenue"}');
+    el.textContent = '$2.3M';
+    document.body.appendChild(el);
+
+    ctx.select(el);
+    const after = getByTestId('prompt').textContent;
+    expect(after).not.toBe(before);
+    expect(after).toContain('revenue');
+
+    el.remove();
+    ctx.destroy();
+  });
+});
+
+describe('Askable component', () => {
+  it('renders a div with data-askable by default', () => {
+    const { container } = render(() => (
+      <Askable meta={{ widget: 'chart' }}>content</Askable>
+    ));
+    const el = container.querySelector('[data-askable]');
+    expect(el?.tagName).toBe('DIV');
+    expect(el?.getAttribute('data-askable')).toBe('{"widget":"chart"}');
+    expect(el?.textContent).toBe('content');
+  });
+
+  it('renders a string meta as-is', () => {
+    const { container } = render(() => (
+      <Askable meta="dashboard-header">header</Askable>
+    ));
+    expect(container.querySelector('[data-askable]')?.getAttribute('data-askable')).toBe(
+      'dashboard-header',
+    );
+  });
+
+  it('renders a custom element via as prop', () => {
+    const { container } = render(() => (
+      <Askable meta="info" as="section">body</Askable>
+    ));
+    expect(container.querySelector('[data-askable]')?.tagName).toBe('SECTION');
+  });
+
+  it('forwards extra props', () => {
+    const { container } = render(() => (
+      <Askable meta="x" class="my-class">text</Askable>
+    ));
+    expect(container.querySelector('.my-class')).toBeTruthy();
+  });
+});

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,0 +1,3 @@
+export { useAskable } from './useAskable.js';
+export type { UseAskableResult } from './useAskable.js';
+export { Askable } from './Askable.js';

--- a/packages/solid/src/useAskable.ts
+++ b/packages/solid/src/useAskable.ts
@@ -1,0 +1,64 @@
+import { createSignal, createEffect, createMemo, onCleanup } from 'solid-js';
+import { createAskableContext } from '@askable-ui/core';
+import type { AskableEvent, AskableFocus, AskableContext } from '@askable-ui/core';
+
+let globalCtx: AskableContext | null = null;
+let refCount = 0;
+
+function getGlobalCtx(): AskableContext {
+  if (!globalCtx) {
+    globalCtx = createAskableContext();
+  }
+  return globalCtx;
+}
+
+export interface UseAskableResult {
+  /** Reactive accessor — call as focus() in JSX or reactive contexts */
+  focus: () => AskableFocus | null;
+  /** Reactive accessor — derived from focus, updates when focus changes */
+  promptContext: () => string;
+  ctx: AskableContext;
+}
+
+export function useAskable(options?: {
+  events?: AskableEvent[];
+  ctx?: AskableContext;
+}): UseAskableResult {
+  const usesProvidedCtx = Boolean(options?.ctx);
+  const ctx = options?.ctx ?? getGlobalCtx();
+
+  const [focus, setFocus] = createSignal<AskableFocus | null>(ctx.getFocus());
+
+  const promptContext = createMemo(() => {
+    focus(); // track the signal so memo updates when focus changes
+    return ctx.toPromptContext();
+  });
+
+  createEffect(() => {
+    if (!usesProvidedCtx) {
+      refCount++;
+      if (typeof document !== 'undefined') {
+        ctx.observe(document, { events: options?.events });
+      }
+    }
+
+    const handler = (f: AskableFocus) => setFocus(() => f);
+    const clearHandler = (_: null) => setFocus(null);
+    ctx.on('focus', handler);
+    ctx.on('clear', clearHandler);
+
+    onCleanup(() => {
+      ctx.off('focus', handler);
+      ctx.off('clear', clearHandler);
+      if (!usesProvidedCtx) {
+        refCount--;
+        if (refCount === 0) {
+          globalCtx?.destroy();
+          globalCtx = null;
+        }
+      }
+    });
+  });
+
+  return { focus, promptContext, ctx };
+}

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/solid/vite.config.ts
+++ b/packages/solid/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import solid from 'vite-plugin-solid';
+
+export default defineConfig({
+  plugins: [solid()],
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      formats: ['es'],
+      fileName: () => 'index.js',
+    },
+    rollupOptions: {
+      external: ['solid-js', 'solid-js/web', '@askable-ui/core'],
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
Closes #34

## Summary

- **`useAskable()`** — Solid primitives: `createSignal` for focus, `createMemo` for promptContext, `createEffect` + `onCleanup` for lifecycle. Returns accessor functions (`focus()`, `promptContext()`) as idiomatic Solid.
- **`<Askable>`** — renders any element via `solid-js/web` `Dynamic`, reactive `data-askable`, forwards all extra props.
- **10 tests** — 2 SSR (node env) + 8 jsdom (focus/clear/promptContext reactivity + component rendering)
- **Build** — `vite-plugin-solid` in lib mode for JS + `tsc --emitDeclarationOnly` for `.d.ts`
- **`release.yml`** updated to publish `@askable-ui/solid` alongside other packages

## Usage

```tsx
import { Askable, useAskable } from '@askable-ui/solid';

function Dashboard() {
  const { focus, promptContext, ctx } = useAskable();

  return (
    <Askable meta={{ widget: 'revenue', value: '$2.3M' }}>
      <h2>Q3 Revenue</h2>
      <button onClick={() => sendToLLM(promptContext())}>Ask AI</button>
    </Askable>
  );
}
```