### PR TITLE
chore: bump packages to v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/npm/v/@askable-ui/core?color=4f46e5&label=npm" alt="npm version" />
   </a>
   <a href="https://bundlephobia.com/package/@askable-ui/core">
-    <img src="https://img.shields.io/bundlephobia/minzip/@askable-ui/core?color=4f46e5&label=~1kb" alt="bundle size" />
+    <img src="https://img.shields.io/badge/minzip-~1kb-4f46e5" alt="bundle size ~1kb" />
   </a>
   <a href="./LICENSE">
     <img src="https://img.shields.io/npm/l/@askable-ui/core?color=4f46e5" alt="license: MIT" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "1.0.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "1.0.0",
+      "version": "0.3.1",
       "workspaces": [
         "packages/*"
       ],
@@ -4920,7 +4920,7 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -4930,7 +4930,7 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@askable-ui/core": "^0.3.0"
@@ -5136,7 +5136,7 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@askable-ui/core": "^0.3.0"
@@ -5151,7 +5151,7 @@
         "vitest": "^2.0.0"
       },
       "peerDependencies": {
-        "svelte": "^4.0.0"
+        "svelte": "^4.0.0 || ^5.0.0"
       }
     },
     "packages/svelte/node_modules/data-urls": {
@@ -5317,7 +5317,7 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@askable-ui/core": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "1.0.0",
+  "version": "0.3.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.3.0"
+    "@askable-ui/core": "^0.3.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.3.0"
+    "@askable-ui/core": "^0.3.1"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.3.0"
+    "@askable-ui/core": "^0.3.1"
   },
   "devDependencies": {
     "@askable-ui/core": "*",


### PR DESCRIPTION
Bumps all JS packages to `0.3.1`.

## Included since v0.3.0

- `maxHistory` option in `AskableContextOptions` — configurable history buffer (default 50, set to `0` to disable)
- Svelte 5 runes support — `Askable5.svelte` + `useAskable.svelte.ts` composable
- React/Vue `useAskable()` now accepts inline context options (`maxHistory`, `sanitizeMeta`, `sanitizeText`, `textExtractor`)
- README overhaul

## Checklist

- [ ] CI passes
- [ ] Merge triggers `v0.3.1` tag push → release workflow publishes to npm + creates GitHub Release