### PR TITLE
chore: update docs version badge to v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "workspaces": [
         "packages/*"
       ],
@@ -3405,7 +3405,7 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -3753,10 +3753,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.4.0"
+        "@askable-ui/core": "^0.4.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4212,10 +4212,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.4.0"
+        "@askable-ui/core": "^0.4.1"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -4610,10 +4610,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.4.0"
+        "@askable-ui/core": "^0.4.1"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       { text: 'API Reference', link: '/api/core', activeMatch: '/api/' },
       { text: 'Examples', link: '/examples/dashboard', activeMatch: '/examples/' },
       {
-        text: 'v0.4.0',
+        text: 'v0.4.1',
         items: [
           { text: 'Changelog', link: 'https://github.com/askable-ui/askable/releases' },
           { text: 'npm', link: 'https://www.npmjs.com/package/@askable-ui/core' },


### PR DESCRIPTION
## Summary
- Update VitePress nav version badge from v0.4.0 to v0.4.1 to match the latest release

## Test plan
- [ ] Verify docs site shows v0.4.1 in the navigation bar