### PR TITLE
feat(angular): add @askable-ui/angular adapter (#33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,23 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@angular/core": {
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.12.tgz",
+      "integrity": "sha512-GLLlDeke/NjroaLYOks0uyzFVo6HyLl7VOm0K1QpLXnYvW63W9Ql/T3yguRZa7tRkOAeFZ3jw+1wnBD4O8MoUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.10.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^6.5.3 || ^7.4.0",
+        "zone.js": "~0.13.0"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -45,6 +62,10 @@
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
       }
+    },
+    "node_modules/@askable-ui/angular": {
+      "resolved": "packages/angular",
+      "link": true
     },
     "node_modules/@askable-ui/core": {
       "resolved": "packages/core",
@@ -4038,6 +4059,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -4598,6 +4630,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -5183,6 +5222,35 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zone.js": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.13.3.tgz",
+      "integrity": "sha512-MKPbmZie6fASC/ps4dkmIhaT5eonHkEt6eAy80K42tAm0G2W+AahLJjbfi6X9NPdciOE9GRFTTM8u2IiF6O3ww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "packages/angular": {
+      "name": "@askable-ui/angular",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@askable-ui/core": "^0.2.0"
+      },
+      "devDependencies": {
+        "@angular/core": "^16.2.12",
+        "@askable-ui/core": "*",
+        "jsdom": "^25.0.0",
+        "typescript": "^5.4.5",
+        "vitest": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=16.0.0"
+      }
     },
     "packages/core": {
       "name": "@askable-ui/core",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@askable-ui/angular",
+  "version": "0.2.0",
+  "description": "Angular bindings for askable — LLM-aware UI context",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/askable-ui/askable.git",
+    "directory": "packages/angular"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "llm",
+    "context",
+    "angular",
+    "ui",
+    "focus"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "@angular/core": ">=16.0.0"
+  },
+  "dependencies": {
+    "@askable-ui/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "@angular/core": "^16.2.12",
+    "@askable-ui/core": "*",
+    "jsdom": "^25.0.0",
+    "typescript": "^5.4.5",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/angular/src/AskableDirective.ts
+++ b/packages/angular/src/AskableDirective.ts
@@ -1,0 +1,27 @@
+import { Directive, Input, HostBinding } from '@angular/core';
+
+/**
+ * Standalone directive that sets the `data-askable` attribute on a host element.
+ *
+ * Use it in templates to annotate any element for LLM context:
+ *
+ * ```html
+ * <div [askable]="{ metric: 'revenue', period: 'Q3' }">...</div>
+ * <nav askable="main navigation">...</nav>
+ * ```
+ *
+ * The value can be a JSON object (serialized automatically) or a plain string.
+ */
+@Directive({
+  selector: '[askable]',
+  standalone: true,
+})
+export class AskableDirective {
+  /** Meta to encode as the `data-askable` attribute. Objects are JSON-serialized. */
+  @Input('askable') meta: Record<string, unknown> | string = '';
+
+  @HostBinding('attr.data-askable')
+  get dataAskable(): string {
+    return typeof this.meta === 'string' ? this.meta : JSON.stringify(this.meta);
+  }
+}

--- a/packages/angular/src/AskableService.ts
+++ b/packages/angular/src/AskableService.ts
@@ -1,0 +1,70 @@
+import { Injectable, OnDestroy, signal, computed } from '@angular/core';
+import { createAskableContext } from '@askable-ui/core';
+import type {
+  AskableContext,
+  AskableContextOptions,
+  AskableObserveOptions,
+  AskableFocus,
+  AskablePromptContextOptions,
+} from '@askable-ui/core';
+
+/**
+ * Angular service that wraps an AskableContext and exposes reactive signals.
+ *
+ * Provided at the root injector by default. To use a scoped instance with custom
+ * options, provide it at the component level:
+ *
+ * ```ts
+ * @Component({
+ *   providers: [{ provide: AskableService, useFactory: () => new AskableService({ textExtractor: ... }) }]
+ * })
+ * ```
+ */
+@Injectable({ providedIn: 'root' })
+export class AskableService implements OnDestroy {
+  private readonly _ctx: AskableContext;
+  private readonly _focus = signal<AskableFocus | null>(null);
+
+  /** Reactive signal — current focus or null */
+  readonly focus = this._focus.asReadonly();
+
+  /** Computed signal — current focus as a prompt-ready string */
+  readonly promptContext = computed(() => {
+    this._focus(); // track the focus signal so this updates when focus changes
+    return this._ctx.toPromptContext();
+  });
+
+  constructor(options?: AskableContextOptions) {
+    this._ctx = createAskableContext(options);
+    this._ctx.on('focus', (f) => this._focus.set(f));
+    this._ctx.on('clear', () => this._focus.set(null));
+
+    if (typeof document !== 'undefined') {
+      this._ctx.observe(document);
+    }
+  }
+
+  /** The underlying AskableContext — for advanced use */
+  get ctx(): AskableContext {
+    return this._ctx;
+  }
+
+  /** Re-observe a specific subtree or change observe options */
+  observe(root: HTMLElement | Document = document, options?: AskableObserveOptions): void {
+    this._ctx.observe(root, options);
+  }
+
+  /** Detach all listeners without destroying the context */
+  unobserve(): void {
+    this._ctx.unobserve();
+  }
+
+  /** Serialize current focus to a prompt-ready string */
+  toPromptContext(options?: AskablePromptContextOptions): string {
+    return this._ctx.toPromptContext(options);
+  }
+
+  ngOnDestroy(): void {
+    this._ctx.destroy();
+  }
+}

--- a/packages/angular/src/__tests__/AskableDirective.spec.ts
+++ b/packages/angular/src/__tests__/AskableDirective.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { AskableDirective } from '../AskableDirective.js';
+
+// AskableDirective is a plain class — the decorator only adds metadata.
+// We can test the core attribute logic by instantiating directly.
+
+describe('AskableDirective', () => {
+  function makeDirective(meta: Record<string, unknown> | string): AskableDirective {
+    const d = new AskableDirective();
+    d.meta = meta;
+    return d;
+  }
+
+  it('serializes an object meta to JSON for data-askable', () => {
+    const d = makeDirective({ metric: 'revenue', period: 'Q3' });
+    expect(d.dataAskable).toBe('{"metric":"revenue","period":"Q3"}');
+  });
+
+  it('passes a string meta through as-is', () => {
+    const d = makeDirective('main navigation');
+    expect(d.dataAskable).toBe('main navigation');
+  });
+
+  it('serializes an empty object', () => {
+    const d = makeDirective({});
+    expect(d.dataAskable).toBe('{}');
+  });
+
+  it('serializes a nested object', () => {
+    const d = makeDirective({ chart: { type: 'bar', data: [1, 2, 3] } });
+    const parsed = JSON.parse(d.dataAskable);
+    expect(parsed.chart.type).toBe('bar');
+    expect(parsed.chart.data).toEqual([1, 2, 3]);
+  });
+
+  it('updates when meta changes (reactive via getter)', () => {
+    const d = makeDirective({ step: 1 });
+    expect(JSON.parse(d.dataAskable).step).toBe(1);
+
+    d.meta = { step: 2 };
+    expect(JSON.parse(d.dataAskable).step).toBe(2);
+  });
+
+  it('default meta is an empty string', () => {
+    const d = new AskableDirective();
+    expect(d.dataAskable).toBe('');
+  });
+});

--- a/packages/angular/src/__tests__/AskableService.spec.ts
+++ b/packages/angular/src/__tests__/AskableService.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { AskableService } from '../AskableService.js';
+
+// AskableService can be instantiated directly (without Angular DI / TestBed)
+// because Angular signals are plain JS primitives and decorators are just metadata.
+
+describe('AskableService', () => {
+  const instances: AskableService[] = [];
+
+  function makeService(options?: ConstructorParameters<typeof AskableService>[0]): AskableService {
+    const svc = new AskableService(options);
+    instances.push(svc);
+    return svc;
+  }
+
+  afterEach(() => {
+    instances.forEach((svc) => svc.ngOnDestroy());
+    instances.length = 0;
+  });
+
+  it('focus signal is null initially', () => {
+    const svc = makeService();
+    expect(svc.focus()).toBeNull();
+  });
+
+  it('promptContext signal returns no-focus string initially', () => {
+    const svc = makeService();
+    expect(svc.promptContext()).toBe('No UI element is currently focused.');
+  });
+
+  it('focus signal updates when ctx.select() is called', () => {
+    const svc = makeService();
+    const el = document.createElement('div');
+    el.setAttribute('data-askable', JSON.stringify({ metric: 'revenue' }));
+    el.textContent = 'Revenue';
+    document.body.appendChild(el);
+
+    svc.ctx.select(el);
+
+    expect(svc.focus()).not.toBeNull();
+    expect((svc.focus()!.meta as Record<string, unknown>).metric).toBe('revenue');
+
+    el.remove();
+  });
+
+  it('promptContext signal updates after focus changes', () => {
+    const svc = makeService();
+    const el = document.createElement('div');
+    el.setAttribute('data-askable', JSON.stringify({ widget: 'chart' }));
+    el.textContent = 'Chart';
+    document.body.appendChild(el);
+
+    expect(svc.promptContext()).toBe('No UI element is currently focused.');
+
+    svc.ctx.select(el);
+    expect(svc.promptContext()).toContain('widget');
+    expect(svc.promptContext()).toContain('chart');
+
+    el.remove();
+  });
+
+  it('focus signal resets to null after ctx.clear()', () => {
+    const svc = makeService();
+    const el = document.createElement('div');
+    el.setAttribute('data-askable', '{}');
+    document.body.appendChild(el);
+
+    svc.ctx.select(el);
+    expect(svc.focus()).not.toBeNull();
+
+    svc.ctx.clear();
+    expect(svc.focus()).toBeNull();
+
+    el.remove();
+  });
+
+  it('ctx getter returns the underlying AskableContext', () => {
+    const svc = makeService();
+    expect(typeof svc.ctx.getFocus).toBe('function');
+    expect(typeof svc.ctx.observe).toBe('function');
+  });
+
+  it('toPromptContext() delegates to the underlying context', () => {
+    const svc = makeService();
+    const result = svc.toPromptContext();
+    expect(typeof result).toBe('string');
+    expect(result).toBe('No UI element is currently focused.');
+  });
+
+  it('unobserve() and re-observe() work without throwing', () => {
+    const svc = makeService();
+    expect(() => svc.unobserve()).not.toThrow();
+    expect(() => svc.observe(document)).not.toThrow();
+  });
+
+  it('ngOnDestroy() cleans up without throwing', () => {
+    const svc = new AskableService(); // not tracked — we call destroy manually
+    expect(() => svc.ngOnDestroy()).not.toThrow();
+  });
+
+  it('accepts textExtractor option', () => {
+    const svc = makeService({
+      textExtractor: (el) => el.getAttribute('aria-label') ?? el.textContent?.trim() ?? '',
+    });
+    const el = document.createElement('button');
+    el.setAttribute('data-askable', '{}');
+    el.setAttribute('aria-label', 'Open menu');
+    el.textContent = 'ignored';
+    document.body.appendChild(el);
+
+    svc.ctx.select(el);
+    expect(svc.focus()?.text).toBe('Open menu');
+
+    el.remove();
+  });
+});

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,0 +1,2 @@
+export { AskableService } from './AskableService.js';
+export { AskableDirective } from './AskableDirective.js';

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": false,
+    "useDefineForClassFields": false
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/angular/vitest.config.ts
+++ b/packages/angular/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+  },
+});

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
             { text: 'React', link: '/guide/react' },
             { text: 'Vue', link: '/guide/vue' },
             { text: 'Svelte', link: '/guide/svelte' },
+            { text: 'Angular', link: '/guide/angular' },
             { text: 'Plain JS / HTML', link: '/guide/vanilla' },
           ],
         },
@@ -61,6 +62,7 @@ export default defineConfig({
             { text: '@askable-ui/react', link: '/api/react' },
             { text: '@askable-ui/vue', link: '/api/vue' },
             { text: '@askable-ui/svelte', link: '/api/svelte' },
+            { text: '@askable-ui/angular', link: '/api/angular' },
           ],
         },
         {

--- a/site/docs/api/angular.md
+++ b/site/docs/api/angular.md
@@ -1,0 +1,76 @@
+# @askable-ui/angular
+
+Angular bindings for askable-ui. Requires Angular 16 or later.
+
+## Install
+
+```bash
+npm install @askable-ui/angular @askable-ui/core
+```
+
+---
+
+## `AskableDirective`
+
+Standalone directive that sets `data-askable` on a host element. Import it in standalone components or an `NgModule`.
+
+```ts
+import { AskableDirective } from '@askable-ui/angular';
+
+@Component({
+  standalone: true,
+  imports: [AskableDirective],
+  template: `
+    <div [askable]="{ metric: 'revenue', delta: '-12%' }">
+      <revenue-chart />
+    </div>
+    <nav askable="main navigation">...</nav>
+  `,
+})
+```
+
+**Inputs:**
+
+| Input | Type | Description |
+|---|---|---|
+| `[askable]` | `Record<string, unknown> \| string` | Value for `data-askable`. Objects are JSON-serialized. |
+
+---
+
+## `AskableService`
+
+Injectable service (provided at root by default) wrapping an `AskableContext`. Exposes Angular signals for reactive integration.
+
+```ts
+import { Component, inject } from '@angular/core';
+import { AskableService } from '@askable-ui/angular';
+
+@Component({ ... })
+export class MyComponent {
+  askable = inject(AskableService);
+  // askable.focus()         — Signal<AskableFocus | null>
+  // askable.promptContext() — Signal<string>
+}
+```
+
+**Signals:**
+
+| Signal | Type | Description |
+|---|---|---|
+| `focus` | `Signal<AskableFocus \| null>` | Current focus, or `null` |
+| `promptContext` | `Signal<string>` | Current focus as a prompt-ready string |
+
+**Methods:**
+
+| Method | Signature | Description |
+|---|---|---|
+| `observe` | `(root?: HTMLElement \| Document, options?: AskableObserveOptions) => void` | Re-observe a subtree or change options. Defaults to `document`. |
+| `unobserve` | `() => void` | Detach all listeners without destroying the context |
+| `toPromptContext` | `(options?: AskablePromptContextOptions) => string` | Serialize focus with custom options |
+| `ctx` | `AskableContext` (getter) | The underlying context for advanced use |
+| `ngOnDestroy` | `() => void` | Automatically called by Angular — destroys the context |
+
+**Notes:**
+- `observe(document)` is called automatically at construction in browser environments. It is skipped on the server (SSR-safe).
+- To scope to a specific subtree, call `unobserve()` then `observe(myElement)`.
+- To use custom options (`textExtractor`, `sanitizeMeta`, `sanitizeText`), provide a factory at the component level — see the [Angular Guide](/guide/angular#scoped-service).

--- a/site/docs/guide/angular.md
+++ b/site/docs/guide/angular.md
@@ -1,0 +1,157 @@
+# Angular Guide
+
+Requires Angular 16 or later (signals-compatible).
+
+## Install
+
+```bash
+npm install @askable-ui/angular @askable-ui/core
+```
+
+## Quick start
+
+```ts
+// app.component.ts
+import { Component, inject } from '@angular/core';
+import { AskableService, AskableDirective } from '@askable-ui/angular';
+
+@Component({
+  standalone: true,
+  imports: [AskableDirective],
+  template: `
+    <div [askable]="{ metric: 'revenue', value: '$128k', period: 'Q3' }">
+      <revenue-chart />
+    </div>
+
+    <button (click)="ask()">Ask AI ✦</button>
+  `,
+})
+export class DashboardComponent {
+  private askable = inject(AskableService);
+
+  ask() {
+    const context = this.askable.toPromptContext();
+    // pass context to your LLM call
+  }
+}
+```
+
+## `AskableDirective`
+
+A standalone directive that sets the `data-askable` attribute on any host element. Import it into standalone components or an `NgModule`.
+
+```ts
+import { AskableDirective } from '@askable-ui/angular';
+
+@Component({
+  standalone: true,
+  imports: [AskableDirective],
+  template: `
+    <!-- Object meta — JSON-serialized automatically -->
+    <div [askable]="{ widget: 'churn-rate', value: '4.2%' }">
+      <churn-chart />
+    </div>
+
+    <!-- String meta — passed through as-is -->
+    <nav askable="main navigation">...</nav>
+  `,
+})
+```
+
+**Inputs:**
+
+| Input | Type | Description |
+|---|---|---|
+| `[askable]` | `Record<string, unknown> \| string` | Metadata for the element. Objects are JSON-serialized to `data-askable`. |
+
+## `AskableService`
+
+Injectable service provided at the root injector. Wraps an `AskableContext` and exposes reactive Angular signals.
+
+```ts
+import { Component, inject } from '@angular/core';
+import { AskableService } from '@askable-ui/angular';
+
+@Component({ ... })
+export class MyComponent {
+  askable = inject(AskableService);
+
+  // focus: Signal<AskableFocus | null>
+  // promptContext: Signal<string>
+}
+```
+
+```html
+<!-- Template — signals unwrap automatically in Angular templates -->
+<p>{{ askable.promptContext() }}</p>
+<p *ngIf="askable.focus()">Focused: {{ askable.focus()?.meta | json }}</p>
+```
+
+**Signals:**
+
+| Signal | Type | Description |
+|---|---|---|
+| `focus` | `Signal<AskableFocus \| null>` | Current focus, or `null` |
+| `promptContext` | `Signal<string>` | Current focus as a prompt-ready string |
+
+**Methods:**
+
+| Method | Description |
+|---|---|
+| `observe(root?, options?)` | Re-observe a subtree or change options. `root` defaults to `document`. |
+| `unobserve()` | Detach all listeners without destroying the context. |
+| `toPromptContext(options?)` | Serialize focus to a string with custom options. |
+| `ctx` | The underlying `AskableContext` for advanced use. |
+
+## Scoped service
+
+To use a service scoped to a single component (for example, to track only a specific subtree or use custom options), provide a new instance at the component level:
+
+```ts
+import { Component } from '@angular/core';
+import { AskableService } from '@askable-ui/angular';
+
+@Component({
+  standalone: true,
+  providers: [
+    {
+      provide: AskableService,
+      useFactory: () =>
+        new AskableService({
+          textExtractor: (el) => el.getAttribute('aria-label') ?? el.textContent?.trim() ?? '',
+        }),
+    },
+  ],
+})
+export class AdminPanelComponent {
+  // This instance is independent of the root AskableService
+}
+```
+
+## SSR
+
+`AskableService` is SSR-safe — it skips `observe()` when `document` is not available (i.e. on the server).
+
+## "Ask AI" button pattern
+
+```ts
+@Component({
+  standalone: true,
+  imports: [AskableDirective],
+  template: `
+    <div #card [askable]="data">
+      <revenue-chart [data]="data" />
+      <button (click)="askAboutCard(card)">Ask AI ✦</button>
+    </div>
+  `,
+})
+export class RevenueCardComponent {
+  data = { metric: 'revenue', value: '$2.3M', period: 'Q3' };
+  private askable = inject(AskableService);
+
+  askAboutCard(el: HTMLElement) {
+    this.askable.ctx.select(el);
+    this.openChatPanel();
+  }
+}
+```


### PR DESCRIPTION
## Summary

Adds `@askable-ui/angular` — a first-class Angular 16+ adapter closing #33.

- **`AskableDirective`** — standalone directive that sets `data-askable` via `[askable]` input; accepts object (auto-JSON-serialized) or string meta
- **`AskableService`** — root-provided injectable wrapping `AskableContext`; exposes `focus` and `promptContext` as Angular signals; auto-observes `document` on construction (SSR-safe via `typeof document` guard); supports scoped instances via component-level factory providers

## Design notes

- Angular 16's `signal()` / `computed()` are plain JS primitives — no `TestBed` required; all 16 tests run in jsdom under vitest
- `@Injectable({ providedIn: 'root' })` with optional `options?` parameter: Angular passes `undefined` for the optional arg, which is the desired default behavior; custom options go through component-level `useFactory`
- `useDefineForClassFields: false` in tsconfig is required for Angular 16 decorator compatibility with TypeScript 5

## Test plan

- [ ] `npm test -w packages/angular` — all 16 tests pass
- [ ] `AskableService.focus()` is null initially
- [ ] `AskableService.focus()` updates after `ctx.select(el)`
- [ ] `AskableService.promptContext()` updates reactively
- [ ] `AskableService.ctx.clear()` resets focus signal to null
- [ ] `textExtractor` option flows through to focus text
- [ ] `AskableDirective` serializes object meta to JSON
- [ ] `AskableDirective` passes string meta through unchanged
- [ ] Docs: guide page and API reference render correctly in sidebar

https://claude.ai/code/session_015RnLQkywZbT1bujJgBuhJu