### PR TITLE
feat(core,vue,svelte): custom text extractor and scoped contexts (#11, #9)

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -535,6 +535,53 @@ describe('createAskableContext', () => {
     });
   });
 
+  describe('textExtractor option', () => {
+    it('uses custom text extractor when provided', () => {
+      const el = makeEl({ metric: 'revenue' }, 'Original text');
+      el.setAttribute('aria-label', 'Custom label');
+      const ctx = createAskableContext({
+        textExtractor: (e) => e.getAttribute('aria-label') ?? e.textContent?.trim() ?? '',
+      });
+      ctx.observe(document);
+      el.click();
+
+      const focus = ctx.getFocus();
+      expect(focus?.text).toBe('Custom label');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('uses default text extraction when no extractor provided', () => {
+      const el = makeEl({ metric: 'revenue' }, 'Default text');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const focus = ctx.getFocus();
+      expect(focus?.text).toBe('Default text');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('select() uses custom text extractor', () => {
+      const el = makeEl({ metric: 'revenue' }, 'Original text');
+      el.setAttribute('aria-label', 'Select label');
+      const ctx = createAskableContext({
+        textExtractor: (e) => e.getAttribute('aria-label') ?? '',
+      });
+
+      ctx.select(el);
+
+      const focus = ctx.getFocus();
+      expect(focus?.text).toBe('Select label');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+  });
+
   it('observe() is a no-op when called outside a browser environment', () => {
     const win = globalThis.window;
     Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -2,6 +2,7 @@ import { Emitter } from './emitter.js';
 import { buildFocus, Observer } from './observer.js';
 import type {
   AskableContext,
+  AskableContextOptions,
   AskableEventHandler,
   AskableEventName,
   AskableFocus,
@@ -24,14 +25,16 @@ export class AskableContextImpl implements AskableContext {
   private observer: Observer;
   private currentFocus: AskableFocus | null = null;
   private history: AskableFocus[] = [];
+  private textExtractor: ((el: HTMLElement) => string) | undefined;
 
-  constructor() {
+  constructor(options?: AskableContextOptions) {
+    this.textExtractor = options?.textExtractor;
     this.observer = new Observer((focus) => {
       this.currentFocus = focus;
       this.history.push(focus);
       if (this.history.length > MAX_HISTORY) this.history.shift();
       this.emitter.emit('focus', focus);
-    });
+    }, this.textExtractor);
   }
 
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void {
@@ -65,7 +68,7 @@ export class AskableContextImpl implements AskableContext {
   }
 
   select(element: HTMLElement): void {
-    const focus = buildFocus(element);
+    const focus = buildFocus(element, this.textExtractor);
     if (focus) {
       this.currentFocus = focus;
       this.history.push(focus);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { AskableContextImpl } from './context.js';
 export type {
   AskableContext,
+  AskableContextOptions,
   AskableEvent,
   AskableEventHandler,
   AskableEventMap,
@@ -14,9 +15,9 @@ export type {
 } from './types.js';
 
 import { AskableContextImpl } from './context.js';
-import type { AskableContext } from './types.js';
+import type { AskableContext, AskableContextOptions } from './types.js';
 
 /** Create a new AskableContext instance */
-export function createAskableContext(): AskableContext {
-  return new AskableContextImpl();
+export function createAskableContext(options?: AskableContextOptions): AskableContext {
+  return new AskableContextImpl(options);
 }

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -28,12 +28,12 @@ function extractText(el: HTMLElement): string {
   return (el.textContent ?? '').trim();
 }
 
-export function buildFocus(el: HTMLElement): AskableFocus | null {
+export function buildFocus(el: HTMLElement, textExtractor?: (el: HTMLElement) => string): AskableFocus | null {
   const raw = el.getAttribute('data-askable');
   if (raw === null) return null;
   return {
     meta: parseMeta(raw),
-    text: extractText(el),
+    text: textExtractor ? textExtractor(el) : extractText(el),
     element: el,
     timestamp: Date.now(),
   };
@@ -46,14 +46,16 @@ export class Observer {
   private mutationObserver: MutationObserver | null = null;
   private boundElements = new Set<HTMLElement>();
   private onFocus: FocusCallback;
+  private textExtractor: ((el: HTMLElement) => string) | undefined;
   private activeEvents: AskableEvent[] = ALL_EVENTS;
   private hoverDebounce = 0;
   private hoverThrottle = 0;
   private hoverTimer: ReturnType<typeof setTimeout> | null = null;
   private lastHoverTimestamp = 0;
 
-  constructor(onFocus: FocusCallback) {
+  constructor(onFocus: FocusCallback, textExtractor?: (el: HTMLElement) => string) {
     this.onFocus = onFocus;
+    this.textExtractor = textExtractor;
   }
 
   observe(
@@ -135,7 +137,7 @@ export class Observer {
       if (this.hoverTimer !== null) clearTimeout(this.hoverTimer);
       this.hoverTimer = setTimeout(() => {
         this.hoverTimer = null;
-        const focus = buildFocus(el);
+        const focus = buildFocus(el, this.textExtractor);
         if (focus) this.onFocus(focus);
       }, this.hoverDebounce);
       return;
@@ -147,7 +149,7 @@ export class Observer {
       this.lastHoverTimestamp = now;
     }
 
-    const focus = buildFocus(el);
+    const focus = buildFocus(el, this.textExtractor);
     if (focus) this.onFocus(focus);
   };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -91,6 +91,26 @@ export interface AskableSerializedFocus {
   timestamp: number;
 }
 
+/**
+ * Options for creating an AskableContext.
+ */
+export interface AskableContextOptions {
+  /**
+   * Custom text extractor called for each focused element.
+   * Receives the DOM element, returns the text to use as `AskableFocus.text`.
+   * Defaults to `el.textContent?.trim() ?? ''`.
+   *
+   * Use this to prefer accessible names, ARIA labels, or a subset of visible content.
+   *
+   * @example
+   * createAskableContext({
+   *   textExtractor: (el) =>
+   *     el.getAttribute('aria-label') ?? el.textContent?.trim() ?? ''
+   * })
+   */
+  textExtractor?: (el: HTMLElement) => string;
+}
+
 export interface AskableContext {
   /** Observe a DOM subtree for [data-askable] elements */
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void;

--- a/packages/svelte/src/__tests__/store.test.ts
+++ b/packages/svelte/src/__tests__/store.test.ts
@@ -74,4 +74,29 @@ describe('createAskableStore', () => {
     el.click();
     expect(get(store.focus)).toBeNull();
   });
+
+  it('accepts a scoped ctx and reflects events from it', async () => {
+    const { createAskableContext } = await import('@askable-ui/core');
+    const scopedCtx = createAskableContext();
+    const el = makeEl({ scope: 'provided' }, 'Scoped');
+
+    const store = createAskableStore({ ctx: scopedCtx });
+    scopedCtx.observe(document.body);
+
+    let latestFocus: unknown = null;
+    const unsub = store.focus.subscribe((f: unknown) => { latestFocus = f; });
+
+    el.click();
+
+    expect(latestFocus).not.toBeNull();
+    expect((latestFocus as any).meta).toEqual({ scope: 'provided' });
+
+    unsub();
+    // destroy() should not call ctx.destroy() when ctx is provided
+    store.destroy();
+    el.click(); // scopedCtx should still be alive
+    expect((latestFocus as any).meta).toEqual({ scope: 'provided' });
+
+    scopedCtx.destroy();
+  });
 });

--- a/packages/svelte/src/askable.ts
+++ b/packages/svelte/src/askable.ts
@@ -9,9 +9,11 @@ export interface AskableStore {
   destroy: () => void;
 }
 
-export function createAskableStore(options?: { events?: AskableEvent[] }) {
-  const ctx = createAskableContext();
-  if (typeof document !== 'undefined') {
+export function createAskableStore(options?: { events?: AskableEvent[]; ctx?: AskableContext }) {
+  const usesProvidedCtx = Boolean(options?.ctx);
+  const ctx = options?.ctx ?? createAskableContext();
+
+  if (!usesProvidedCtx && typeof document !== 'undefined') {
     ctx.observe(document, { events: options?.events });
   }
 
@@ -23,7 +25,9 @@ export function createAskableStore(options?: { events?: AskableEvent[] }) {
   const promptContext = derived(_focus, () => ctx.toPromptContext());
 
   function destroy() {
-    ctx.destroy();
+    if (!usesProvidedCtx) {
+      ctx.destroy();
+    }
   }
 
   return { focus, promptContext, ctx, destroy };

--- a/packages/vue/src/__tests__/useAskable.test.ts
+++ b/packages/vue/src/__tests__/useAskable.test.ts
@@ -73,6 +73,42 @@ describe('useAskable (Vue)', () => {
     expect(prompt).toContain('revenue');
   });
 
+  it('accepts a scoped ctx and does not touch globalCtx', async () => {
+    const { createAskableContext } = await import('@askable-ui/core');
+    const scopedCtx = createAskableContext();
+
+    const ScopedConsumer = defineComponent({
+      name: 'ScopedConsumer',
+      setup() {
+        const { focus, ctx } = useAskable({ ctx: scopedCtx });
+        return { focus, ctx };
+      },
+      template: `
+        <div>
+          <div data-testid="scoped-target" data-askable='{"scope":"scoped"}'>Scoped</div>
+          <span data-testid="scoped-focus">{{ focus ? JSON.stringify(focus.meta) : 'null' }}</span>
+        </div>
+      `,
+    });
+
+    const wrapper = track(mount(ScopedConsumer, { attachTo: document.body }));
+    await flushAll();
+
+    // scopedCtx is provided, so observe is NOT called automatically
+    scopedCtx.observe(document.body);
+    await flushAll();
+
+    await wrapper.find('[data-testid="scoped-target"]').trigger('click');
+    await nextTick();
+
+    const metaText = wrapper.find('[data-testid="scoped-focus"]').text();
+    expect(metaText).not.toBe('null');
+    expect(JSON.parse(metaText)).toEqual({ scope: 'scoped' });
+
+    wrapper.unmount();
+    scopedCtx.destroy();
+  });
+
   it('cleans up listener on unmount', async () => {
     const wrapper = track(mount(Consumer, { attachTo: document.body }));
     await flushAll();

--- a/packages/vue/src/useAskable.ts
+++ b/packages/vue/src/useAskable.ts
@@ -18,8 +18,9 @@ export interface UseAskableResult {
   ctx: AskableContext;
 }
 
-export function useAskable(options?: { events?: AskableEvent[] }) {
-  const ctx = getGlobalCtx();
+export function useAskable(options?: { events?: AskableEvent[]; ctx?: AskableContext }) {
+  const usesProvidedCtx = Boolean(options?.ctx);
+  const ctx = options?.ctx ?? getGlobalCtx();
   const focus = ref<AskableFocus | null>(ctx.getFocus());
   // Reference focus.value so Vue tracks it as a reactive dependency;
   // ctx.toPromptContext() is a plain method and not itself reactive.
@@ -31,14 +32,16 @@ export function useAskable(options?: { events?: AskableEvent[] }) {
   function handler(f: AskableFocus) {
     focus.value = f;
   }
-  function clearHandler() {
+  function clearHandler(_: null) {
     focus.value = null;
   }
 
   onMounted(() => {
-    refCount++;
-    if (typeof document !== 'undefined') {
-      ctx.observe(document, { events: options?.events });
+    if (!usesProvidedCtx) {
+      refCount++;
+      if (typeof document !== 'undefined') {
+        ctx.observe(document, { events: options?.events });
+      }
     }
     ctx.on('focus', handler);
     ctx.on('clear', clearHandler);
@@ -47,10 +50,12 @@ export function useAskable(options?: { events?: AskableEvent[] }) {
   onUnmounted(() => {
     ctx.off('focus', handler);
     ctx.off('clear', clearHandler);
-    refCount--;
-    if (refCount === 0) {
-      globalCtx?.destroy();
-      globalCtx = null;
+    if (!usesProvidedCtx) {
+      refCount--;
+      if (refCount === 0) {
+        globalCtx?.destroy();
+        globalCtx = null;
+      }
     }
   });
 

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -5,6 +5,7 @@ All types are exported from `@askable-ui/core`.
 ```ts
 import type {
   AskableContext,
+  AskableContextOptions,
   AskableFocus,
   AskableSerializedFocus,
   AskablePromptContextOptions,
@@ -16,6 +17,22 @@ import type {
   AskableEventName,
   AskableEventHandler,
 } from '@askable-ui/core';
+```
+
+---
+
+## `AskableContextOptions`
+
+Options passed to `createAskableContext()`.
+
+```ts
+interface AskableContextOptions {
+  /**
+   * Custom text extractor called for each focused element.
+   * Defaults to el.textContent?.trim() ?? ''
+   */
+  textExtractor?: (el: HTMLElement) => string;
+}
 ```
 
 ---

--- a/site/docs/guide/annotating.md
+++ b/site/docs/guide/annotating.md
@@ -102,6 +102,29 @@ Good candidates:
 | Dashboard KPI | `{"metric":"churn","value":"4.2%","trend":"up"}` |
 | Page section | `"analytics overview"` |
 
+## Custom text extraction
+
+By default, Askable uses `element.textContent.trim()` to derive the text for each focused element. You can override this globally when creating the context:
+
+```ts
+import { createAskableContext } from '@askable-ui/core';
+
+const ctx = createAskableContext({
+  textExtractor: (el) =>
+    el.getAttribute('aria-label') ??
+    el.getAttribute('title') ??
+    el.textContent?.trim() ??
+    '',
+});
+```
+
+The extractor receives the DOM element and returns a string. It applies to all focus events — clicks, hovers, and explicit `select()` calls.
+
+Use this when:
+- Accessible names (ARIA labels) are more meaningful to the LLM than raw text content
+- Elements contain noisy child text (icons, timestamps, decorative strings) you want to exclude
+- You need a different representation per element type
+
 ## What not to annotate
 
 - Generic layout wrappers with no semantic meaning (`<div class="flex">`)

--- a/site/docs/guide/svelte.md
+++ b/site/docs/guide/svelte.md
@@ -87,6 +87,25 @@ onDestroy(destroy);
 | Option | Type | Description |
 |---|---|---|
 | `events` | `AskableEvent[]` | Which events trigger updates. Defaults to `['click', 'hover', 'focus']`. |
+| `ctx` | `AskableContext` | Provide a scoped context instead of creating a new one. See below. |
+
+## Scoped contexts
+
+By default, `createAskableStore()` creates its own `AskableContext`. For surfaces that need to share a context (or require independent event policies, prompt shaping, or redaction rules), pass a pre-created `ctx`:
+
+```ts
+import { createAskableContext } from '@askable-ui/core';
+import { createAskableStore } from '@askable-ui/svelte';
+
+const sharedCtx = createAskableContext();
+sharedCtx.observe(document.getElementById('dashboard')!);
+
+// Two stores backed by the same context
+const storeA = createAskableStore({ ctx: sharedCtx });
+const storeB = createAskableStore({ ctx: sharedCtx });
+```
+
+When a scoped `ctx` is provided, `destroy()` on the store does **not** call `ctx.destroy()` — you manage the context lifecycle separately.
 
 **Returns:**
 | Value | Type | Description |

--- a/site/docs/guide/vue.md
+++ b/site/docs/guide/vue.md
@@ -74,6 +74,25 @@ const { focus } = useAskable({ events: ['click'] });
 | Option | Type | Description |
 |---|---|---|
 | `events` | `AskableEvent[]` | Which events trigger updates. Defaults to `['click', 'hover', 'focus']`. |
+| `ctx` | `AskableContext` | Provide a scoped context instead of the global singleton. See below. |
+
+## Scoped contexts
+
+By default, `useAskable()` shares a single global `AskableContext` across all composable instances on the page. For surfaces that need independent tracking (different event policies, prompt shaping, or redaction rules), pass a pre-created `ctx`:
+
+```ts
+import { createAskableContext } from '@askable-ui/core';
+import { useAskable } from '@askable-ui/vue';
+
+// Create once, e.g. at the module level or in a parent component
+const adminCtx = createAskableContext();
+adminCtx.observe(document.getElementById('admin-panel')!);
+
+// In a component that should only track the admin panel
+const { focus, promptContext } = useAskable({ ctx: adminCtx });
+```
+
+When a scoped `ctx` is provided, `useAskable` does not call `observe()` automatically — you control when and what the context observes. The lifecycle (destroy) is also your responsibility.
 
 **Returns:**
 | Value | Type | Description |


### PR DESCRIPTION
## Summary

- **Custom text extractor (#11)**: Add `textExtractor` option to `createAskableContext()`. A callback `(el: HTMLElement) => string` replaces the default `el.textContent.trim()` extraction globally. Works for click, hover, focus events and explicit `select()` calls. Useful for preferring ARIA labels, filtering noisy child text, or customising per-element extraction logic.
- **Scoped contexts (#9)**: Vue's `useAskable()` and Svelte's `createAskableStore()` now accept an optional `ctx` parameter. When provided, the adapter skips auto-observe and does not manage the context lifecycle — giving callers full control. React already had this; this PR adds parity for Vue and Svelte.

## Test plan

- [ ] `npm test --workspaces --if-present` — all tests pass
- [ ] `textExtractor` returns custom text (e.g. `aria-label`) instead of `textContent`
- [ ] Default extraction unchanged when no `textExtractor` provided
- [ ] `select()` also uses the custom extractor
- [ ] Vue `useAskable({ ctx: scopedCtx })` — focuses tracked via provided ctx, global ctx unaffected
- [ ] Svelte `createAskableStore({ ctx: scopedCtx })` — `destroy()` does not destroy provided ctx
- [ ] SSR tests still pass (no regressions)