### PR TITLE
fix: dispatch publish workflow on tag ref

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -75,4 +75,4 @@ jobs:
         run: |
           gh workflow run publish_release.yml \
             --field tag="v${TAG_VERSION}" \
-            --ref main
+            --ref "v${TAG_VERSION}"


### PR DESCRIPTION
npm OIDC token includes the workflow run ref. Dispatching on `main` gives `refs/heads/main` which doesn't match the Trusted Publisher. Dispatch on the tag ref instead so the OIDC token has `refs/tags/v*`.