### PR TITLE
feat(core): prompt presets and data-askable-priority targeting (#21, #20)

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -448,6 +448,93 @@ describe('createAskableContext', () => {
     cleanup(el2);
   });
 
+  describe('preset option', () => {
+    it('compact preset omits text and uses natural format', () => {
+      const el = makeEl({ metric: 'churn', value: '4.2%' }, 'Churn Rate');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const prompt = ctx.toPromptContext({ preset: 'compact' });
+      expect(prompt).toContain('User is focused on');
+      expect(prompt).toContain('metric: churn');
+      expect(prompt).not.toContain('Churn Rate');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('verbose preset includes text and uses natural format', () => {
+      const el = makeEl({ metric: 'churn' }, 'Churn Rate');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const prompt = ctx.toPromptContext({ preset: 'verbose' });
+      expect(prompt).toContain('User is focused on');
+      expect(prompt).toContain('Churn Rate');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('json preset returns JSON with text', () => {
+      const el = makeEl({ metric: 'churn' }, 'Churn Rate');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const prompt = ctx.toPromptContext({ preset: 'json' });
+      const parsed = JSON.parse(prompt);
+      expect(parsed.meta).toEqual({ metric: 'churn' });
+      expect(parsed.text).toBe('Churn Rate');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('individual options override the preset', () => {
+      const el = makeEl({ metric: 'churn' }, 'Churn Rate');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      // compact sets includeText: false, but we override it to true
+      const prompt = ctx.toPromptContext({ preset: 'compact', includeText: true });
+      expect(prompt).toContain('Churn Rate');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('serializeFocus() respects preset', () => {
+      const el = makeEl({ metric: 'churn' }, 'Churn Rate');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const serialized = (ctx as any).serializeFocus({ preset: 'compact' });
+      expect(serialized.text).toBeUndefined();
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('toHistoryContext() respects preset', () => {
+      const el = makeEl({ metric: 'mrr' }, 'MRR');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const history = ctx.toHistoryContext(undefined, { preset: 'compact' });
+      expect(history).toContain('mrr');
+      expect(history).not.toContain('MRR');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+  });
+
   it('observe() is a no-op when called outside a browser environment', () => {
     const win = globalThis.window;
     Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });

--- a/packages/core/src/__tests__/observer.test.ts
+++ b/packages/core/src/__tests__/observer.test.ts
@@ -160,6 +160,65 @@ describe('Observer', () => {
     obs.unobserve();
   });
 
+  it('data-askable-priority: outer with higher priority wins over inner', () => {
+    const outer = attach(makeEl({ level: 'outer' }, 'Outer'));
+    outer.setAttribute('data-askable-priority', '10');
+    const inner = makeEl({ level: 'inner' }, 'Inner');
+    outer.appendChild(inner);
+    elements.push(inner);
+
+    const onFocus = vi.fn();
+    const obs = new Observer(onFocus);
+    obs.observe(document);
+
+    inner.click();
+
+    expect(onFocus).toHaveBeenCalledOnce();
+    expect((onFocus.mock.calls[0][0].meta as Record<string, unknown>).level).toBe('outer');
+
+    obs.unobserve();
+  });
+
+  it('data-askable-priority: equal priority — inner still wins', () => {
+    const outer = attach(makeEl({ level: 'outer' }, 'Outer'));
+    outer.setAttribute('data-askable-priority', '5');
+    const inner = makeEl({ level: 'inner' }, 'Inner');
+    inner.setAttribute('data-askable-priority', '5');
+    outer.appendChild(inner);
+    elements.push(inner);
+
+    const onFocus = vi.fn();
+    const obs = new Observer(onFocus);
+    obs.observe(document);
+
+    inner.click();
+
+    expect(onFocus).toHaveBeenCalledOnce();
+    expect((onFocus.mock.calls[0][0].meta as Record<string, unknown>).level).toBe('inner');
+
+    obs.unobserve();
+  });
+
+  it('data-askable-priority: inner with higher priority still wins', () => {
+    const outer = attach(makeEl({ level: 'outer' }, 'Outer'));
+    outer.setAttribute('data-askable-priority', '10');
+    const inner = makeEl({ level: 'inner' }, 'Inner');
+    inner.setAttribute('data-askable-priority', '20');
+    outer.appendChild(inner);
+    elements.push(inner);
+
+    const onFocus = vi.fn();
+    const obs = new Observer(onFocus);
+    obs.observe(document);
+
+    inner.click();
+
+    expect(onFocus).toHaveBeenCalledOnce();
+    expect((onFocus.mock.calls[0][0].meta as Record<string, unknown>).level).toBe('inner');
+
+    obs.unobserve();
+  });
+
   it('hover debounce: does not fire immediately', async () => {
     const el = attach(makeEl({ id: 'debounce-test' }, 'Hover'));
     const onFocus = vi.fn();

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -7,8 +7,15 @@ import type {
   AskableFocus,
   AskableObserveOptions,
   AskablePromptContextOptions,
+  AskablePromptPreset,
   AskableSerializedFocus,
 } from './types.js';
+
+const PRESETS: Record<AskablePromptPreset, AskablePromptContextOptions> = {
+  compact: { includeText: false, format: 'natural' },
+  verbose: { includeText: true, format: 'natural' },
+  json: { format: 'json', includeText: true },
+};
 
 const MAX_HISTORY = 50;
 
@@ -74,20 +81,22 @@ export class AskableContextImpl implements AskableContext {
 
   serializeFocus(options?: AskablePromptContextOptions): AskableSerializedFocus | null {
     if (!this.currentFocus) return null;
-    return this.serializeFocusFrom(this.currentFocus, options);
+    return this.serializeFocusFrom(this.currentFocus, this.resolveOptions(options));
   }
 
   toPromptContext(options?: AskablePromptContextOptions): string {
-    const output = this.buildPromptString(this.currentFocus, options);
-    return this.applyTokenBudget(output, options?.maxTokens);
+    const resolved = this.resolveOptions(options);
+    const output = this.buildPromptString(this.currentFocus, resolved);
+    return this.applyTokenBudget(output, resolved.maxTokens);
   }
 
   toHistoryContext(limit?: number, options?: AskablePromptContextOptions): string {
+    const resolved = this.resolveOptions(options);
     const history = this.getHistory(limit);
     if (history.length === 0) return 'No interaction history.';
-    const lines = history.map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, options)}`);
+    const lines = history.map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
     const output = lines.join('\n');
-    return this.applyTokenBudget(output, options?.maxTokens);
+    return this.applyTokenBudget(output, resolved.maxTokens);
   }
 
   destroy(): void {
@@ -125,8 +134,9 @@ export class AskableContextImpl implements AskableContext {
   }
 
   private buildPromptString(focus: AskableFocus | null, options?: AskablePromptContextOptions): string {
-    const format = options?.format ?? 'natural';
-    const serialized = focus ? this.serializeFocusFrom(focus, options) : null;
+    const resolved = this.resolveOptions(options);
+    const format = resolved.format ?? 'natural';
+    const serialized = focus ? this.serializeFocusFrom(focus, resolved) : null;
 
     if (!serialized) return format === 'json' ? 'null' : 'No UI element is currently focused.';
 
@@ -134,8 +144,8 @@ export class AskableContextImpl implements AskableContext {
       return JSON.stringify(serialized);
     }
 
-    const textLabel = options?.textLabel ?? 'value';
-    const prefix = options?.prefix ?? 'User is focused on:';
+    const textLabel = resolved.textLabel ?? 'value';
+    const prefix = resolved.prefix ?? 'User is focused on:';
 
     const metaStr = typeof serialized.meta === 'string'
       ? serialized.meta
@@ -149,12 +159,13 @@ export class AskableContextImpl implements AskableContext {
   }
 
   private serializeFocusFrom(focus: AskableFocus, options?: AskablePromptContextOptions): AskableSerializedFocus {
-    const includeText = options?.includeText ?? true;
-    const maxTextLength = options?.maxTextLength;
+    const resolved = this.resolveOptions(options);
+    const includeText = resolved.includeText ?? true;
+    const maxTextLength = resolved.maxTextLength;
 
     const meta = typeof focus.meta === 'string'
       ? focus.meta
-      : this.normalizeMeta(focus.meta, options);
+      : this.normalizeMeta(focus.meta, resolved);
 
     const text = includeText ? this.normalizeText(focus.text, maxTextLength) : '';
 
@@ -163,6 +174,12 @@ export class AskableContextImpl implements AskableContext {
       ...(text ? { text } : {}),
       timestamp: focus.timestamp,
     };
+  }
+
+  private resolveOptions(options?: AskablePromptContextOptions): AskablePromptContextOptions {
+    if (!options?.preset) return options ?? {};
+    const { preset, ...rest } = options;
+    return { ...PRESETS[preset], ...rest };
   }
 
   private applyTokenBudget(output: string, maxTokens?: number): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export type {
   AskableObserveOptions,
   AskablePromptContextOptions,
   AskablePromptFormat,
+  AskablePromptPreset,
   AskableSerializedFocus,
 } from './types.js';
 

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -104,13 +104,29 @@ export class Observer {
   private handleInteraction = (event: Event): void => {
     const el = event.currentTarget as HTMLElement;
 
-    // Nested element priority: when a click/hover reaches a parent [data-askable],
-    // check if the actual target is inside a closer (nested) askable descendant that
-    // is also bound. If so, skip — the inner element takes precedence.
+    // Nested element priority: resolve which [data-askable] element should
+    // handle the event when nested elements are involved.
+    // data-askable-priority (numeric, higher wins) overrides the default innermost-wins rule.
     const target = event.target as HTMLElement;
     if (target !== el) {
+      // Event bubbled from a deeper target — check if a closer descendant should win.
       const closer = target.closest('[data-askable]');
-      if (closer && closer !== el && el.contains(closer)) return;
+      if (closer && closer !== el && el.contains(closer)) {
+        const elPriority = parseInt(el.getAttribute('data-askable-priority') ?? '0', 10);
+        const closerPriority = parseInt((closer as HTMLElement).getAttribute('data-askable-priority') ?? '0', 10);
+        if (elPriority <= closerPriority) return;
+      }
+    } else {
+      // Direct target — check if any [data-askable] ancestor has higher priority.
+      const elPriority = parseInt(el.getAttribute('data-askable-priority') ?? '0', 10);
+      let ancestor = el.parentElement;
+      while (ancestor) {
+        if (ancestor.hasAttribute('data-askable')) {
+          const ancestorPriority = parseInt(ancestor.getAttribute('data-askable-priority') ?? '0', 10);
+          if (ancestorPriority > elPriority) return;
+        }
+        ancestor = ancestor.parentElement;
+      }
     }
 
     const isHover = event.type === 'mouseenter';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,7 +43,25 @@ export interface AskableObserveOptions {
 
 export type AskablePromptFormat = 'natural' | 'json';
 
+/**
+ * Named presets for prompt serialization. Individual options override the preset.
+ *
+ * - `compact`  — meta only, no text content. Good for tight token budgets.
+ * - `verbose`  — meta + full text (same as default, but explicit).
+ * - `json`     — structured JSON output, includes meta + text.
+ */
+export type AskablePromptPreset = 'compact' | 'verbose' | 'json';
+
 export interface AskablePromptContextOptions {
+  /**
+   * Apply a named preset as the default configuration.
+   * Individual options specified alongside the preset take precedence.
+   *
+   * - `compact` → `{ includeText: false, format: 'natural' }`
+   * - `verbose` → `{ includeText: true, format: 'natural' }`
+   * - `json`    → `{ format: 'json', includeText: true }`
+   */
+  preset?: AskablePromptPreset;
   /** Output format. Defaults to natural language. */
   format?: AskablePromptFormat;
   /** Include extracted text in serialized output. Defaults to true. */

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -9,6 +9,7 @@ import type {
   AskableSerializedFocus,
   AskablePromptContextOptions,
   AskablePromptFormat,
+  AskablePromptPreset,
   AskableEvent,
   AskableObserveOptions,
   AskableEventMap,
@@ -52,12 +53,29 @@ interface AskableSerializedFocus {
 
 ---
 
+## `AskablePromptPreset`
+
+Named shorthand for common option combinations. See [Prompt Serialization → Presets](/guide/serialization#presets).
+
+```ts
+type AskablePromptPreset = 'compact' | 'verbose' | 'json';
+```
+
+| Value | Equivalent |
+|---|---|
+| `compact` | `{ includeText: false, format: 'natural' }` |
+| `verbose` | `{ includeText: true, format: 'natural' }` |
+| `json` | `{ format: 'json', includeText: true }` |
+
+---
+
 ## `AskablePromptContextOptions`
 
 Options accepted by `toPromptContext()`, `toHistoryContext()`, and `serializeFocus()`.
 
 ```ts
 interface AskablePromptContextOptions {
+  preset?: AskablePromptPreset;    // Named shorthand. Individual options override it.
   format?: AskablePromptFormat;    // 'natural' | 'json'. Default: 'natural'
   includeText?: boolean;           // Include element text. Default: true
   maxTextLength?: number;          // Truncate text to N chars

--- a/site/docs/guide/annotating.md
+++ b/site/docs/guide/annotating.md
@@ -49,7 +49,7 @@ The key insight: **the same data that renders your component also feeds the AI**
 
 ## Nesting
 
-You can nest `[data-askable]` elements. When a user interacts with a nested element, the innermost (closest ancestor) element takes priority:
+You can nest `[data-askable]` elements. When a user interacts with a nested element, the innermost (closest ancestor) element takes priority by default:
 
 ```html
 <section data-askable='{"page":"dashboard"}'>
@@ -58,6 +58,30 @@ You can nest `[data-askable]` elements. When a user interacts with a nested elem
     <canvas></canvas>
   </div>
 </section>
+```
+
+### Priority targeting
+
+Use `data-askable-priority` (numeric) to override the default innermost-wins rule. Higher values win.
+
+```html
+<!-- Outer has higher priority — clicking the inner card still focuses the section -->
+<section data-askable='{"section":"highlights"}' data-askable-priority="10">
+  <div data-askable='{"card":"revenue"}'>
+    <canvas></canvas>
+  </div>
+</section>
+```
+
+When priorities are equal, the default innermost-wins rule applies. You only need to set the attribute on elements where you want to override that default.
+
+A common use case is a "selected row" pattern where the table-level annotation should take over from individual cell annotations when the row is in a special state:
+
+```html
+<tr data-askable='{"row":"order-42","status":"selected"}' data-askable-priority="5">
+  <td data-askable='{"col":"amount"}'>$1,200</td>
+  <td data-askable='{"col":"date"}'>2024-03-01</td>
+</tr>
 ```
 
 ## Dynamic elements

--- a/site/docs/guide/serialization.md
+++ b/site/docs/guide/serialization.md
@@ -2,6 +2,30 @@
 
 `toPromptContext()` and `toHistoryContext()` accept an `AskablePromptContextOptions` object to control exactly how context is serialized.
 
+## Presets
+
+Named presets are shorthand for common option combinations. Specify a preset via the `preset` option — any individual options you pass alongside it override the preset.
+
+| Preset | Equivalent options | Use case |
+|---|---|---|
+| `compact` | `{ includeText: false, format: 'natural' }` | Tight token budgets, meta-only |
+| `verbose` | `{ includeText: true, format: 'natural' }` | Full natural language (same as default) |
+| `json` | `{ format: 'json', includeText: true }` | Structured output for tool calls / storage |
+
+```ts
+ctx.toPromptContext({ preset: 'compact' });
+// → "User is focused on: — metric: revenue, delta: -12%"
+
+ctx.toPromptContext({ preset: 'json' });
+// → '{"meta":{"metric":"revenue","delta":"-12%"},"text":"Revenue","timestamp":...}'
+
+// Individual options override the preset
+ctx.toPromptContext({ preset: 'compact', includeText: true });
+// compact but with text included
+```
+
+Presets work with all serialization methods: `toPromptContext()`, `toHistoryContext()`, and `serializeFocus()`.
+
 ## Default output
 
 ```ts
@@ -120,6 +144,7 @@ Use this to:
 
 | Option | Type | Default | Description |
 |---|---|---|---|
+| `preset` | `'compact' \| 'verbose' \| 'json'` | — | Named shorthand; individual options override it |
 | `format` | `'natural' \| 'json'` | `'natural'` | Output format |
 | `includeText` | `boolean` | `true` | Include element text content |
 | `maxTextLength` | `number` | — | Truncate text to N characters |


### PR DESCRIPTION
## Summary

- **Prompt presets (#21)**: Add `preset` option (`'compact' | 'verbose' | 'json'`) to `AskablePromptContextOptions` as named shorthand for common option combinations. Individual options override preset. Works with `toPromptContext()`, `toHistoryContext()`, and `serializeFocus()`.
- **Priority targeting (#20)**: Add `data-askable-priority` (numeric) attribute support to the Observer. Higher values win over lower values regardless of DOM nesting depth. Equal priorities preserve the existing innermost-wins rule.
- Exports new `AskablePromptPreset` type from core index.
- Updates docs: serialization guide (Presets section, updated options table), annotating guide (Priority targeting section with examples), type reference.

## Test plan

- [ ] `npm test -w packages/core` — all 50 tests pass
- [ ] Preset `compact` omits text, `verbose` includes text, `json` produces JSON output
- [ ] Individual options override preset (e.g. `{ preset: 'compact', includeText: true }`)
- [ ] `data-askable-priority` outer-wins when outer priority > inner priority
- [ ] Equal priorities: inner element still wins
- [ ] No priority set: existing innermost-wins behaviour unchanged