### PR TITLE
fix: use Node 24 for publish (ships fixed npm for OIDC)

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -45,17 +45,15 @@ jobs:
         with:
           ref: ${{ steps.resolve-tag.outputs.tag }}
 
+      # Node 24 ships npm 11.5.1+ which fixes the OIDC bug for scoped
+      # packages (npm/cli#9088). Do NOT use Node 20/22 — they have npm v10
+      # which silently fails OIDC token exchange for @scoped packages.
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: npm
-
-      # Node 20 ships npm v10.x which has a known OIDC bug for scoped
-      # packages (npm/cli#9088). Upgrade to npm >= 11.5.1 to fix.
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Node 24 ships npm 11.5.1+ which fixes the scoped package OIDC bug. Same approach as Vite and Biome.