### PR TITLE
fix: restore publish.yml as npm OIDC trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,55 +1,78 @@
-name: Tag on version change
+name: Publish to npm
 
-# Detects a version bump in packages/core/package.json and pushes a git tag.
-# The tag triggers release.yml which handles building, testing, publishing to
-# npm, and creating the GitHub Release.
+# Triggered by version tags pushed by the tag workflow or manually.
+# npm Trusted Publisher is configured for this workflow file.
+#
+#   v1.2.3         → stable release (dist-tag "latest")
+#   v1.2.3-beta.1  → pre-release   (dist-tag "beta")
 
 on:
   push:
-    branches: [main]
-    paths:
-      - 'packages/*/package.json'
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to tag (e.g. 0.2.0) — leave blank to read from packages/core/package.json'
-        required: false
+      tag:
+        description: 'Tag to release (e.g. v0.3.1)'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write   # npm OIDC Trusted Publisher
 
 jobs:
-  tag:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - name: Resolve version
-        id: version
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build core
+        run: npm run build -w packages/core
+
+      - name: Build all packages
+        run: npm run build --workspaces --if-present
+
+      - name: Run tests
+        run: npm test -- --runInBand
+
+      - name: Resolve dist-tag
+        id: tag
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          if [[ "$TAG" == *"-beta."* || "$TAG" == *"-alpha."* || "$TAG" == *"-rc."* ]]; then
+            echo "dist_tag=beta" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            CHANGED=$(git diff HEAD~1 HEAD --name-only -- 'packages/*/package.json' | head -1)
-            if [ -z "$CHANGED" ]; then
-              echo "changed=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            VERSION=$(node -p "require('./packages/core/package.json').version")
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Push git tag
-        if: steps.version.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          TAG="v${{ steps.version.outputs.version }}"
-          git tag "$TAG" || echo "Tag already exists, skipping"
-          git push origin "$TAG" || echo "Tag already pushed, skipping"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish @askable-ui/core
+        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
+        working-directory: packages/core
+
+      - name: Publish @askable-ui/react
+        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
+        working-directory: packages/react
+
+      - name: Publish @askable-ui/vue
+        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
+        working-directory: packages/vue
+
+      - name: Publish @askable-ui/svelte
+        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
+        working-directory: packages/svelte

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
-name: Release
+name: GitHub Release
 
-# Triggered by version tags:
-#   v0.2.0          → stable release (published with dist-tag "latest")
-#   v0.2.0-beta.1   → pre-release  (published with dist-tag "beta")
+# Creates a GitHub Release after a version tag is pushed.
+# npm publishing is handled by publish.yml (npm Trusted Publisher).
 
 on:
   push:
@@ -11,75 +10,34 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g. v0.3.0)'
+        description: 'Tag to release (e.g. v0.3.1)'
         required: true
 
 permissions:
-  contents: write   # create GitHub Release
-  id-token: write   # npm trusted publishing (OIDC provenance)
+  contents: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build core
-        run: npm run build -w packages/core
-
-      - name: Build all packages
-        run: npm run build --workspaces --if-present
-
-      - name: Run tests
-        run: npm test -- --runInBand
-
-      # Determine dist-tag: "beta" for pre-releases, "latest" for stable
-      - name: Resolve npm dist-tag
-        id: tag
+      - name: Resolve tag and pre-release flag
+        id: meta
         run: |
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           if [[ "$TAG" == *"-beta."* || "$TAG" == *"-alpha."* || "$TAG" == *"-rc."* ]]; then
-            echo "dist_tag=beta" >> "$GITHUB_OUTPUT"
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Publish @askable-ui/core
-        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
-        working-directory: packages/core
-
-      - name: Publish @askable-ui/react
-        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
-        working-directory: packages/react
-
-      - name: Publish @askable-ui/vue
-        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
-        working-directory: packages/vue
-
-      - name: Publish @askable-ui/svelte
-        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
-        working-directory: packages/svelte
 
       - name: Create GitHub Release
         uses: actions/github-script@v7
         with:
           script: |
-            const tag = context.payload.inputs?.tag || context.ref.replace('refs/tags/', '');
-            const isPrerelease = ${{ steps.tag.outputs.prerelease }};
+            const tag = '${{ steps.meta.outputs.tag }}';
+            const isPrerelease = ${{ steps.meta.outputs.prerelease }};
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,55 @@
+name: Tag on version change
+
+# Detects a version bump in packages/core/package.json on main and pushes
+# a git tag. The tag triggers publish.yml (npm) and release.yml (GitHub Release).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/*/package.json'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag (e.g. 0.3.1) — leave blank to read from packages/core/package.json'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            CHANGED=$(git diff HEAD~1 HEAD --name-only -- 'packages/*/package.json' | head -1)
+            if [ -z "$CHANGED" ]; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            VERSION=$(node -p "require('./packages/core/package.json').version")
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push git tag
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          TAG="v${{ steps.version.outputs.version }}"
+          git tag "$TAG" || echo "Tag already exists, skipping"
+          git push origin "$TAG" || echo "Tag already pushed, skipping"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the `404 Not Found` npm publish errors caused by an OIDC Trusted Publisher mismatch.

## What happened

npm's Trusted Publisher was configured for `.github/workflows/publish.yml`, but `publish.yml` was repurposed as a "tag on version change" helper and the actual `npm publish` was moved to `release.yml`. The OIDC token from `release.yml` is not trusted by npm → 404.

## Fix

Split into 3 focused workflows:

| Workflow | Trigger | Does |
|---|---|---|
| `tag.yml` | Push to main with `packages/*/package.json` changes | Creates and pushes the git tag |
| `publish.yml` | Tag push `v*` | Builds, tests, publishes to npm (OIDC Trusted Publisher) |
| `release.yml` | Tag push `v*` | Creates GitHub Release with auto-generated notes |

`publish.yml` is restored as the npm publisher so the existing Trusted Publisher config on npm continues to work without any changes on npm's side.

## After merging

Re-trigger `publish.yml` via `workflow_dispatch` with tag `v0.3.1` to publish to npm.