### PR TITLE
feat(core): add createAskableInspector devtools panel (#22)

### DIFF
--- a/packages/core/src/__tests__/inspector.test.ts
+++ b/packages/core/src/__tests__/inspector.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createAskableContext } from '../index.js';
+import { createAskableInspector } from '../inspector.js';
+
+function makeEl(meta: object | string, text = ''): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('data-askable', typeof meta === 'string' ? meta : JSON.stringify(meta));
+  el.textContent = text;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('createAskableInspector', () => {
+  const elements: HTMLElement[] = [];
+
+  afterEach(() => {
+    elements.forEach((el) => el.parentNode?.removeChild(el));
+    elements.length = 0;
+    document.getElementById('askable-inspector')?.remove();
+  });
+
+  function attach(el: HTMLElement): HTMLElement {
+    elements.push(el);
+    return el;
+  }
+
+  it('mounts a panel to the document body', () => {
+    const ctx = createAskableContext();
+    const inspector = createAskableInspector(ctx);
+
+    expect(document.getElementById('askable-inspector')).not.toBeNull();
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('shows "No element focused" when nothing is focused', () => {
+    const ctx = createAskableContext();
+    const inspector = createAskableInspector(ctx);
+
+    const panel = document.getElementById('askable-inspector')!;
+    expect(panel.textContent).toContain('No element focused');
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('updates panel content when focus changes', () => {
+    const el = attach(makeEl({ metric: 'revenue', value: '$128k' }, 'Revenue'));
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx);
+
+    el.click();
+
+    const panel = document.getElementById('askable-inspector')!;
+    expect(panel.textContent).toContain('revenue');
+    expect(panel.textContent).toContain('$128k');
+    expect(panel.textContent).not.toContain('No element focused');
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('shows element tag in the panel', () => {
+    const el = attach(makeEl({ id: 'test' }, 'Test'));
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx);
+
+    el.click();
+
+    const panel = document.getElementById('askable-inspector')!;
+    expect(panel.innerHTML).toContain('&lt;div');
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('shows prompt context output in the panel', () => {
+    const el = attach(makeEl({ metric: 'churn' }, 'Churn'));
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx);
+
+    el.click();
+
+    const panel = document.getElementById('askable-inspector')!;
+    expect(panel.textContent).toContain('User is focused on');
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('highlights the focused element', () => {
+    const el = attach(makeEl({ metric: 'revenue' }, 'Revenue'));
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx, { highlight: true });
+
+    el.click();
+
+    expect(el.getAttribute('data-askable-inspector-highlight')).toBe('');
+    expect(el.style.outline).toBeTruthy();
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('clears highlight when focus is cleared', () => {
+    const el = attach(makeEl({ metric: 'revenue' }, 'Revenue'));
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx, { highlight: true });
+
+    el.click();
+    expect(el.getAttribute('data-askable-inspector-highlight')).toBe('');
+
+    ctx.clear();
+
+    expect(el.getAttribute('data-askable-inspector-highlight')).toBeNull();
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('removes panel from DOM on destroy()', () => {
+    const ctx = createAskableContext();
+    const inspector = createAskableInspector(ctx);
+
+    expect(document.getElementById('askable-inspector')).not.toBeNull();
+
+    inspector.destroy();
+
+    expect(document.getElementById('askable-inspector')).toBeNull();
+
+    ctx.destroy();
+  });
+
+  it('is a no-op outside browser environments', () => {
+    const win = globalThis.window;
+    Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });
+
+    const ctx = createAskableContext();
+    expect(() => createAskableInspector(ctx)).not.toThrow();
+
+    Object.defineProperty(globalThis, 'window', { value: win, configurable: true });
+    ctx.destroy();
+  });
+
+  it('destroy() is idempotent — calling twice does not throw', () => {
+    const ctx = createAskableContext();
+    const inspector = createAskableInspector(ctx);
+
+    expect(() => {
+      inspector.destroy();
+      inspector.destroy();
+    }).not.toThrow();
+
+    ctx.destroy();
+  });
+
+  it('a second inspector replaces the first', () => {
+    const ctx = createAskableContext();
+    const inspector1 = createAskableInspector(ctx);
+    const inspector2 = createAskableInspector(ctx);
+
+    expect(document.querySelectorAll('#askable-inspector').length).toBe(1);
+
+    inspector2.destroy();
+    ctx.destroy();
+  });
+
+  it('does not highlight element that has been removed from DOM', () => {
+    const el = attach(makeEl({ metric: 'revenue' }, 'Revenue'));
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx, { highlight: true });
+
+    el.click();
+    expect(el.getAttribute('data-askable-inspector-highlight')).toBe('');
+
+    // Remove element from DOM before next update
+    el.parentNode?.removeChild(el);
+    ctx.clear();
+    // Now re-focus (simulate a select on detached element)
+    ctx.select(el);
+
+    // Detached element should not get highlight
+    expect(el.getAttribute('data-askable-inspector-highlight')).toBeNull();
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('escapes HTML special characters in meta values', () => {
+    const el = attach(makeEl({ xss: '<script>alert(1)</script>' }, 'Test'));
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx);
+
+    el.click();
+
+    const panel = document.getElementById('askable-inspector')!;
+    expect(panel.querySelector('script')).toBeNull();
+    expect(panel.innerHTML).toContain('&lt;script&gt;');
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('respects promptOptions', () => {
+    const el = attach(makeEl({ metric: 'churn' }, 'Churn Rate'));
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx, { promptOptions: { preset: 'compact' } });
+
+    el.click();
+
+    const panel = document.getElementById('askable-inspector')!;
+    expect(panel.textContent).toContain('User is focused on');
+    // compact excludes text, so 'Churn Rate' should not appear in prompt output
+    // (it may appear in the element section, but not the prompt)
+    expect(panel.textContent).toContain('churn');
+
+    inspector.destroy();
+    ctx.destroy();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,10 @@
 export { AskableContextImpl } from './context.js';
+export { createAskableInspector } from './inspector.js';
+export type {
+  AskableInspectorHandle,
+  AskableInspectorOptions,
+  AskableInspectorPosition,
+} from './inspector.js';
 export type {
   AskableContext,
   AskableContextOptions,

--- a/packages/core/src/inspector.ts
+++ b/packages/core/src/inspector.ts
@@ -1,0 +1,191 @@
+import type { AskableContext, AskableFocus, AskablePromptContextOptions } from './types.js';
+
+export type AskableInspectorPosition = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
+
+export interface AskableInspectorOptions {
+  /**
+   * Where to anchor the inspector panel.
+   * @default 'bottom-right'
+   */
+  position?: AskableInspectorPosition;
+  /**
+   * Serialization options passed to toPromptContext() for the output preview.
+   */
+  promptOptions?: AskablePromptContextOptions;
+  /**
+   * Highlight the focused element with an outline.
+   * @default true
+   */
+  highlight?: boolean;
+}
+
+export interface AskableInspectorHandle {
+  /** Remove the inspector panel from the DOM and detach all listeners. */
+  destroy(): void;
+}
+
+const PANEL_ID = 'askable-inspector';
+const HIGHLIGHT_ATTR = 'data-askable-inspector-highlight';
+
+const POSITION_STYLES: Record<AskableInspectorPosition, string> = {
+  'bottom-right': 'bottom:16px;right:16px',
+  'bottom-left':  'bottom:16px;left:16px',
+  'top-right':    'top:16px;right:16px',
+  'top-left':     'top:16px;left:16px',
+};
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function renderMeta(meta: Record<string, unknown> | string): string {
+  if (typeof meta === 'string') return `<span style="color:#a5d6ff">"${escapeHtml(meta)}"</span>`;
+  const lines = Object.entries(meta)
+    .map(([k, v]) => `  <span style="color:#79c0ff">${escapeHtml(k)}</span>: <span style="color:#a5d6ff">${escapeHtml(JSON.stringify(v))}</span>`)
+    .join(',\n');
+  return `{\n${lines}\n}`;
+}
+
+function buildPanelHTML(focus: AskableFocus | null, promptContext: string): string {
+  if (!focus) {
+    return `
+      <div style="color:#8b949e;font-style:italic;padding:4px 0">No element focused</div>
+    `;
+  }
+
+  const tag = focus.element.tagName.toLowerCase();
+  const id = focus.element.id ? `#${escapeHtml(focus.element.id)}` : '';
+  const cls = focus.element.className
+    ? `.${String(focus.element.className).trim().split(/\s+/).slice(0, 2).map(escapeHtml).join('.')}`
+    : '';
+
+  return `
+    <div style="margin-bottom:8px">
+      <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Element</span><br>
+      <code style="color:#e6edf3">&lt;${escapeHtml(tag)}${id}${cls}&gt;</code>
+    </div>
+    <div style="margin-bottom:8px">
+      <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Meta</span><br>
+      <pre style="color:#e6edf3;margin:4px 0;white-space:pre-wrap;word-break:break-all">${renderMeta(focus.meta)}</pre>
+    </div>
+    ${focus.text ? `
+    <div style="margin-bottom:8px">
+      <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Text</span><br>
+      <code style="color:#e6edf3">"${escapeHtml(focus.text.slice(0, 120))}${focus.text.length > 120 ? '…' : ''}"</code>
+    </div>
+    ` : ''}
+    <div>
+      <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Prompt context</span><br>
+      <pre style="color:#a5d6ff;margin:4px 0;white-space:pre-wrap;word-break:break-all">${escapeHtml(promptContext)}</pre>
+    </div>
+  `;
+}
+
+/**
+ * Mount a floating inspector panel that shows the current Askable focus,
+ * parsed metadata, and prompt output in real time.
+ *
+ * Call `destroy()` on the returned handle to remove it.
+ *
+ * @example
+ * const inspector = createAskableInspector(ctx);
+ * // later:
+ * inspector.destroy();
+ */
+export function createAskableInspector(
+  ctx: AskableContext,
+  options: AskableInspectorOptions = {}
+): AskableInspectorHandle {
+  if (typeof document === 'undefined') {
+    return { destroy: () => {} };
+  }
+
+  const { position = 'bottom-right', promptOptions, highlight = true } = options;
+
+  // Remove any existing inspector
+  document.getElementById(PANEL_ID)?.remove();
+
+  const panel = document.createElement('div');
+  panel.id = PANEL_ID;
+  panel.setAttribute('aria-label', 'Askable inspector');
+  panel.style.cssText = [
+    'position:fixed',
+    POSITION_STYLES[position],
+    'z-index:2147483647',
+    'width:320px',
+    'max-height:420px',
+    'overflow:auto',
+    'background:#161b22',
+    'color:#e6edf3',
+    'font-family:ui-monospace,SFMono-Regular,Menlo,monospace',
+    'font-size:12px',
+    'line-height:1.5',
+    'border:1px solid #30363d',
+    'border-radius:8px',
+    'box-shadow:0 8px 24px rgba(1,4,9,.8)',
+    'padding:10px 12px',
+  ].join(';');
+
+  // Header row
+  const header = document.createElement('div');
+  header.style.cssText = 'display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;padding-bottom:8px;border-bottom:1px solid #30363d';
+  header.innerHTML = `
+    <span style="color:#58a6ff;font-weight:700;font-size:11px;letter-spacing:.06em">✦ ASKABLE INSPECTOR</span>
+    <button id="askable-inspector-close" style="background:none;border:none;color:#8b949e;cursor:pointer;font-size:14px;line-height:1;padding:2px" title="Close">&times;</button>
+  `;
+  panel.appendChild(header);
+
+  const body = document.createElement('div');
+  panel.appendChild(body);
+
+  document.body.appendChild(panel);
+
+  let highlightedEl: HTMLElement | null = null;
+
+  function clearHighlight() {
+    if (highlightedEl) {
+      highlightedEl.removeAttribute(HIGHLIGHT_ATTR);
+      highlightedEl.style.removeProperty('outline');
+      highlightedEl.style.removeProperty('outline-offset');
+      highlightedEl = null;
+    }
+  }
+
+  function applyHighlight(el: HTMLElement) {
+    clearHighlight();
+    if (!highlight) return;
+    el.setAttribute(HIGHLIGHT_ATTR, '');
+    el.style.outline = '2px solid #58a6ff';
+    el.style.outlineOffset = '2px';
+    highlightedEl = el;
+  }
+
+  function update(focus: AskableFocus | null) {
+    const promptContext = ctx.toPromptContext(promptOptions);
+    body.innerHTML = buildPanelHTML(focus, promptContext);
+    if (focus && focus.element.isConnected) applyHighlight(focus.element);
+    else clearHighlight();
+  }
+
+  // Initial render
+  update(ctx.getFocus());
+
+  const focusHandler = (f: AskableFocus) => update(f);
+  const clearHandler = (_: null) => update(null);
+  ctx.on('focus', focusHandler);
+  ctx.on('clear', clearHandler);
+
+  let destroyed = false;
+  function destroy() {
+    if (destroyed) return;
+    destroyed = true;
+    ctx.off('focus', focusHandler);
+    ctx.off('clear', clearHandler);
+    clearHighlight();
+    panel.remove();
+  }
+
+  panel.querySelector('#askable-inspector-close')?.addEventListener('click', destroy);
+
+  return { destroy };
+}

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -201,6 +201,42 @@ ctx.destroy();
 
 ---
 
+---
+
+## `createAskableInspector(ctx, options?)`
+
+Mount a floating inspector panel that shows the active focus, parsed metadata, and prompt output in real time. Designed for development and demos.
+
+```ts
+import { createAskableContext, createAskableInspector } from '@askable-ui/core';
+
+const ctx = createAskableContext();
+ctx.observe(document);
+
+const inspector = createAskableInspector(ctx);
+// Shows a floating panel in the bottom-right corner.
+
+// Tear down when done:
+inspector.destroy();
+```
+
+**Options (`AskableInspectorOptions`):**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `position` | `'bottom-right' \| 'bottom-left' \| 'top-right' \| 'top-left'` | `'bottom-right'` | Panel anchor position |
+| `highlight` | `boolean` | `true` | Outline the focused element |
+| `promptOptions` | `AskablePromptContextOptions` | — | Options passed to `toPromptContext()` for the preview |
+
+**Returns:** `AskableInspectorHandle` — object with `destroy()` method.
+
+**Notes:**
+- No-op in non-browser environments (SSR-safe)
+- Calling `createAskableInspector()` a second time replaces any existing panel
+- Add it in development only — wrap in `if (process.env.NODE_ENV !== 'production')`
+
+---
+
 ## `AskablePromptContextOptions`
 
 | Option | Type | Default | Description |


### PR DESCRIPTION
## Summary

Adds a `createAskableInspector(ctx, options?)` export to `@askable-ui/core`. It mounts a floating panel in the DOM (no framework required) that shows in real time:
- The currently focused element and its tag/id/class
- Parsed meta (formatted JSON object or string)
- Element text content
- Live `toPromptContext()` output

Useful during development and for demos to make Askable's behavior visible.

```ts
import { createAskableContext, createAskableInspector } from '@askable-ui/core';

const ctx = createAskableContext();
ctx.observe(document);

if (process.env.NODE_ENV !== 'production') {
  createAskableInspector(ctx);
}
```

## Options

| Option | Default | Description |
|---|---|---|
| `position` | `'bottom-right'` | Panel anchor corner |
| `highlight` | `true` | Outline the focused element |
| `promptOptions` | — | Forwarded to `toPromptContext()` |

## Test plan

- [ ] `npm test -w packages/core` — all 67 tests pass
- [ ] Panel mounts on first call, replaces existing panel on second call
- [ ] Updates content on every focus event
- [ ] Highlights focused element; clears on `ctx.clear()`
- [ ] `destroy()` removes panel and clears highlight; idempotent (safe to call twice)
- [ ] XSS: `<script>` in meta values is escaped, not executed
- [ ] No-op in SSR (non-browser) environments