### PR TITLE
chore: bump packages to v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.3.1"
+    "@askable-ui/core": "^0.4.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.3.1"
+    "@askable-ui/core": "^0.4.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.3.1"
+    "@askable-ui/core": "^0.4.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",


### PR DESCRIPTION
## Summary

- Bump all packages from v0.3.1 to v0.4.0
- Update cross-package `@askable-ui/core` dependency references

This will trigger the automated release pipeline on merge:
`tag.yml` → `publish_release.yml` (npm OIDC) → `release.yml` (GitHub Release)