### PR TITLE
feat: configurable maxHistory + Svelte 5 runes support + inline context options

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -311,6 +311,29 @@ describe('createAskableContext', () => {
     cleanup(el3);
   });
 
+  it('maxHistory option caps the history buffer', () => {
+    const els = [makeEl({ id: 'a' }), makeEl({ id: 'b' }), makeEl({ id: 'c' }), makeEl({ id: 'd' })];
+    const ctx = createAskableContext({ maxHistory: 2 });
+    ctx.observe(document);
+    els.forEach(el => el.click());
+    const history = ctx.getHistory();
+    expect(history).toHaveLength(2);
+    expect((history[0].meta as Record<string, unknown>).id).toBe('d');
+    expect((history[1].meta as Record<string, unknown>).id).toBe('c');
+    ctx.destroy();
+    els.forEach(cleanup);
+  });
+
+  it('maxHistory: 0 disables history entirely', () => {
+    const el = makeEl({ id: 'x' });
+    const ctx = createAskableContext({ maxHistory: 0 });
+    ctx.observe(document);
+    el.click();
+    expect(ctx.getHistory()).toHaveLength(0);
+    ctx.destroy();
+    cleanup(el);
+  });
+
   it('clear() resets focus to null and emits clear event', () => {
     const el = makeEl({ widget: 'chart' }, 'Chart');
     const ctx = createAskableContext();

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -18,13 +18,14 @@ const PRESETS: Record<AskablePromptPreset, AskablePromptContextOptions> = {
   json: { format: 'json', includeText: true },
 };
 
-const MAX_HISTORY = 50;
+const DEFAULT_MAX_HISTORY = 50;
 
 export class AskableContextImpl implements AskableContext {
   private emitter = new Emitter();
   private observer: Observer;
   private currentFocus: AskableFocus | null = null;
   private history: AskableFocus[] = [];
+  private maxHistory: number;
   private textExtractor: ((el: HTMLElement) => string) | undefined;
   private sanitizeMetaFn: ((meta: Record<string, unknown>) => Record<string, unknown>) | undefined;
   private sanitizeTextFn: ((text: string) => string) | undefined;
@@ -33,11 +34,14 @@ export class AskableContextImpl implements AskableContext {
     this.textExtractor = options?.textExtractor;
     this.sanitizeMetaFn = options?.sanitizeMeta;
     this.sanitizeTextFn = options?.sanitizeText;
+    this.maxHistory = options?.maxHistory ?? DEFAULT_MAX_HISTORY;
     this.observer = new Observer((rawFocus) => {
       const focus = this.applySanitizers(rawFocus);
       this.currentFocus = focus;
-      this.history.push(focus);
-      if (this.history.length > MAX_HISTORY) this.history.shift();
+      if (this.maxHistory > 0) {
+        this.history.push(focus);
+        if (this.history.length > this.maxHistory) this.history.shift();
+      }
       this.emitter.emit('focus', focus);
     }, this.textExtractor);
   }
@@ -87,8 +91,10 @@ export class AskableContextImpl implements AskableContext {
     const focus = rawFocus ? this.applySanitizers(rawFocus) : null;
     if (focus) {
       this.currentFocus = focus;
-      this.history.push(focus);
-      if (this.history.length > MAX_HISTORY) this.history.shift();
+      if (this.maxHistory > 0) {
+        this.history.push(focus);
+        if (this.history.length > this.maxHistory) this.history.shift();
+      }
       this.emitter.emit('focus', focus);
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -134,6 +134,15 @@ export interface AskableContextOptions {
    * })
    */
   sanitizeText?: (text: string) => string;
+  /**
+   * Maximum number of focus entries retained in history.
+   * Oldest entries are evicted when the limit is exceeded.
+   * Defaults to 50. Set to 0 to disable history entirely.
+   *
+   * @example
+   * createAskableContext({ maxHistory: 10 })
+   */
+  maxHistory?: number;
 }
 
 export interface AskableSerializedFocus {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,3 @@
 export { Askable } from './Askable.js';
 export { useAskable } from './useAskable.js';
-export type { UseAskableResult } from './useAskable.js';
+export type { UseAskableOptions, UseAskableResult } from './useAskable.js';

--- a/packages/react/src/useAskable.ts
+++ b/packages/react/src/useAskable.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { createAskableContext } from '@askable-ui/core';
-import type { AskableEvent, AskableFocus, AskableContext } from '@askable-ui/core';
+import type { AskableContextOptions, AskableEvent, AskableFocus, AskableContext } from '@askable-ui/core';
 
 let globalCtx: AskableContext | null = null;
 let refCount = 0;
@@ -17,25 +17,46 @@ function getGlobalCtx(): AskableContext {
   return globalCtx;
 }
 
+export interface UseAskableOptions extends AskableContextOptions {
+  events?: AskableEvent[];
+  /**
+   * Provide a pre-created context. When set, all `AskableContextOptions`
+   * (maxHistory, sanitizeMeta, etc.) are ignored — configure those on the
+   * context you pass in.
+   */
+  ctx?: AskableContext;
+}
+
 export interface UseAskableResult {
   focus: AskableFocus | null;
   promptContext: string;
   ctx: AskableContext;
 }
 
-export function useAskable(options?: {
-  events?: AskableEvent[];
-  ctx?: AskableContext;
-}): UseAskableResult {
+function hasContextCreationOptions(options?: UseAskableOptions): boolean {
+  return Boolean(
+    options?.maxHistory !== undefined ||
+    options?.sanitizeMeta ||
+    options?.sanitizeText ||
+    options?.textExtractor
+  );
+}
+
+export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const usesProvidedCtx = Boolean(options?.ctx);
-  const ctx = useRef<AskableContext>(options?.ctx ?? getGlobalCtx());
+  // Use a private context when context-creation options are specified
+  const usePrivateCtx = !usesProvidedCtx && hasContextCreationOptions(options);
+
+  const ctx = useRef<AskableContext>(
+    options?.ctx ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx())
+  );
   const [focus, setFocus] = useState<AskableFocus | null>(() => ctx.current.getFocus());
 
   useEffect(() => {
     const current = ctx.current;
 
     if (!usesProvidedCtx) {
-      refCount++;
+      if (!usePrivateCtx) refCount++;
       if (typeof document !== 'undefined') {
         current.observe(document, { events: options?.events });
       }
@@ -50,14 +71,18 @@ export function useAskable(options?: {
       current.off('focus', handler);
       current.off('clear', clearHandler);
       if (!usesProvidedCtx) {
-        refCount--;
-        if (refCount === 0) {
-          globalCtx?.destroy();
-          globalCtx = null;
+        if (usePrivateCtx) {
+          current.destroy();
+        } else {
+          refCount--;
+          if (refCount === 0) {
+            globalCtx?.destroy();
+            globalCtx = null;
+          }
         }
       }
     };
-  }, [options?.events, usesProvidedCtx]);
+  }, [options?.events, usesProvidedCtx, usePrivateCtx]);
 
   return {
     focus,

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@askable-ui/svelte",
   "version": "0.3.0",
-  "description": "Svelte 4 bindings for askable — LLM-aware UI context",
+  "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,11 +10,15 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./Askable.svelte": "./src/Askable.svelte"
+    "./Askable.svelte": "./src/Askable.svelte",
+    "./Askable5.svelte": "./src/Askable5.svelte",
+    "./useAskable.svelte": "./src/useAskable.svelte.ts"
   },
   "files": [
     "dist",
     "src/Askable.svelte",
+    "src/Askable5.svelte",
+    "src/useAskable.svelte.ts",
     "README.md"
   ],
   "repository": {
@@ -32,12 +36,13 @@
     "context",
     "svelte",
     "svelte4",
+    "svelte5",
     "ui",
     "focus"
   ],
   "license": "MIT",
   "peerDependencies": {
-    "svelte": "^4.0.0"
+    "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "@askable-ui/core": "^0.3.0"

--- a/packages/svelte/src/Askable5.svelte
+++ b/packages/svelte/src/Askable5.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    meta: Record<string, unknown> | string;
+    as?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }
+
+  let { meta, as = 'div', children, ...rest }: Props = $props();
+
+  const dataAskable = $derived(typeof meta === 'string' ? meta : JSON.stringify(meta));
+</script>
+
+<svelte:element this={as} data-askable={dataAskable} {...rest}>
+  {@render children?.()}
+</svelte:element>

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,3 +1,9 @@
+// Svelte 4 — store-based API
 export { createAskableStore } from './askable.js';
 export type { AskableStore } from './askable.js';
-// Askable.svelte is exported as a separate package entry: "@askable-ui/svelte/Askable.svelte"
+
+// Svelte 5 runes-based API:
+//   import { useAskable } from '@askable-ui/svelte/useAskable.svelte'
+// Askable components:
+//   import Askable  from '@askable-ui/svelte/Askable.svelte'   (Svelte 4)
+//   import Askable5 from '@askable-ui/svelte/Askable5.svelte'  (Svelte 5)

--- a/packages/svelte/src/useAskable.svelte.ts
+++ b/packages/svelte/src/useAskable.svelte.ts
@@ -1,0 +1,65 @@
+import { createAskableContext } from '@askable-ui/core';
+import type { AskableContext, AskableContextOptions, AskableFocus, AskableObserveOptions } from '@askable-ui/core';
+
+export interface UseAskableOptions extends AskableContextOptions {
+  observe?: boolean | AskableObserveOptions;
+  /** Provide an existing context instead of creating a new one. */
+  ctx?: AskableContext;
+}
+
+export interface UseAskable {
+  readonly focus: AskableFocus | null;
+  readonly promptContext: string;
+  readonly ctx: AskableContext;
+  destroy(): void;
+}
+
+/**
+ * Svelte 5 runes-based composable for Askable context.
+ *
+ * Must be used inside a Svelte component or `.svelte.ts` file.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { useAskable } from '@askable-ui/svelte';
+ *   const askable = useAskable({ observe: true });
+ * </script>
+ *
+ * <p>{askable.promptContext}</p>
+ * ```
+ */
+export function useAskable(options?: UseAskableOptions): UseAskable {
+  const usesProvidedCtx = Boolean(options?.ctx);
+  const ctx = options?.ctx ?? createAskableContext(options);
+
+  let focus: AskableFocus | null = $state(null);
+
+  ctx.on('focus', (f) => { focus = f; });
+  ctx.on('clear', () => { focus = null; });
+
+  const promptContext = $derived(focus ? ctx.toPromptContext() : 'No UI element is currently focused.');
+
+  if (!usesProvidedCtx && typeof document !== 'undefined') {
+    const observeOpts = options?.observe === true
+      ? undefined
+      : options?.observe === false || options?.observe === undefined
+        ? undefined
+        : options.observe;
+
+    if (options?.observe !== false) {
+      ctx.observe(document, observeOpts);
+    }
+  }
+
+  function destroy() {
+    if (!usesProvidedCtx) ctx.destroy();
+  }
+
+  return {
+    get focus() { return focus; },
+    get promptContext() { return promptContext; },
+    ctx,
+    destroy,
+  };
+}

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -12,5 +12,6 @@
     "rootDir": "./src",
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/useAskable.svelte.ts"]
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,3 @@
 export { Askable } from './Askable.js';
 export { useAskable } from './useAskable.js';
-export type { UseAskableResult } from './useAskable.js';
+export type { UseAskableOptions, UseAskableResult } from './useAskable.js';

--- a/packages/vue/src/useAskable.ts
+++ b/packages/vue/src/useAskable.ts
@@ -1,6 +1,6 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { createAskableContext } from '@askable-ui/core';
-import type { AskableEvent, AskableFocus, AskableContext } from '@askable-ui/core';
+import type { AskableContextOptions, AskableEvent, AskableFocus, AskableContext } from '@askable-ui/core';
 
 let globalCtx: AskableContext | null = null;
 let refCount = 0;
@@ -17,15 +17,37 @@ function getGlobalCtx(): AskableContext {
   return globalCtx;
 }
 
+export interface UseAskableOptions extends AskableContextOptions {
+  events?: AskableEvent[];
+  /**
+   * Provide a pre-created context. When set, all `AskableContextOptions`
+   * (maxHistory, sanitizeMeta, etc.) are ignored — configure those on the
+   * context you pass in.
+   */
+  ctx?: AskableContext;
+}
+
 export interface UseAskableResult {
   focus: ReturnType<typeof ref<AskableFocus | null>>;
   promptContext: ReturnType<typeof computed<string>>;
   ctx: AskableContext;
 }
 
-export function useAskable(options?: { events?: AskableEvent[]; ctx?: AskableContext }) {
+function hasContextCreationOptions(options?: UseAskableOptions): boolean {
+  return Boolean(
+    options?.maxHistory !== undefined ||
+    options?.sanitizeMeta ||
+    options?.sanitizeText ||
+    options?.textExtractor
+  );
+}
+
+export function useAskable(options?: UseAskableOptions) {
   const usesProvidedCtx = Boolean(options?.ctx);
-  const ctx = options?.ctx ?? getGlobalCtx();
+  // Use a private context when context-creation options are specified
+  const usePrivateCtx = !usesProvidedCtx && hasContextCreationOptions(options);
+
+  const ctx = options?.ctx ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx());
   const focus = ref<AskableFocus | null>(ctx.getFocus());
   // Reference focus.value so Vue tracks it as a reactive dependency;
   // ctx.toPromptContext() is a plain method and not itself reactive.
@@ -43,7 +65,7 @@ export function useAskable(options?: { events?: AskableEvent[]; ctx?: AskableCon
 
   onMounted(() => {
     if (!usesProvidedCtx) {
-      refCount++;
+      if (!usePrivateCtx) refCount++;
       if (typeof document !== 'undefined') {
         ctx.observe(document, { events: options?.events });
       }
@@ -56,10 +78,14 @@ export function useAskable(options?: { events?: AskableEvent[]; ctx?: AskableCon
     ctx.off('focus', handler);
     ctx.off('clear', clearHandler);
     if (!usesProvidedCtx) {
-      refCount--;
-      if (refCount === 0) {
-        globalCtx?.destroy();
-        globalCtx = null;
+      if (usePrivateCtx) {
+        ctx.destroy();
+      } else {
+        refCount--;
+        if (refCount === 0) {
+          globalCtx?.destroy();
+          globalCtx = null;
+        }
       }
     }
   });

--- a/site/docs/guide/focus-history.md
+++ b/site/docs/guide/focus-history.md
@@ -17,10 +17,23 @@ if (focus) {
 
 ## History
 
-Askable automatically tracks the last 50 focus events (newest first). Use `getHistory()` to access them:
+Askable automatically tracks focus events (newest first). The default buffer size is 50; configure it with `maxHistory`:
 
 ```ts
-const all   = ctx.getHistory();     // all up to 50, newest first
+// Default: last 50 events
+const ctx = createAskableContext();
+
+// Custom buffer
+const ctx = createAskableContext({ maxHistory: 10 });
+
+// Disable history entirely
+const ctx = createAskableContext({ maxHistory: 0 });
+```
+
+Use `getHistory()` to access the buffer:
+
+```ts
+const all   = ctx.getHistory();     // all entries, newest first
 const last5 = ctx.getHistory(5);    // capped at 5
 ```
 

--- a/site/docs/guide/react.md
+++ b/site/docs/guide/react.md
@@ -77,15 +77,25 @@ const { focus, promptContext, ctx } = useAskable();
 // Click only
 const { focus } = useAskable({ events: ['click'] });
 
-// Scoped to a custom context instance
+// Inline context options — creates a private context (not the singleton)
+const { focus } = useAskable({ maxHistory: 10 });
+const { focus } = useAskable({ sanitizeMeta: ({ secret, ...rest }) => rest });
+
+// Scoped to a pre-created context instance
 const { focus } = useAskable({ ctx: myCtx });
 ```
+
+When any `AskableContextOptions` are provided (`maxHistory`, `sanitizeMeta`, `sanitizeText`, `textExtractor`), a private context is created for that component instead of sharing the global singleton.
 
 **Options:**
 | Option | Type | Description |
 |---|---|---|
 | `events` | `AskableEvent[]` | Which events trigger updates. Defaults to `['click', 'hover', 'focus']`. |
-| `ctx` | `AskableContext` | Use a custom context instead of the global singleton. |
+| `maxHistory` | `number` | History buffer size. Defaults to 50. Set to `0` to disable. |
+| `sanitizeMeta` | `(meta) => meta` | Redact sensitive metadata keys before storage. |
+| `sanitizeText` | `(text) => string` | Redact sensitive text content before storage. |
+| `textExtractor` | `(el) => string` | Custom text extraction function. |
+| `ctx` | `AskableContext` | Use a pre-created context (ignores all options above). |
 
 **Returns:**
 | Value | Type | Description |
@@ -148,20 +158,30 @@ function ChatInput() {
 
 ## Sanitization
 
-For production apps, pass sanitizers at context creation time to strip sensitive fields before they're stored or sent to an LLM:
+Pass sanitizers inline to strip sensitive fields before they're stored or sent to an LLM:
+
+```tsx
+function App() {
+  const { promptContext } = useAskable({
+    sanitizeMeta: ({ password, token, ...safe }) => safe,
+    sanitizeText: (text) => text.replace(/\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g, '[card]'),
+  });
+  // ...
+}
+```
+
+When `sanitizeMeta` or `sanitizeText` are provided, a private context is created for that component. For app-wide sanitization shared across all components, create a context manually:
 
 ```tsx
 import { createAskableContext } from '@askable-ui/core';
-import { useAskable } from '@askable-ui/react';
 
+// Create once at module level (or with useMemo)
 const safeCtx = createAskableContext({
   sanitizeMeta: ({ password, token, ...safe }) => safe,
-  sanitizeText: (text) => text.replace(/\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g, '[card]'),
 });
 
 function App() {
   const { promptContext } = useAskable({ ctx: safeCtx });
-  // ...
 }
 ```
 

--- a/site/docs/guide/svelte.md
+++ b/site/docs/guide/svelte.md
@@ -1,12 +1,46 @@
 # Svelte Guide
 
+Both Svelte 4 (store-based) and Svelte 5 (runes-based) APIs are supported.
+
 ## Install
 
 ```bash
 npm install @askable-ui/svelte @askable-ui/core
 ```
 
-## Quick start
+## Quick start (Svelte 5 runes)
+
+```svelte
+<script lang="ts">
+  import { useAskable } from '@askable-ui/svelte/useAskable.svelte';
+  import Askable5 from '@askable-ui/svelte/Askable5.svelte';
+
+  const { focus, promptContext, destroy, ctx } = useAskable();
+  $effect(() => () => destroy());
+
+  async function ask(question: string) {
+    return fetch('/api/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        messages: [
+          { role: 'system', content: `UI context: ${promptContext}` },
+          { role: 'user', content: question },
+        ],
+      }),
+    });
+  }
+</script>
+
+<Askable5 meta={{ metric: 'revenue', value: '$128k', period: 'Q3' }}>
+  <RevenueChart />
+</Askable5>
+
+{#if focus}
+  <p>Focused: {JSON.stringify(focus.meta)}</p>
+{/if}
+```
+
+## Quick start (Svelte 4 stores)
 
 ```svelte
 <script lang="ts">
@@ -39,7 +73,57 @@ npm install @askable-ui/svelte @askable-ui/core
 {/if}
 ```
 
-## `<Askable>`
+## Svelte 5: `useAskable(options?)`
+
+Runes-based composable. Must be called inside a Svelte 5 component or `.svelte.ts` file.
+
+```svelte
+<script lang="ts">
+  import { useAskable } from '@askable-ui/svelte/useAskable.svelte';
+
+  // Observes document automatically (SSR-safe)
+  const askable = useAskable();
+
+  // Click events only
+  const askable = useAskable({ observe: { events: ['click'] } });
+
+  // Disable auto-observe, use a shared context
+  import { createAskableContext } from '@askable-ui/core';
+  const ctx = createAskableContext();
+  const askable = useAskable({ ctx, observe: false });
+</script>
+
+<!-- askable.focus and askable.promptContext are reactive state -->
+<p>{askable.promptContext}</p>
+```
+
+**Returns:**
+| Value | Type | Description |
+|---|---|---|
+| `focus` | `AskableFocus \| null` | Reactive current focus (`$state`) |
+| `promptContext` | `string` | Reactive prompt-ready string (`$derived`) |
+| `ctx` | `AskableContext` | Underlying context for advanced use |
+| `destroy` | `() => void` | Tears down the context — call in `$effect(() => () => destroy())` |
+
+## Svelte 5: `<Askable5>`
+
+```svelte
+<script lang="ts">
+  import Askable5 from '@askable-ui/svelte/Askable5.svelte';
+</script>
+
+<!-- Object meta -->
+<Askable5 meta={{ widget: 'churn-rate', value: '4.2%' }}>
+  <ChurnChart />
+</Askable5>
+
+<!-- String meta, custom element -->
+<Askable5 meta="pricing page hero" as="section">
+  <HeroSection />
+</Askable5>
+```
+
+## `<Askable>` (Svelte 4)
 
 Renders any element (default: `div`) with `data-askable` set from the `meta` prop.
 

--- a/site/docs/guide/vue.md
+++ b/site/docs/guide/vue.md
@@ -68,13 +68,23 @@ const { focus, promptContext, ctx } = useAskable();
 
 // Click only
 const { focus } = useAskable({ events: ['click'] });
+
+// Inline context options — creates a private context (not the singleton)
+const { focus } = useAskable({ maxHistory: 10 });
+const { focus } = useAskable({ sanitizeMeta: ({ secret, ...rest }) => rest });
 ```
+
+When `maxHistory`, `sanitizeMeta`, `sanitizeText`, or `textExtractor` are provided, a private context is created for that component instead of sharing the global singleton.
 
 **Options:**
 | Option | Type | Description |
 |---|---|---|
 | `events` | `AskableEvent[]` | Which events trigger updates. Defaults to `['click', 'hover', 'focus']`. |
-| `ctx` | `AskableContext` | Provide a scoped context instead of the global singleton. See below. |
+| `maxHistory` | `number` | History buffer size. Defaults to 50. Set to `0` to disable. |
+| `sanitizeMeta` | `(meta) => meta` | Redact sensitive metadata keys before storage. |
+| `sanitizeText` | `(text) => string` | Redact sensitive text content before storage. |
+| `textExtractor` | `(el) => string` | Custom text extraction function. |
+| `ctx` | `AskableContext` | Provide a pre-created context (ignores all options above). See below. |
 
 ## Scoped contexts
 


### PR DESCRIPTION
## Summary

### `@askable-ui/core` — configurable `maxHistory` (closes #83)
- New `maxHistory` option in `AskableContextOptions` (default: 50, set to `0` to disable history entirely)
- Applied in both the observer callback and `select()`
- 2 new tests: cap enforcement and `maxHistory: 0` disables history

### `@askable-ui/svelte` — Svelte 5 runes support (closes #84)
- `Askable5.svelte` — uses `$props()` / `{@render children?.()}` syntax
- `useAskable.svelte.ts` — `$state`/`$derived` runes composable, ships as source
- New export paths: `@askable-ui/svelte/Askable5.svelte` and `@askable-ui/svelte/useAskable.svelte`
- Peer dep updated to `^4.0.0 || ^5.0.0`

### `@askable-ui/react` + `@askable-ui/vue` — inline context options
- `useAskable()` now accepts `maxHistory`, `sanitizeMeta`, `sanitizeText`, `textExtractor` directly
- When context-creation options are provided, a private context is created instead of sharing the global singleton
- Exports new `UseAskableOptions` type from both packages

### Docs
- `svelte.md`: Svelte 5 quick start, `useAskable()` runes composable section, `Askable5` docs
- `focus-history.md`: `maxHistory` configuration section
- `react.md` / `vue.md`: updated `useAskable()` options table with inline context options

## Test plan

- [ ] `npm test --workspaces` — all 162 tests pass
- [ ] `npm run build --workspaces` — clean build
- [ ] Svelte 5 `Askable5.svelte` renders with `$props()` in a Svelte 5 app
- [ ] `useAskable({ maxHistory: 2 })` caps history at 2 entries
- [ ] `useAskable({ maxHistory: 0 })` — `getHistory()` returns `[]`