### PR TITLE
docs: add browser support policy and expand SSR guide (#15,#19,#44)

### DIFF
--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
             { text: 'Focus & History', link: '/guide/focus-history' },
             { text: 'Prompt Serialization', link: '/guide/serialization' },
             { text: 'SSR Safety', link: '/guide/ssr' },
+            { text: 'Browser Support', link: '/guide/browser-support' },
           ],
         },
       ],

--- a/site/docs/guide/browser-support.md
+++ b/site/docs/guide/browser-support.md
@@ -1,0 +1,42 @@
+# Browser Support
+
+## Supported browsers
+
+askable-ui targets **modern evergreen browsers**:
+
+| Browser | Minimum version |
+|---|---|
+| Chrome / Chromium | 80+ |
+| Firefox | 78+ |
+| Safari / WebKit | 14+ |
+| Edge (Chromium) | 80+ |
+
+Mobile browsers (Chrome for Android, Safari iOS) follow the same policy. IE11 and legacy Edge (EdgeHTML) are **not supported**.
+
+## Browser API dependencies
+
+askable-ui relies on the following browser APIs:
+
+| API | Used for | Fallback |
+|---|---|---|
+| `MutationObserver` | Detecting dynamically added/removed `[data-askable]` elements | No-op — `observe()` does nothing if unavailable |
+| `addEventListener` | Click, hover, and focus event listeners | No-op |
+| `Element.closest()` | Nested element resolution | Not polyfilled |
+| `Element.contains()` | Containment checks for nested strategy | Not polyfilled |
+
+If `window`, `document`, or `MutationObserver` are not present (SSR, Node.js, old browsers), `observe()` exits immediately without attaching any listeners. Context creation, serialization, and `select()` are always safe.
+
+## Node.js / SSR
+
+All packages are safe to import and render in Node.js. See [SSR Safety](/guide/ssr) for the full server/client boundary documentation.
+
+## Polyfills
+
+askable-ui does not ship or require polyfills. If you need to support older browsers:
+
+- `MutationObserver` — widely supported since 2013; no polyfill needed for any realistic target
+- `Element.closest()` — available everywhere; if you target very old Safari, add the standard [MDN polyfill](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#polyfill)
+
+## Testing targets
+
+CI runs tests in Node.js + jsdom (unit). Browser-level integration tests (Playwright) are tracked in [#16](https://github.com/askable-ui/askable/issues/16).

--- a/site/docs/guide/ssr.md
+++ b/site/docs/guide/ssr.md
@@ -18,43 +18,7 @@ function isBrowser(): boolean {
 
 If any of these are missing, `observe()` is a silent no-op. Creating a context on the server is safe — it just won't start tracking until the browser hydrates.
 
-## Framework behaviour
-
-### React (`useAskable`)
-
-Observation starts inside a `useEffect`, which only runs on the client. The hook is safe to call in Server Components (it renders to `null` focus state) and in Client Components.
-
-```tsx
-// ✅ Safe in Next.js App Router
-'use client';
-import { useAskable } from '@askable-ui/react';
-
-export function ChatInput() {
-  const { promptContext } = useAskable();
-  // On server: promptContext = 'No UI element is currently focused.'
-  // On client: tracks real user interactions
-}
-```
-
-### Vue (`useAskable`)
-
-Observation starts in `onMounted()`, which is client-only. SSR renders receive `null` focus and the `'No UI element is currently focused.'` prompt string.
-
-```ts
-// ✅ Safe in Nuxt
-const { promptContext } = useAskable();
-// Server render: promptContext.value = 'No UI element is currently focused.'
-```
-
-### Svelte (`createAskableStore`)
-
-`createAskableStore()` calls `observe()` immediately, but the `observe()` call is guarded. On the server, the stores initialize with `null` / `'No UI element is currently focused.'` and hydrate when the browser loads.
-
-```ts
-// ✅ Safe in SvelteKit
-const { promptContext } = createAskableStore();
-// Server: $promptContext = 'No UI element is currently focused.'
-```
+Each framework adapter also ensures the module-level global context is **never persisted across SSR requests**. When `window` is undefined, a fresh throwaway context is created per render, preventing state leakage between concurrent server requests.
 
 ## What renders on the server
 
@@ -69,19 +33,162 @@ All adapters render a predictable initial state on the server:
 
 This means your LLM calls still work on the server — they just receive the empty-state strings. If you need to guard against sending LLM requests with no context, check `focus !== null` before calling.
 
-## Scoped contexts (React)
+---
 
-If you create a context instance manually and call `observe()` yourself, wrap it in a browser check or put it inside `useEffect` / `onMounted`:
+## React — Next.js App Router
+
+`useAskable()` observes the DOM only inside a `useEffect`, which never runs on the server. It is safe to call in any component tree.
+
+```tsx
+// app/dashboard/page.tsx — Server Component
+// Components inside can use useAskable() — it silently returns no-focus state
+export default function Page() {
+  return <Dashboard />;
+}
+```
+
+Components that call `useAskable()` must be Client Components:
+
+```tsx
+// components/ChatInput.tsx
+'use client';
+import { useAskable } from '@askable-ui/react';
+
+export function ChatInput() {
+  const { promptContext } = useAskable();
+  // Server render: 'No UI element is currently focused.'
+  // Client (after hydration): live focus context
+}
+```
+
+The `<Askable>` component renders `data-askable` attributes during SSR — the HTML is present immediately and hydrates without a flash:
+
+```tsx
+// ✅ data-askable appears in server-rendered HTML
+<Askable meta={{ widget: 'revenue-chart' }}>
+  <RevenueChart />
+</Askable>
+```
+
+**Concurrent request safety:** Each SSR render gets a fresh, independent context object. There is no cross-request state leakage, even under concurrent load.
+
+---
+
+## Vue — Nuxt
+
+`useAskable()` starts observing in `onMounted()`, which is client-only. The composable is safe to call in Nuxt pages and layouts without any special configuration.
+
+```ts
+// pages/dashboard.vue
+<script setup>
+import { useAskable } from '@askable-ui/vue';
+
+const { promptContext } = useAskable();
+// Server render: promptContext.value = 'No UI element is currently focused.'
+// Client (after hydration): live context
+</script>
+```
+
+The `<Askable>` component renders correctly during SSR:
+
+```vue
+<template>
+  <!-- data-askable is in server-rendered HTML -->
+  <Askable :meta="{ widget: 'revenue-chart' }">
+    <RevenueChart />
+  </Askable>
+</template>
+```
+
+If you need to branch on whether focus is set:
+
+```ts
+const { focus } = useAskable();
+
+// Check before sending to LLM
+const context = focus.value ? promptContext.value : null;
+```
+
+---
+
+## Svelte — SvelteKit
+
+`createAskableStore()` calls `observe()` immediately, but the call is guarded — it is a no-op on the server.
+
+```ts
+// +layout.svelte or +page.svelte
+<script>
+  import { createAskableStore } from '@askable-ui/svelte';
+
+  const { focus, promptContext } = createAskableStore();
+  // Server: $focus = null, $promptContext = 'No UI element is currently focused.'
+  // Client (after hydration): live context
+</script>
+```
+
+For SvelteKit with SSR, create the store in the component body (not at module level) to ensure each server request gets a fresh instance:
+
+```ts
+// ✅ Per-render instance — safe for concurrent requests
+<script>
+  import { createAskableStore } from '@askable-ui/svelte';
+  const store = createAskableStore();
+</script>
+
+// ❌ Module-level — shared across all server requests
+import { createAskableStore } from '@askable-ui/svelte';
+const store = createAskableStore(); // runs once at import time
+```
+
+---
+
+## Scoped contexts in SSR
+
+If you create a context manually, `observe()` is already a no-op on the server:
 
 ```ts
 import { createAskableContext } from '@askable-ui/core';
 
 // ✅ Safe — observe() is a no-op outside browser
 const ctx = createAskableContext();
-ctx.observe(document); // no-op on server
+ctx.observe(document);
 
-// ✅ Explicit browser guard (not required, but explicit)
+// ✅ Explicit browser guard (optional)
 if (typeof window !== 'undefined') {
   ctx.observe(document);
 }
+```
+
+---
+
+## Server/client privacy boundary
+
+Askable captures data **entirely in the browser**. Nothing is automatically sent to your server. The flow is:
+
+```
+Browser                              Server / LLM
+──────────────────────────────       ──────────────────────────
+[data-askable] elements observed
+      ↓
+ctx.getFocus() → AskableFocus
+      ↓
+ctx.toPromptContext() → string  ──→  system prompt for LLM call
+```
+
+**What to be mindful of:**
+
+1. **Sensitive meta** — if `data-askable` attributes contain PII or internal IDs, use `sanitizeMeta` to strip them before they reach the prompt. See [Sanitization](/guide/annotating#sanitization-and-redaction).
+
+2. **Text content** — `text` is the trimmed `textContent` of the element. For elements that display sensitive user data (account numbers, addresses), use `sanitizeText` or a `textExtractor` that returns a safe label.
+
+3. **Transport** — `promptContext` is a plain string. You decide when and whether to include it in your LLM call. It is never sent anywhere by askable-ui itself.
+
+```ts
+// Recommended server-side pattern: validate before forwarding
+app.post('/api/chat', (req, res) => {
+  const { context, question } = req.body;
+  // context comes from the browser — treat it as user input
+  const safeContext = context?.slice(0, 2000) ?? ''; // length-limit
+  // pass to LLM
+});
 ```


### PR DESCRIPTION
## Summary

Documentation-only PR covering two issues:

- **Browser support policy (#15)** — new `guide/browser-support.md` defining supported browsers (Chrome 80+, Firefox 78+, Safari 14+), listing browser API dependencies with fallback notes, and polyfill stance
- **Expanded SSR guide (#19, #44)** — rewrites `guide/ssr.md` with per-framework sections for Next.js App Router, Nuxt, SvelteKit; documents concurrent-request safety; adds a server/client **privacy boundary** section explaining the data flow and transport responsibilities

Both pages added to the VitePress sidebar.

## Test plan

- [ ] Docs build succeeds (`npm run build` in `site/docs`)
- [ ] Browser support page renders at `/guide/browser-support`
- [ ] SSR guide has Next.js, Nuxt, SvelteKit code examples
- [ ] Privacy boundary section covers sanitization links

https://claude.ai/code/session_015RnLQkywZbT1bujJgBuhJu