### PR TITLE
fix: remove AskableContextImpl from public exports; add source field and toContext()

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -47,6 +47,7 @@ describe('createAskableContext', () => {
     expect(focus!.text).toBe('Revenue Chart');
     expect(typeof focus!.timestamp).toBe('number');
     expect(focus!.element).toBe(el);
+    expect(focus!.source).toBe('dom');
 
     ctx.destroy();
     cleanup(el);
@@ -764,6 +765,7 @@ describe('createAskableContext', () => {
       expect(focus!.meta).toEqual({ widget: 'deals-table', rowIndex: 3, company: 'Acme' });
       expect(focus!.text).toBe('Acme — Closed — $50k');
       expect(focus!.element).toBeUndefined();
+      expect(focus!.source).toBe('push');
       expect(typeof focus!.timestamp).toBe('number');
 
       ctx.destroy();
@@ -841,6 +843,109 @@ describe('createAskableContext', () => {
       expect(prompt).toContain('Acme');
 
       ctx.destroy();
+    });
+  });
+
+  describe('source field', () => {
+    it('DOM click sets source to "dom"', () => {
+      const el = makeEl({ widget: 'chart' });
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+      expect(ctx.getFocus()!.source).toBe('dom');
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('select() sets source to "select"', () => {
+      const el = makeEl({ widget: 'chart' });
+      const ctx = createAskableContext();
+      ctx.select(el);
+      expect(ctx.getFocus()!.source).toBe('select');
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('push() sets source to "push"', () => {
+      const ctx = createAskableContext();
+      ctx.push({ widget: 'grid' });
+      expect(ctx.getFocus()!.source).toBe('push');
+      ctx.destroy();
+    });
+  });
+
+  describe('toContext()', () => {
+    it('with no history option behaves like toPromptContext()', () => {
+      const el = makeEl({ metric: 'revenue' }, 'Revenue');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      expect(ctx.toContext()).toBe(ctx.toPromptContext());
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('includes current focus and history sections when history > 0', () => {
+      const el1 = makeEl({ id: 'a' }, 'A');
+      const el2 = makeEl({ id: 'b' }, 'B');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el1.click();
+      el2.click();
+
+      const out = ctx.toContext({ history: 5 });
+      expect(out).toContain('Current:');
+      expect(out).toContain('Recent interactions:');
+      expect(out).toContain('id: b');
+      expect(out).toContain('id: a');
+
+      ctx.destroy();
+      cleanup(el1);
+      cleanup(el2);
+    });
+
+    it('respects custom labels', () => {
+      const el = makeEl({ metric: 'mrr' }, 'MRR');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const out = ctx.toContext({ history: 1, currentLabel: 'Now', historyLabel: 'Before' });
+      expect(out).toContain('Now:');
+      expect(out).toContain('Before:');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('omits history section when history entries are empty', () => {
+      const el = makeEl({ metric: 'mrr' }, 'MRR');
+      const ctx = createAskableContext({ maxHistory: 0 });
+      ctx.observe(document);
+      el.click();
+
+      const out = ctx.toContext({ history: 5 });
+      expect(out).toContain('Current:');
+      expect(out).not.toContain('Recent interactions:');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('respects serialization options', () => {
+      const el = makeEl({ metric: 'mrr', secret: 'x' }, 'MRR');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const out = ctx.toContext({ excludeKeys: ['secret'], includeText: false });
+      expect(out).not.toContain('secret');
+      expect(out).not.toContain('MRR');
+
+      ctx.destroy();
+      cleanup(el);
     });
   });
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -3,6 +3,7 @@ import { buildFocus, Observer } from './observer.js';
 import type {
   AskableContext,
   AskableContextOptions,
+  AskableContextOutputOptions,
   AskableEventHandler,
   AskableEventName,
   AskableFocus,
@@ -87,7 +88,7 @@ export class AskableContextImpl implements AskableContext {
   }
 
   select(element: HTMLElement): void {
-    const rawFocus = buildFocus(element, this.textExtractor);
+    const rawFocus = buildFocus(element, this.textExtractor, 'select');
     const focus = rawFocus ? this.applySanitizers(rawFocus) : null;
     if (focus) {
       this.currentFocus = focus;
@@ -100,7 +101,7 @@ export class AskableContextImpl implements AskableContext {
   }
 
   push(meta: Record<string, unknown> | string, text = ''): void {
-    const rawFocus: AskableFocus = { meta, text, timestamp: Date.now() };
+    const rawFocus: AskableFocus = { meta, text, source: 'push', timestamp: Date.now() };
     const focus = this.applySanitizers(rawFocus);
     this.currentFocus = focus;
     if (this.maxHistory > 0) {
@@ -132,6 +133,25 @@ export class AskableContextImpl implements AskableContext {
     if (history.length === 0) return 'No interaction history.';
     const lines = history.map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
     const output = lines.join('\n');
+    return this.applyTokenBudget(output, resolved.maxTokens);
+  }
+
+  toContext(options?: AskableContextOutputOptions): string {
+    const { history: historyLimit = 0, currentLabel = 'Current', historyLabel = 'Recent interactions', ...promptOpts } = options ?? {};
+    const resolved = this.resolveOptions(promptOpts);
+    const currentStr = this.buildPromptString(this.currentFocus, resolved);
+
+    if (historyLimit === 0) {
+      return this.applyTokenBudget(currentStr, resolved.maxTokens);
+    }
+
+    const history = this.getHistory(historyLimit);
+    const parts: string[] = [`${currentLabel}: ${currentStr}`];
+    if (history.length > 0) {
+      const lines = history.map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
+      parts.push(`\n${historyLabel}:\n${lines.join('\n')}`);
+    }
+    const output = parts.join('\n');
     return this.applyTokenBudget(output, resolved.maxTokens);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,3 @@
-export { AskableContextImpl } from './context.js';
 export { createAskableInspector } from './inspector.js';
 export { a11yTextExtractor } from './a11y.js';
 export type {
@@ -9,11 +8,13 @@ export type {
 export type {
   AskableContext,
   AskableContextOptions,
+  AskableContextOutputOptions,
   AskableEvent,
   AskableEventHandler,
   AskableEventMap,
   AskableEventName,
   AskableFocus,
+  AskableFocusSource,
   AskableObserveOptions,
   AskablePromptContextOptions,
   AskablePromptFormat,

--- a/packages/core/src/inspector.ts
+++ b/packages/core/src/inspector.ts
@@ -72,8 +72,15 @@ function buildPanelHTML(focus: AskableFocus | null, promptContext: string): stri
       <code style="color:#8b949e">(programmatic — no DOM element)</code>
     </div>`;
 
+  const sourceColors: Record<string, string> = { dom: '#7ee787', select: '#f0883e', push: '#58a6ff' };
+  const sourceColor = sourceColors[focus.source] ?? '#8b949e';
+
   return `
     ${elementSection}
+    <div style="margin-bottom:8px">
+      <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Source</span><br>
+      <code style="color:${sourceColor}">${escapeHtml(focus.source)}</code>
+    </div>
     <div style="margin-bottom:8px">
       <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Meta</span><br>
       <pre style="color:#e6edf3;margin:4px 0;white-space:pre-wrap;word-break:break-all">${renderMeta(focus.meta)}</pre>

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -1,4 +1,4 @@
-import type { AskableFocus, AskableEvent, AskableTargetStrategy } from './types.js';
+import type { AskableFocus, AskableEvent, AskableFocusSource, AskableTargetStrategy } from './types.js';
 
 type FocusCallback = (focus: AskableFocus) => void;
 
@@ -28,7 +28,11 @@ function extractText(el: HTMLElement): string {
   return (el.textContent ?? '').trim();
 }
 
-export function buildFocus(el: HTMLElement, textExtractor?: (el: HTMLElement) => string): AskableFocus | null {
+export function buildFocus(
+  el: HTMLElement,
+  textExtractor?: (el: HTMLElement) => string,
+  source: AskableFocusSource = 'dom'
+): AskableFocus | null {
   const raw = el.getAttribute('data-askable');
   if (raw === null) return null;
   // data-askable-text overrides both textExtractor and default textContent extraction.
@@ -41,6 +45,7 @@ export function buildFocus(el: HTMLElement, textExtractor?: (el: HTMLElement) =>
     meta: parseMeta(raw),
     text,
     element: el,
+    source,
     timestamp: Date.now(),
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Indicates how a focus entry was created.
+ * - `'dom'`    — user interacted with a `[data-askable]` element (click, hover, or keyboard focus)
+ * - `'select'` — set programmatically via `ctx.select(element)`
+ * - `'push'`   — set programmatically via `ctx.push(meta, text)` (no DOM element involved)
+ */
+export type AskableFocusSource = 'dom' | 'select' | 'push';
+
 export interface AskableFocus {
   /** Parsed data-askable attribute (JSON object or raw string) */
   meta: Record<string, unknown> | string;
@@ -8,6 +16,8 @@ export interface AskableFocus {
    * Undefined when focus was set programmatically via `ctx.push()`.
    */
   element?: HTMLElement;
+  /** How this focus entry was created. */
+  source: AskableFocusSource;
   /** Unix timestamp (ms) of when focus was set */
   timestamp: number;
 }
@@ -154,6 +164,27 @@ export interface AskableSerializedFocus {
   timestamp: number;
 }
 
+/**
+ * Options for `toContext()` — combines current focus and recent history into one string.
+ */
+export interface AskableContextOutputOptions extends AskablePromptContextOptions {
+  /**
+   * Number of history entries to include after the current focus.
+   * Defaults to 0 (current focus only — same as `toPromptContext()`).
+   */
+  history?: number;
+  /**
+   * Section label for the current focus.
+   * @default 'Current'
+   */
+  currentLabel?: string;
+  /**
+   * Section label for the history block.
+   * @default 'Recent interactions'
+   */
+  historyLabel?: string;
+}
+
 export interface AskableContext {
   /** Observe a DOM subtree for [data-askable] elements */
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void;
@@ -193,6 +224,19 @@ export interface AskableContext {
   toPromptContext(options?: AskablePromptContextOptions): string;
   /** Serialize focus history to a prompt-ready string (newest first). Optional limit caps the entries returned. */
   toHistoryContext(limit?: number, options?: AskablePromptContextOptions): string;
+  /**
+   * Serialize current focus and optional history into a single prompt-ready string.
+   * When `history` is 0 or omitted the output is identical to `toPromptContext()`.
+   *
+   * @example
+   * ctx.toContext({ history: 5, maxTokens: 300 })
+   * // Current: User is focused on: widget: deals-table, rowIndex: 3 — value "Acme Corp"
+   * //
+   * // Recent interactions:
+   * // [1] User is focused on: metric: revenue — value "$2.3M"
+   * // [2] User is focused on: widget: churn-chart — value "4.2%"
+   */
+  toContext(options?: AskableContextOutputOptions): string;
   /** Clean up all listeners and observers */
   destroy(): void;
 }


### PR DESCRIPTION
## Summary

Stacks on #147.

- **Closes #138** — removes `AskableContextImpl` from the public barrel export; consumers should only use `createAskableContext()`, not the class directly
- **Closes #143** — `AskableFocus.source: AskableFocusSource` traces how each entry was created (`'dom'` | `'select'` | `'push'`); inspector panel displays source with colour coding
- **Closes #144** — `ctx.toContext(options?)` combines current focus and optional history into one prompt-ready string, replacing the common pattern of calling `toPromptContext()` + `toHistoryContext()` separately; accepts `history`, `currentLabel`, and `historyLabel` options alongside all existing `AskablePromptContextOptions`

## Test plan

- [ ] `import { AskableContextImpl }` is a type error after this PR
- [ ] `getFocus().source` is `'dom'` for click/hover/focus events, `'select'` for `ctx.select()`, `'push'` for `ctx.push()`
- [ ] `ctx.toContext()` returns just the current focus string when `history` is omitted
- [ ] `ctx.toContext({ history: 3 })` returns current + up to 3 history entries
- [ ] `maxTokens` budget applies to the combined toContext() output