### PR TITLE
fix: trigger publish via workflow_dispatch from tag.yml

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,6 +1,7 @@
 name: publish / release
 
-# Triggered by version tags. Uses npm OIDC Trusted Publisher — no secret needed.
+# Triggered by tag/auto workflow_dispatch or manual tag pushes.
+# Uses npm OIDC Trusted Publisher — no secret needed.
 #
 # Setup: npmjs.com → package → Settings → Publishing → Add Trusted Publisher
 #   Repository:  askable-ui/askable
@@ -34,10 +35,16 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: Resolve tag
+        id: resolve-tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ steps.resolve-tag.outputs.tag }}
 
       # setup-node with registry-url configures .npmrc for OIDC automatically.
       # Do NOT manually write to .npmrc — it will clobber the auth config.
@@ -63,13 +70,13 @@ jobs:
       - name: Resolve dist-tag
         id: dist-tag
         env:
-          INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          RELEASE_TAG: ${{ steps.resolve-tag.outputs.tag }}
         run: |
-          if [[ "$INPUT_TAG" == *"-beta."* ]]; then
+          if [[ "$RELEASE_TAG" == *"-beta."* ]]; then
             echo "tag=beta" >> "$GITHUB_OUTPUT"
-          elif [[ "$INPUT_TAG" == *"-alpha."* ]]; then
+          elif [[ "$RELEASE_TAG" == *"-alpha."* ]]; then
             echo "tag=alpha" >> "$GITHUB_OUTPUT"
-          elif [[ "$INPUT_TAG" == *"-rc."* ]]; then
+          elif [[ "$RELEASE_TAG" == *"-rc."* ]]; then
             echo "tag=rc" >> "$GITHUB_OUTPUT"
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,7 +1,10 @@
 name: tag / auto
 
 # Detects a version bump in packages/core/package.json on main and pushes
-# a git tag. The tag triggers publish_release.yml (npm) and release.yml (GitHub Release).
+# a git tag, then triggers publish_release.yml via workflow_dispatch.
+#
+# NOTE: Tags pushed by GITHUB_TOKEN do NOT trigger other workflows (GitHub
+# security measure). We must explicitly dispatch publish_release.yml.
 
 on:
   push:
@@ -16,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  actions: write # needed to dispatch publish_release.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,3 +66,13 @@ jobs:
           TAG="v${TAG_VERSION}"
           git tag "$TAG" 2>&1 || echo "::warning::Tag $TAG already exists locally"
           git push origin "$TAG" 2>&1 || echo "::warning::Failed to push tag $TAG (may already exist)"
+
+      - name: Trigger publish workflow
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh workflow run publish_release.yml \
+            --field tag="v${TAG_VERSION}" \
+            --ref main


### PR DESCRIPTION
## Summary

Tags pushed by `GITHUB_TOKEN` in GitHub Actions do **not** trigger other workflows (GitHub security measure to prevent infinite loops). This broke the release chain: `tag.yml` pushed `v0.4.0` but `publish_release.yml` never fired.

**Fix:** `tag.yml` now explicitly dispatches `publish_release.yml` via `gh workflow run` after pushing the tag.

### Release chain (fixed)

```
version bump merged to main
  → tag.yml detects change, pushes v* tag
  → tag.yml dispatches publish_release.yml (workflow_dispatch)
    → publish_release.yml builds, tests, publishes to npm (OIDC)
      → release.yml creates GitHub Release (workflow_run on success)
```

## Test Plan

- [x] Identified root cause: GITHUB_TOKEN tag push doesn't trigger workflows
- [x] Merge this, then re-trigger tag.yml manually to test the v0.4.0 release