### PR TITLE
fix: add git+ prefix to repository.url in all package.json files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/core"
   },
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/react"
   },
   "scripts": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -23,7 +23,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/svelte"
   },
   "scripts": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/vue"
   },
   "scripts": {


### PR DESCRIPTION
Fixes the `npm warn publish "repository.url" was normalized` warning during `npm publish` by adding the `git+` prefix to all four package `repository.url` fields.

Minor cosmetic fix — no functional change.