### PR TITLE
feat(core): add a11yTextExtractor and promote select() docs (#17,#18)

### DIFF
--- a/packages/core/src/__tests__/a11y.test.ts
+++ b/packages/core/src/__tests__/a11y.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { a11yTextExtractor } from '../a11y.js';
+
+function el(
+  tag: string,
+  attrs: Record<string, string> = {},
+  text = '',
+): HTMLElement {
+  const elem = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) elem.setAttribute(k, v);
+  if (text) elem.textContent = text;
+  return elem;
+}
+
+describe('a11yTextExtractor', () => {
+  it('prefers aria-label over textContent', () => {
+    const button = el('button', { 'aria-label': 'Close dialog' }, 'X');
+    expect(a11yTextExtractor(button)).toBe('Close dialog');
+  });
+
+  it('uses aria-labelledby reference text', () => {
+    const label = document.createElement('span');
+    label.id = 'chart-label';
+    label.textContent = 'Revenue chart';
+    document.body.appendChild(label);
+
+    const div = el('div', { 'aria-labelledby': 'chart-label' });
+    expect(a11yTextExtractor(div)).toBe('Revenue chart');
+
+    label.remove();
+  });
+
+  it('concatenates multiple aria-labelledby references', () => {
+    const l1 = document.createElement('span');
+    l1.id = 'prefix';
+    l1.textContent = 'Q3';
+    const l2 = document.createElement('span');
+    l2.id = 'metric';
+    l2.textContent = 'Revenue';
+    document.body.appendChild(l1);
+    document.body.appendChild(l2);
+
+    const div = el('div', { 'aria-labelledby': 'prefix metric' });
+    expect(a11yTextExtractor(div)).toBe('Q3 Revenue');
+
+    l1.remove();
+    l2.remove();
+  });
+
+  it('falls back to title when no aria-label or labelledby', () => {
+    const img = el('img', { title: 'Bar chart', src: 'chart.png' });
+    expect(a11yTextExtractor(img)).toBe('Bar chart');
+  });
+
+  it('uses alt attribute for images', () => {
+    const img = el('img', { alt: 'Revenue trend line', src: 'chart.png' });
+    expect(a11yTextExtractor(img)).toBe('Revenue trend line');
+  });
+
+  it('aria-label takes precedence over alt', () => {
+    const img = el('img', { 'aria-label': 'Explicit label', alt: 'Alt text' });
+    expect(a11yTextExtractor(img)).toBe('Explicit label');
+  });
+
+  it('uses placeholder for inputs', () => {
+    const input = el('input', { placeholder: 'Search metrics…', type: 'text' });
+    expect(a11yTextExtractor(input)).toBe('Search metrics…');
+  });
+
+  it('falls back to textContent when no accessible attributes', () => {
+    const div = el('div', {}, 'Revenue: $2.3M');
+    expect(a11yTextExtractor(div)).toBe('Revenue: $2.3M');
+  });
+
+  it('returns empty string for element with no text or attributes', () => {
+    const div = el('div');
+    expect(a11yTextExtractor(div)).toBe('');
+  });
+
+  it('trims whitespace from all sources', () => {
+    const button = el('button', { 'aria-label': '  Save  ' });
+    expect(a11yTextExtractor(button)).toBe('Save');
+  });
+
+  it('skips empty aria-label and falls through to next source', () => {
+    const div = el('div', { 'aria-label': '  ', title: 'Dashboard widget' });
+    expect(a11yTextExtractor(div)).toBe('Dashboard widget');
+  });
+
+  it('empty alt attribute falls through to textContent', () => {
+    // decorative image — alt="" is intentionally empty; use textContent
+    const img = el('img', { alt: '', src: 'deco.png' });
+    // alt is empty string, so fall through to placeholder, then textContent
+    expect(a11yTextExtractor(img)).toBe('');
+  });
+
+  it('integrates with createAskableContext textExtractor option', () => {
+    // Verify the function signature matches what createAskableContext expects
+    const fn: (el: HTMLElement) => string = a11yTextExtractor;
+    expect(typeof fn).toBe('function');
+  });
+});

--- a/packages/core/src/a11y.ts
+++ b/packages/core/src/a11y.ts
@@ -1,0 +1,62 @@
+/**
+ * Accessibility-aware text extraction utilities.
+ *
+ * Pass `a11yTextExtractor` as the `textExtractor` option to
+ * `createAskableContext()` to prefer accessible names and ARIA labels over
+ * raw `textContent`:
+ *
+ * ```ts
+ * import { createAskableContext, a11yTextExtractor } from '@askable-ui/core';
+ *
+ * const ctx = createAskableContext({ textExtractor: a11yTextExtractor });
+ * ```
+ */
+
+/**
+ * Returns the accessible text for an element, following a priority order that
+ * mirrors the W3C Accessible Name and Description Computation algorithm
+ * (simplified):
+ *
+ * 1. `aria-label` — explicit author-provided label
+ * 2. `aria-labelledby` — references to other elements' text
+ * 3. `title` attribute — tooltip/fallback label
+ * 4. `alt` attribute — image alternative text
+ * 5. `placeholder` — form field hint
+ * 6. `textContent.trim()` — visible text (default fallback)
+ *
+ * This is the recommended extractor for applications where elements may have
+ * accessible labels that differ from their visible content (icon buttons,
+ * data cells with screen-reader-only descriptions, etc.).
+ */
+export function a11yTextExtractor(el: HTMLElement): string {
+  // 1. aria-label — highest priority
+  const ariaLabel = el.getAttribute('aria-label');
+  if (ariaLabel?.trim()) return ariaLabel.trim();
+
+  // 2. aria-labelledby — concatenate text from referenced elements
+  const labelledBy = el.getAttribute('aria-labelledby');
+  if (labelledBy?.trim()) {
+    const root = el.ownerDocument ?? document;
+    const parts = labelledBy
+      .trim()
+      .split(/\s+/)
+      .map((id) => root.getElementById(id)?.textContent?.trim() ?? '')
+      .filter(Boolean);
+    if (parts.length > 0) return parts.join(' ');
+  }
+
+  // 3. title attribute
+  const title = el.getAttribute('title');
+  if (title?.trim()) return title.trim();
+
+  // 4. alt attribute (img, area, input[type=image])
+  const alt = el.getAttribute('alt');
+  if (alt !== null && alt.trim()) return alt.trim();
+
+  // 5. placeholder (inputs, textareas)
+  const placeholder = el.getAttribute('placeholder');
+  if (placeholder?.trim()) return placeholder.trim();
+
+  // 6. Fallback to trimmed textContent
+  return el.textContent?.trim() ?? '';
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export { AskableContextImpl } from './context.js';
 export { createAskableInspector } from './inspector.js';
+export { a11yTextExtractor } from './a11y.js';
 export type {
   AskableInspectorHandle,
   AskableInspectorOptions,

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -49,8 +49,10 @@ export default defineConfig({
           items: [
             { text: 'Annotating Elements', link: '/guide/annotating' },
             { text: 'Focus & History', link: '/guide/focus-history' },
+            { text: 'Ask AI Buttons (select())', link: '/guide/select' },
             { text: 'Prompt Serialization', link: '/guide/serialization' },
             { text: 'SSR Safety', link: '/guide/ssr' },
+            { text: 'Browser Support', link: '/guide/browser-support' },
           ],
         },
       ],

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -287,3 +287,28 @@ inspector.destroy();
 | `compact` | `{ includeText: false, format: 'natural' }` |
 | `verbose` | `{ includeText: true, format: 'natural' }` |
 | `json` | `{ format: 'json', includeText: true }` |
+
+---
+
+## `a11yTextExtractor`
+
+Built-in accessibility-aware text extractor. Pass it as `textExtractor` to `createAskableContext()` to prefer ARIA labels and accessible names over raw `textContent`.
+
+```ts
+import { createAskableContext, a11yTextExtractor } from '@askable-ui/core';
+
+const ctx = createAskableContext({ textExtractor: a11yTextExtractor });
+```
+
+**Priority order (returns first non-empty value):**
+
+| Priority | Source | Notes |
+|---|---|---|
+| 1 | `aria-label` | Highest — explicit author label |
+| 2 | `aria-labelledby` | Concatenates referenced elements |
+| 3 | `title` | Tooltip/fallback label |
+| 4 | `alt` | Images and image inputs |
+| 5 | `placeholder` | Input hints |
+| 6 | `textContent.trim()` | Default fallback |
+
+See [Accessibility-aware text extraction](/guide/annotating#accessibility-aware-text-extraction) in the guide.

--- a/site/docs/guide/annotating.md
+++ b/site/docs/guide/annotating.md
@@ -138,28 +138,46 @@ Good candidates:
 | Dashboard KPI | `{"metric":"churn","value":"4.2%","trend":"up"}` |
 | Page section | `"analytics overview"` |
 
-## Custom text extraction
+## Accessibility-aware text extraction
 
-By default, Askable uses `element.textContent.trim()` to derive the text for each focused element. You can override this globally when creating the context:
+By default, Askable uses `element.textContent.trim()` to derive the text for each focused element. For applications where accessible names (ARIA labels, `aria-labelledby`, `title`, `alt`) are more semantically meaningful to the LLM, use the built-in `a11yTextExtractor`:
 
 ```ts
-import { createAskableContext } from '@askable-ui/core';
+import { createAskableContext, a11yTextExtractor } from '@askable-ui/core';
 
-const ctx = createAskableContext({
-  textExtractor: (el) =>
-    el.getAttribute('aria-label') ??
-    el.getAttribute('title') ??
-    el.textContent?.trim() ??
-    '',
-});
+const ctx = createAskableContext({ textExtractor: a11yTextExtractor });
 ```
 
-The extractor receives the DOM element and returns a string. It applies to all focus events — clicks, hovers, and explicit `select()` calls.
+`a11yTextExtractor` follows this priority order, returning the first non-empty value:
 
-Use this when:
-- Accessible names (ARIA labels) are more meaningful to the LLM than raw text content
-- Elements contain noisy child text (icons, timestamps, decorative strings) you want to exclude
-- You need a different representation per element type
+| Priority | Source | Example |
+|---|---|---|
+| 1 | `aria-label` | `"Close dialog"` |
+| 2 | `aria-labelledby` references | `"Q3 Revenue chart"` |
+| 3 | `title` attribute | `"Bar chart — hover for details"` |
+| 4 | `alt` attribute (images) | `"Revenue trend line"` |
+| 5 | `placeholder` (inputs) | `"Search metrics…"` |
+| 6 | `textContent.trim()` | `"Revenue: $2.3M"` |
+
+This is useful for icon buttons, data cells with screen-reader-only labels, or any element whose visible text is less informative than its accessible name.
+
+### Custom extractor
+
+For full control, write your own extractor. The function receives the DOM element and returns a string. It applies to all focus events and explicit `select()` calls:
+
+```ts
+const ctx = createAskableContext({
+  textExtractor: (el) => {
+    // prefer data attribute, fall back to aria-label, then textContent
+    return (
+      el.getAttribute('data-label') ??
+      el.getAttribute('aria-label') ??
+      el.textContent?.trim() ??
+      ''
+    );
+  },
+});
+```
 
 ## Sanitization and redaction
 

--- a/site/docs/guide/select.md
+++ b/site/docs/guide/select.md
@@ -1,0 +1,153 @@
+# Explicit `select()` and Ask AI Buttons
+
+Passive observation (hover/click/focus) is great for automatically tracking what the user is looking at. But many real products also need a **user-triggered, explicit** hand-off — an "Ask AI" button that sends context for the element the user consciously chose.
+
+`ctx.select(element)` does exactly this: it programmatically sets focus to any `HTMLElement`, fires the `'focus'` event, and updates history — without requiring the user to click the annotated element.
+
+## When to use `select()` vs passive observation
+
+| Pattern | When to use |
+|---|---|
+| Passive observation | Always-on context — user browsing a dashboard, hover-to-ask interactions |
+| `select()` | "Ask AI" button next to a widget; right-click → explain; keyboard shortcut for current selection |
+
+Use both together: passive observation sets context as the user browses, and `select()` lets them explicitly pin a specific element before asking a question.
+
+## Basic usage
+
+```ts
+import { createAskableContext } from '@askable-ui/core';
+
+const ctx = createAskableContext();
+ctx.observe(document);
+
+const el = document.getElementById('revenue-chart')!;
+
+document.getElementById('ask-btn')!.addEventListener('click', () => {
+  ctx.select(el);
+  openChatPanel(); // your chat UI
+});
+```
+
+`select()` accepts any `HTMLElement`. It does not need to be inside the observed subtree, and it does not need `data-askable` to be set (though it must have the attribute for meaningful context).
+
+## React
+
+```tsx
+import { useRef } from 'react';
+import { Askable, useAskable } from '@askable-ui/react';
+
+function RevenueCard({ data }) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const { ctx } = useAskable();
+
+  return (
+    <Askable meta={data} ref={cardRef}>
+      <RevenueChart data={data} />
+      <button
+        onClick={() => {
+          ctx.select(cardRef.current!);
+          openChatPanel();
+        }}
+      >
+        Ask AI ✦
+      </button>
+    </Askable>
+  );
+}
+```
+
+The `<Askable>` component forwards `ref` to the underlying DOM element so you can pass it directly to `select()`.
+
+## Vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { Askable, useAskable } from '@askable-ui/vue';
+
+const props = defineProps(['data']);
+const card = ref(null);
+const { ctx } = useAskable();
+
+function askAboutCard() {
+  ctx.select(card.value.$el);
+  openChatPanel();
+}
+</script>
+
+<template>
+  <Askable :meta="data" ref="card">
+    <RevenueChart :data="data" />
+    <button @click="askAboutCard">Ask AI ✦</button>
+  </Askable>
+</template>
+```
+
+## Svelte
+
+```svelte
+<script>
+  import { Askable, createAskableStore } from '@askable-ui/svelte';
+
+  export let data;
+
+  let card;
+  const { ctx } = createAskableStore();
+
+  function askAboutCard() {
+    ctx.select(card);
+    openChatPanel();
+  }
+</script>
+
+<Askable meta={data} bind:element={card}>
+  <RevenueChart {data} />
+  <button on:click={askAboutCard}>Ask AI ✦</button>
+</Askable>
+```
+
+## Combining with passive observation
+
+`select()` and passive observation work together — each `select()` call is added to history alongside hover/click events:
+
+```ts
+ctx.on('focus', (focus) => {
+  // fires on hover, click, focus events AND on ctx.select()
+  updateChatContext(ctx.toPromptContext());
+});
+```
+
+This means if the user hovers a chart, then clicks "Ask AI" on a table row, both are in history — the LLM can see the full interaction trail.
+
+## Clearing after the conversation
+
+After the user's question is answered, clear focus to indicate no element is actively selected:
+
+```ts
+chatPanel.on('close', () => ctx.clear());
+```
+
+The `'clear'` event fires, letting any reactive components reset their UI state.
+
+## History-aware Ask AI
+
+For multi-turn conversations, include recent focus history so the LLM can see what the user was exploring before clicking Ask AI:
+
+```ts
+document.getElementById('ask-btn').addEventListener('click', () => {
+  ctx.select(currentCard);
+
+  const systemPrompt = [
+    'You are a dashboard assistant.',
+    '',
+    'Current selection:',
+    ctx.toPromptContext(),
+    '',
+    'Recent interactions:',
+    ctx.toHistoryContext(5),
+  ].join('\n');
+
+  sendToLLM(systemPrompt, userQuestion);
+});
+```


### PR DESCRIPTION
## Summary

- **`a11yTextExtractor` (#17)** — new exported helper for `@askable-ui/core`. Pass it as `textExtractor` to `createAskableContext()` to prefer accessible names over raw `textContent`. Follows W3C Accessible Name Computation order: `aria-label` → `aria-labelledby` → `title` → `alt` → `placeholder` → `textContent`.

- **`select()` / Ask AI button guide (#18)** — new `guide/select.md` with React, Vue, Svelte examples; when to use `select()` vs passive observation; history-aware patterns; sidebar entry added.

Closes #17, #18.

## Changes

- `packages/core/src/a11y.ts` — `a11yTextExtractor` implementation
- `packages/core/src/__tests__/a11y.test.ts` — 13 tests
- `packages/core/src/index.ts` — export `a11yTextExtractor`
- `site/docs/guide/select.md` — new Ask AI button guide
- `site/docs/guide/annotating.md` — rewrites text extraction section
- `site/docs/api/core.md` — documents `a11yTextExtractor` with priority table
- `site/docs/.vitepress/config.ts` — sidebar entries

## Test plan

- [ ] `npm test -w packages/core` — all 93 tests pass
- [ ] `a11yTextExtractor` prefers `aria-label` over textContent
- [ ] `aria-labelledby` concatenates multiple referenced elements
- [ ] Falls back through title → alt → placeholder → textContent
- [ ] Empty attribute values fall through to next source

https://claude.ai/code/session_015RnLQkywZbT1bujJgBuhJu