### PR TITLE
fix: upgrade npm for OIDC scoped package bug

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,14 +1,14 @@
 name: publish / release
 
-# Triggered by version tags. Uses npm OIDC Trusted Publisher — no secret needed.
+# Triggered by tag/auto via workflow_dispatch, or manual tag pushes.
+# Uses npm OIDC Trusted Publisher — no NPM_TOKEN needed.
 #
 # Setup: npmjs.com → package → Settings → Publishing → Add Trusted Publisher
 #   Repository:  askable-ui/askable
-#   Workflow:    .github/workflows/publish_release.yml
+#   Workflow:    publish_release.yml
 #   Environment: (leave blank)
 #
-#   v1.2.3         → stable release  (dist-tag "latest")
-#   v1.2.3-beta.1  → pre-release     (dist-tag "beta")
+# Modeled after: Vite (vitejs/vite), Effect-TS, shadcn/ui
 
 on:
   push:
@@ -34,19 +34,28 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: Resolve tag
+        id: resolve-tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ steps.resolve-tag.outputs.tag }}
 
-      # setup-node with registry-url configures .npmrc for OIDC automatically.
-      # Do NOT manually write to .npmrc — it will clobber the auth config.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
           cache: npm
+
+      # Node 20 ships npm v10.x which has a known OIDC bug for scoped
+      # packages (npm/cli#9088). Upgrade to npm >= 11.5.1 to fix.
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -63,13 +72,13 @@ jobs:
       - name: Resolve dist-tag
         id: dist-tag
         env:
-          INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          RELEASE_TAG: ${{ steps.resolve-tag.outputs.tag }}
         run: |
-          if [[ "$INPUT_TAG" == *"-beta."* ]]; then
+          if [[ "$RELEASE_TAG" == *"-beta."* ]]; then
             echo "tag=beta" >> "$GITHUB_OUTPUT"
-          elif [[ "$INPUT_TAG" == *"-alpha."* ]]; then
+          elif [[ "$RELEASE_TAG" == *"-alpha."* ]]; then
             echo "tag=alpha" >> "$GITHUB_OUTPUT"
-          elif [[ "$INPUT_TAG" == *"-rc."* ]]; then
+          elif [[ "$RELEASE_TAG" == *"-rc."* ]]; then
             echo "tag=rc" >> "$GITHUB_OUTPUT"
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,7 +1,10 @@
 name: tag / auto
 
-# Detects a version bump in packages/core/package.json on main and pushes
-# a git tag. The tag triggers publish_release.yml (npm) and release.yml (GitHub Release).
+# Detects a version bump in packages/core/package.json on main, pushes a
+# git tag, then dispatches publish_release.yml.
+#
+# NOTE: Tags pushed by GITHUB_TOKEN do NOT trigger other workflows (GitHub
+# security measure). We explicitly dispatch publish_release.yml instead.
 
 on:
   push:
@@ -16,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  actions: write # needed to dispatch publish_release.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,8 +66,6 @@ jobs:
           TAG="v${TAG_VERSION}"
           git tag "$TAG" 2>&1 || echo "::warning::Tag $TAG already exists locally"
           git push origin "$TAG" 2>&1 || echo "::warning::Failed to push tag $TAG (may already exist)"
-<<<<<<< HEAD
-=======
 
       - name: Trigger publish workflow
         if: steps.version.outputs.changed == 'true'
@@ -72,5 +74,5 @@ jobs:
           TAG_VERSION: ${{ steps.version.outputs.version }}
         run: |
           gh workflow run publish_release.yml \
-            --field tag="v${TAG_VERSION}" \
+            -f tag="v${TAG_VERSION}" \
             --ref "v${TAG_VERSION}"


### PR DESCRIPTION
## Root cause

Node 20 ships npm v10.x which has a **known bug** ([npm/cli#9088](https://github.com/npm/cli/issues/9088)) where OIDC token exchange silently fails for scoped packages (`@askable-ui/*`), returning a misleading `E404` instead of an auth error.

## Fix

- Add `npm install -g npm@latest` step before publishing (like Effect-TS, shadcn/ui do)
- Bump to Node 22 (closer to Node 24 which ships with the fix)
- Clean up conflict markers in tag.yml

## Reference repos using this pattern

| Repo | Approach |
|---|---|
| [Effect-TS](https://github.com/Effect-TS/effect) | `npm install -g npm@latest` |
| [shadcn/ui](https://github.com/shadcn-ui/ui) | `npm install -g npm@latest` |
| [Vite](https://github.com/vitejs/vite) | Node 24 (ships with fixed npm) |
| [Biome](https://github.com/biomejs/biome) | Node 24 |