### PR TITLE
feat(core): add AskableTargetStrategy — deepest, shallowest, exact (#8)

### DIFF
--- a/packages/core/src/__tests__/observer.test.ts
+++ b/packages/core/src/__tests__/observer.test.ts
@@ -285,4 +285,127 @@ describe('Observer', () => {
 
     obs.unobserve();
   });
+
+  describe('targetStrategy option', () => {
+    it("'deepest' (default) — innermost element wins when clicking nested", () => {
+      const outer = attach(makeEl({ level: 'outer' }, 'Outer'));
+      const inner = makeEl({ level: 'inner' }, 'Inner');
+      outer.appendChild(inner);
+      elements.push(inner);
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document, undefined, 0, 0, 'deepest');
+
+      inner.click();
+
+      expect(onFocus).toHaveBeenCalledOnce();
+      expect((onFocus.mock.calls[0][0].meta as Record<string, unknown>).level).toBe('inner');
+
+      obs.unobserve();
+    });
+
+    it("'shallowest' — outermost element wins when clicking nested", () => {
+      const outer = attach(makeEl({ level: 'outer' }, 'Outer'));
+      const inner = makeEl({ level: 'inner' }, 'Inner');
+      outer.appendChild(inner);
+      elements.push(inner);
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document, undefined, 0, 0, 'shallowest');
+
+      inner.click();
+
+      expect(onFocus).toHaveBeenCalledOnce();
+      expect((onFocus.mock.calls[0][0].meta as Record<string, unknown>).level).toBe('outer');
+
+      obs.unobserve();
+    });
+
+    it("'shallowest' — outer directly clicked fires outer (not suppressed)", () => {
+      const outer = attach(makeEl({ level: 'outer' }, 'Outer'));
+      const inner = makeEl({ level: 'inner' }, 'Inner');
+      outer.appendChild(inner);
+      elements.push(inner);
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document, undefined, 0, 0, 'shallowest');
+
+      outer.click();
+
+      expect(onFocus).toHaveBeenCalledOnce();
+      expect((onFocus.mock.calls[0][0].meta as Record<string, unknown>).level).toBe('outer');
+
+      obs.unobserve();
+    });
+
+    it("'shallowest' — standalone element (no ancestor) still fires", () => {
+      const solo = attach(makeEl({ level: 'solo' }, 'Solo'));
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document, undefined, 0, 0, 'shallowest');
+
+      solo.click();
+
+      expect(onFocus).toHaveBeenCalledOnce();
+      expect((onFocus.mock.calls[0][0].meta as Record<string, unknown>).level).toBe('solo');
+
+      obs.unobserve();
+    });
+
+    it("'exact' — fires when event target itself has [data-askable]", () => {
+      const el = attach(makeEl({ id: 'exact-target' }, 'Exact'));
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document, undefined, 0, 0, 'exact');
+
+      el.click();
+
+      expect(onFocus).toHaveBeenCalledOnce();
+
+      obs.unobserve();
+    });
+
+    it("'exact' — does NOT fire when event bubbles up from a child without [data-askable]", () => {
+      const outer = attach(makeEl({ level: 'outer' }, ''));
+      const child = document.createElement('span');
+      child.textContent = 'child';
+      outer.appendChild(child);
+      elements.push(child);
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document, undefined, 0, 0, 'exact');
+
+      // clicking the non-annotated child bubbles to outer, should NOT trigger
+      child.click();
+
+      expect(onFocus).not.toHaveBeenCalled();
+
+      obs.unobserve();
+    });
+
+    it("'exact' — does NOT fire when event bubbles up from a nested [data-askable] child", () => {
+      const outer = attach(makeEl({ level: 'outer' }, ''));
+      const inner = makeEl({ level: 'inner' }, 'Inner');
+      outer.appendChild(inner);
+      elements.push(inner);
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document, undefined, 0, 0, 'exact');
+
+      // inner fires (it is the direct target), outer must NOT also fire
+      inner.click();
+
+      expect(onFocus).toHaveBeenCalledOnce();
+      expect((onFocus.mock.calls[0][0].meta as Record<string, unknown>).level).toBe('inner');
+
+      obs.unobserve();
+    });
+  });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -56,7 +56,8 @@ export class AskableContextImpl implements AskableContext {
       root,
       options?.events,
       options?.hoverDebounce ?? 0,
-      options?.hoverThrottle ?? 0
+      options?.hoverThrottle ?? 0,
+      options?.targetStrategy ?? 'deepest'
     );
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export type {
   AskablePromptFormat,
   AskablePromptPreset,
   AskableSerializedFocus,
+  AskableTargetStrategy,
 } from './types.js';
 
 import { AskableContextImpl } from './context.js';

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -1,4 +1,4 @@
-import type { AskableFocus, AskableEvent } from './types.js';
+import type { AskableFocus, AskableEvent, AskableTargetStrategy } from './types.js';
 
 type FocusCallback = (focus: AskableFocus) => void;
 
@@ -48,6 +48,7 @@ export class Observer {
   private onFocus: FocusCallback;
   private textExtractor: ((el: HTMLElement) => string) | undefined;
   private activeEvents: AskableEvent[] = ALL_EVENTS;
+  private targetStrategy: AskableTargetStrategy = 'deepest';
   private hoverDebounce = 0;
   private hoverThrottle = 0;
   private hoverTimer: ReturnType<typeof setTimeout> | null = null;
@@ -62,12 +63,14 @@ export class Observer {
     root: HTMLElement | Document,
     events: AskableEvent[] = ALL_EVENTS,
     hoverDebounce = 0,
-    hoverThrottle = 0
+    hoverThrottle = 0,
+    targetStrategy: AskableTargetStrategy = 'deepest'
   ): void {
     if (!isBrowser()) return;
     if (this.root) this.unobserve();
     this.root = root;
     this.activeEvents = events;
+    this.targetStrategy = targetStrategy;
     this.hoverDebounce = hoverDebounce;
     this.hoverThrottle = hoverThrottle;
     this.lastHoverTimestamp = 0;
@@ -105,29 +108,40 @@ export class Observer {
 
   private handleInteraction = (event: Event): void => {
     const el = event.currentTarget as HTMLElement;
-
-    // Nested element priority: resolve which [data-askable] element should
-    // handle the event when nested elements are involved.
-    // data-askable-priority (numeric, higher wins) overrides the default innermost-wins rule.
     const target = event.target as HTMLElement;
-    if (target !== el) {
-      // Event bubbled from a deeper target — check if a closer descendant should win.
-      const closer = target.closest('[data-askable]');
-      if (closer && closer !== el && el.contains(closer)) {
-        const elPriority = parseInt(el.getAttribute('data-askable-priority') ?? '0', 10);
-        const closerPriority = parseInt((closer as HTMLElement).getAttribute('data-askable-priority') ?? '0', 10);
-        if (elPriority <= closerPriority) return;
-      }
-    } else {
-      // Direct target — check if any [data-askable] ancestor has higher priority.
-      const elPriority = parseInt(el.getAttribute('data-askable-priority') ?? '0', 10);
+
+    // Apply targetStrategy to decide which [data-askable] element handles the event.
+    if (this.targetStrategy === 'exact') {
+      // Only fire if the event target itself has [data-askable] — no bubbled triggers.
+      if (!target.hasAttribute('data-askable') || target !== el) return;
+    } else if (this.targetStrategy === 'shallowest') {
+      // Outermost [data-askable] ancestor wins — skip if a bound ancestor exists.
       let ancestor = el.parentElement;
       while (ancestor) {
-        if (ancestor.hasAttribute('data-askable')) {
-          const ancestorPriority = parseInt(ancestor.getAttribute('data-askable-priority') ?? '0', 10);
-          if (ancestorPriority > elPriority) return;
-        }
+        if (this.boundElements.has(ancestor as HTMLElement)) return;
         ancestor = ancestor.parentElement;
+      }
+    } else {
+      // 'deepest' (default): innermost wins. data-askable-priority overrides.
+      if (target !== el) {
+        // Event bubbled — check if a closer descendant should win.
+        const closer = target.closest('[data-askable]');
+        if (closer && closer !== el && el.contains(closer)) {
+          const elPriority = parseInt(el.getAttribute('data-askable-priority') ?? '0', 10);
+          const closerPriority = parseInt((closer as HTMLElement).getAttribute('data-askable-priority') ?? '0', 10);
+          if (elPriority <= closerPriority) return;
+        }
+      } else {
+        // Direct target — check if any ancestor has higher priority.
+        const elPriority = parseInt(el.getAttribute('data-askable-priority') ?? '0', 10);
+        let ancestor = el.parentElement;
+        while (ancestor) {
+          if (ancestor.hasAttribute('data-askable')) {
+            const ancestorPriority = parseInt(ancestor.getAttribute('data-askable-priority') ?? '0', 10);
+            if (ancestorPriority > elPriority) return;
+          }
+          ancestor = ancestor.parentElement;
+        }
       }
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,9 +23,26 @@ export type AskableEventHandler<K extends AskableEventName> = (
 
 export type AskableEvent = 'click' | 'hover' | 'focus';
 
+/**
+ * Controls which [data-askable] element handles an interaction when multiple
+ * elements are nested.
+ *
+ * - `'deepest'`  (default) — innermost element wins. Override with `data-askable-priority`.
+ * - `'shallowest'` — outermost element wins.
+ * - `'exact'`    — only fires when the event target itself has `[data-askable]`.
+ *                  Parent elements are never triggered via bubbling.
+ */
+export type AskableTargetStrategy = 'deepest' | 'shallowest' | 'exact';
+
 export interface AskableObserveOptions {
   /** Which interaction types trigger context updates. Defaults to all: ['click', 'hover', 'focus'] */
   events?: AskableEvent[];
+  /**
+   * How to resolve the winning element when nested [data-askable] elements are involved.
+   * See `AskableTargetStrategy` for details.
+   * @default 'deepest'
+   */
+  targetStrategy?: AskableTargetStrategy;
   /**
    * Debounce delay in ms applied to hover (mouseenter) events.
    * Prevents rapid context switches when the user moves the cursor across many elements.

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -72,8 +72,17 @@ ctx.observe(document, { hoverThrottle: 100 });
 |---|---|---|
 | `root` | `HTMLElement \| Document` | Root element to observe |
 | `options.events` | `AskableEvent[]` | Trigger events. Default: `['click', 'hover', 'focus']` |
+| `options.targetStrategy` | `AskableTargetStrategy` | Which element wins when nested `[data-askable]` elements are involved. Default: `'deepest'` |
 | `options.hoverDebounce` | `number` | Debounce delay in ms for hover events. Default: `0` |
 | `options.hoverThrottle` | `number` | Throttle window in ms for hover events. Default: `0` |
+
+**`AskableTargetStrategy` values:**
+
+| Value | Behaviour |
+|---|---|
+| `'deepest'` | Innermost `[data-askable]` element wins. Override with `data-askable-priority`. |
+| `'shallowest'` | Outermost `[data-askable]` ancestor wins; inner elements are suppressed. |
+| `'exact'` | Only fires when the event target itself has `[data-askable]`. No bubbled triggers. |
 
 ---
 

--- a/site/docs/guide/annotating.md
+++ b/site/docs/guide/annotating.md
@@ -60,9 +60,45 @@ You can nest `[data-askable]` elements. When a user interacts with a nested elem
 </section>
 ```
 
+### Target strategy
+
+The `targetStrategy` option passed to `observe()` controls how the winning element is chosen when nested `[data-askable]` elements are involved:
+
+```ts
+ctx.observe(document, { targetStrategy: 'deepest' });   // default
+ctx.observe(document, { targetStrategy: 'shallowest' });
+ctx.observe(document, { targetStrategy: 'exact' });
+```
+
+| Strategy | Behaviour |
+|---|---|
+| `'deepest'` | Innermost element wins. Use `data-askable-priority` to override. |
+| `'shallowest'` | Outermost `[data-askable]` ancestor wins; inner elements are suppressed. |
+| `'exact'` | Only fires when the event target itself has `[data-askable]`. No bubbled triggers. |
+
+**`'shallowest'`** is useful for dashboards where a page-level context should always take precedence:
+
+```html
+<!-- With 'shallowest': clicking the chart fires the section, not the widget -->
+<section data-askable='{"page":"analytics"}'>
+  <div data-askable='{"widget":"revenue-chart"}'>
+    <canvas></canvas>
+  </div>
+</section>
+```
+
+**`'exact'`** prevents any bubbling — the element that was directly clicked must carry the attribute:
+
+```html
+<!-- With 'exact': clicking the <canvas> inside the div does NOT fire the div -->
+<div data-askable='{"widget":"revenue-chart"}'>
+  <canvas></canvas>
+</div>
+```
+
 ### Priority targeting
 
-Use `data-askable-priority` (numeric) to override the default innermost-wins rule. Higher values win.
+Use `data-askable-priority` (numeric) to override the default innermost-wins rule within `'deepest'` strategy. Higher values win.
 
 ```html
 <!-- Outer has higher priority — clicking the inner card still focuses the section -->


### PR DESCRIPTION
## Summary

Adds a `targetStrategy` option to `ctx.observe()` that controls which nested `[data-askable]` element wins when an interaction bubbles through multiple annotated ancestors.

- **`'deepest'`** (default) — innermost element wins; respects `data-askable-priority`
- **`'shallowest'`** — outermost `[data-askable]` ancestor wins; inner elements are suppressed
- **`'exact'`** — only fires when the event target itself carries `[data-askable]`; no bubbled triggers

Closes #8.

## Changes

- `types.ts` — adds `AskableTargetStrategy` union type and `targetStrategy?` to `AskableObserveOptions`
- `observer.ts` — implements strategy dispatch in `handleInteraction`
- `context.ts` — passes `targetStrategy` through to `Observer.observe()`
- `index.ts` — exports `AskableTargetStrategy`
- 7 new observer tests covering all three strategies (including direct-click-outer for shallowest)
- Docs: annotating guide gets a "Target strategy" section; API reference gets `targetStrategy` row and strategy table

## Test plan

- [ ] `npm test -w packages/core` — all 74 tests pass
- [ ] `'deepest'`: clicking inner fires inner; `data-askable-priority` overrides still work
- [ ] `'shallowest'`: clicking inner fires outer; clicking outer directly fires outer; standalone element fires
- [ ] `'exact'`: direct click on annotated element fires; bubbled click from non-annotated child does NOT fire; bubbled click from annotated inner fires inner only (outer suppressed)

https://claude.ai/code/session_015RnLQkywZbT1bujJgBuhJu