### PR TITLE
chore: bump packages to v0.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.2.0"
+    "@askable-ui/core": "^0.3.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Svelte 4 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "svelte": "^4.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.2.0"
+    "@askable-ui/core": "^0.3.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.2.0"
+    "@askable-ui/core": "^0.3.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",


### PR DESCRIPTION
Bump all JS packages from `0.2.0` → `0.3.0` and update peer dependency ranges.

| Package | Before | After |
|---|---|---|
| `@askable-ui/core` | 0.2.0 | 0.3.0 |
| `@askable-ui/react` | 0.2.0 | 0.3.0 |
| `@askable-ui/vue` | 0.2.0 | 0.3.0 |
| `@askable-ui/svelte` | 0.2.0 | 0.3.0 |

Merge after #81 lands. Triggers npm publish via `publish.yml`.