### PR TITLE
fix(svelte): add browser resolve condition for Svelte 5 tests

### DIFF
--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
+  resolve: {
+    conditions: ['browser'],
+  },
   plugins: [svelte({ hot: false, preprocess: vitePreprocess() })],
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
Fixes `lifecycle_function_unavailable: mount(...) is not available on the server` in Svelte tests.