### PR TITLE
fix(react): make inspector option reactive in useAskable

### DIFF
--- a/packages/react/src/useAskable.ts
+++ b/packages/react/src/useAskable.ts
@@ -5,6 +5,9 @@ import type { AskableContextOptions, AskableEvent, AskableFocus, AskableContext,
 let globalCtx: AskableContext | null = null;
 let refCount = 0;
 
+// Registry for named/scoped contexts — keyed by name, reference-counted.
+const namedRegistry = new Map<string, { ctx: AskableContext; refCount: number }>();
+
 function getGlobalCtx(): AskableContext {
   // During SSR (no window), never persist to the module-level singleton —
   // each render gets a fresh throwaway context so requests don't share state.
@@ -17,6 +20,28 @@ function getGlobalCtx(): AskableContext {
   return globalCtx;
 }
 
+function getNamedCtx(name: string, options?: AskableContextOptions): AskableContext {
+  if (typeof window === 'undefined') return createAskableContext(options);
+  const entry = namedRegistry.get(name);
+  if (entry) {
+    entry.refCount++;
+    return entry.ctx;
+  }
+  const ctx = createAskableContext(options);
+  namedRegistry.set(name, { ctx, refCount: 1 });
+  return ctx;
+}
+
+function releaseNamedCtx(name: string): void {
+  const entry = namedRegistry.get(name);
+  if (!entry) return;
+  entry.refCount--;
+  if (entry.refCount === 0) {
+    entry.ctx.destroy();
+    namedRegistry.delete(name);
+  }
+}
+
 export interface UseAskableOptions extends AskableContextOptions {
   events?: AskableEvent[];
   /**
@@ -27,6 +52,16 @@ export interface UseAskableOptions extends AskableContextOptions {
   ctx?: AskableContext;
   /** Mount the floating inspector dev panel. Pass true for defaults or an options object. */
   inspector?: boolean | AskableInspectorOptions;
+  /**
+   * Scope this hook to a named context. Multiple components using the same `name`
+   * share one context instance (reference-counted, destroyed when the last
+   * component unmounts). Useful for pages with multiple independent AI regions.
+   *
+   * @example
+   * const { ctx } = useAskable({ name: 'table' });
+   * const { ctx } = useAskable({ name: 'chart' });
+   */
+  name?: string;
 }
 
 export interface UseAskableResult {
@@ -46,19 +81,30 @@ function hasContextCreationOptions(options?: UseAskableOptions): boolean {
 
 export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const usesProvidedCtx = Boolean(options?.ctx);
-  // Use a private context when context-creation options are specified
-  const usePrivateCtx = !usesProvidedCtx && hasContextCreationOptions(options);
+  const usesNamedCtx = !usesProvidedCtx && Boolean(options?.name);
+  // Use a private context when context-creation options are specified (and no name/ctx provided)
+  const usePrivateCtx = !usesProvidedCtx && !usesNamedCtx && hasContextCreationOptions(options);
 
   const ctx = useRef<AskableContext>(
-    options?.ctx ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx())
+    options?.ctx
+      ?? (usesNamedCtx ? getNamedCtx(options!.name!, options) : undefined)
+      ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx())
   );
   const [focus, setFocus] = useState<AskableFocus | null>(() => ctx.current.getFocus());
+
+  // Stable serialized key for inspector so the effect re-runs when it changes,
+  // without false positives when a new object literal with the same shape is passed.
+  const inspectorKey = options?.inspector === true
+    ? 'true'
+    : options?.inspector
+      ? JSON.stringify(options.inspector)
+      : 'false';
 
   useEffect(() => {
     const current = ctx.current;
 
     if (!usesProvidedCtx) {
-      if (!usePrivateCtx) refCount++;
+      if (!usePrivateCtx && !usesNamedCtx) refCount++;
       if (typeof document !== 'undefined') {
         current.observe(document, { events: options?.events });
       }
@@ -80,7 +126,9 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
       current.off('focus', handler);
       current.off('clear', clearHandler);
       if (!usesProvidedCtx) {
-        if (usePrivateCtx) {
+        if (usesNamedCtx) {
+          releaseNamedCtx(options!.name!);
+        } else if (usePrivateCtx) {
           current.destroy();
         } else {
           refCount--;
@@ -91,7 +139,9 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
         }
       }
     };
-  }, [options?.events, usesProvidedCtx, usePrivateCtx]);
+  // inspectorKey captures changes to the inspector option value
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options?.events, usesProvidedCtx, usesNamedCtx, usePrivateCtx, inspectorKey]);
 
   return {
     focus,


### PR DESCRIPTION
## Summary

Stacks on #148.

**Closes #139** — the `inspector` option in `useAskable()` was absent from the effect dependency array, so changes after mount were silently ignored (the old inspector stayed mounted, the new options never applied).

Changes:
- Computes a stable `inspectorKey` string from the inspector option (`'false'`, `'true'`, or `JSON.stringify(options.inspector)`) so object references don't cause spurious re-runs
- Adds `inspectorKey` to the `useEffect` deps array so the inspector is re-mounted when the option changes

## Test plan

- [ ] Changing `inspector` from `false` → `true` after mount mounts the panel
- [ ] Changing `inspector` position (`bottom-right` → `top-left`) after mount re-creates the panel at the new position
- [ ] Stable object reference does not cause unnecessary effect re-runs