### PR TITLE
fix(react): use React.JSX namespace for TypeScript 5.x compat

### DIFF
--- a/packages/react/src/Askable.tsx
+++ b/packages/react/src/Askable.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-type AnyTag = keyof JSX.IntrinsicElements;
+type AnyTag = keyof React.JSX.IntrinsicElements;
 
 type AskableProps<T extends AnyTag = 'div'> = {
   meta: Record<string, unknown> | string;
   as?: T;
   children?: React.ReactNode;
-} & Omit<JSX.IntrinsicElements[T], 'children'>;
+} & Omit<React.JSX.IntrinsicElements[T], 'children'>;
 
 export function Askable<T extends AnyTag = 'div'>({
   meta,
@@ -14,7 +14,7 @@ export function Askable<T extends AnyTag = 'div'>({
   children,
   ...props
 }: AskableProps<T>) {
-  const Tag = (as ?? 'div') as AnyTag;
+  const Tag = (as ?? 'div') as string;
   const dataAskable = typeof meta === 'string' ? meta : JSON.stringify(meta);
   return React.createElement(Tag, { 'data-askable': dataAskable, ...props }, children);
 }


### PR DESCRIPTION
## Summary

- Use `React.JSX.IntrinsicElements` instead of global `JSX.IntrinsicElements` (removed in TS 5.x)
- Cast polymorphic tag to `string` for `createElement` compatibility

Fixes the build failure in `@askable-ui/react`.

## Test Plan

- [x] `npm run build -w packages/react` passes locally