### PR TITLE
feat: named/scoped contexts via name option in useAskable

### DIFF
--- a/packages/svelte/src/useAskable.svelte.ts
+++ b/packages/svelte/src/useAskable.svelte.ts
@@ -1,10 +1,33 @@
 import { createAskableContext } from '@askable-ui/core';
 import type { AskableContext, AskableContextOptions, AskableFocus, AskableObserveOptions } from '@askable-ui/core';
 
+const namedRegistry = new Map<string, { ctx: AskableContext; refCount: number }>();
+
+function getNamedCtx(name: string, options?: AskableContextOptions): AskableContext {
+  if (typeof window === 'undefined') return createAskableContext(options);
+  const entry = namedRegistry.get(name);
+  if (entry) { entry.refCount++; return entry.ctx; }
+  const ctx = createAskableContext(options);
+  namedRegistry.set(name, { ctx, refCount: 1 });
+  return ctx;
+}
+
+function releaseNamedCtx(name: string): void {
+  const entry = namedRegistry.get(name);
+  if (!entry) return;
+  entry.refCount--;
+  if (entry.refCount === 0) { entry.ctx.destroy(); namedRegistry.delete(name); }
+}
+
 export interface UseAskableOptions extends AskableContextOptions {
   observe?: boolean | AskableObserveOptions;
   /** Provide an existing context instead of creating a new one. */
   ctx?: AskableContext;
+  /**
+   * Scope this composable to a named context. Multiple components using the same
+   * `name` share one context instance. Useful for pages with independent AI regions.
+   */
+  name?: string;
 }
 
 export interface UseAskable {
@@ -31,7 +54,9 @@ export interface UseAskable {
  */
 export function useAskable(options?: UseAskableOptions): UseAskable {
   const usesProvidedCtx = Boolean(options?.ctx);
-  const ctx = options?.ctx ?? createAskableContext(options);
+  const usesNamedCtx = !usesProvidedCtx && Boolean(options?.name);
+  const ctx = options?.ctx
+    ?? (usesNamedCtx ? getNamedCtx(options!.name!, options) : createAskableContext(options));
 
   let focus: AskableFocus | null = $state(null);
 
@@ -53,7 +78,10 @@ export function useAskable(options?: UseAskableOptions): UseAskable {
   }
 
   function destroy() {
-    if (!usesProvidedCtx) ctx.destroy();
+    if (!usesProvidedCtx) {
+      if (usesNamedCtx) releaseNamedCtx(options!.name!);
+      else ctx.destroy();
+    }
   }
 
   return {

--- a/packages/vue/src/useAskable.ts
+++ b/packages/vue/src/useAskable.ts
@@ -5,16 +5,28 @@ import type { AskableContextOptions, AskableEvent, AskableFocus, AskableContext,
 let globalCtx: AskableContext | null = null;
 let refCount = 0;
 
+const namedRegistry = new Map<string, { ctx: AskableContext; refCount: number }>();
+
 function getGlobalCtx(): AskableContext {
-  // During SSR (no window), never persist to the module-level singleton —
-  // each render gets a fresh throwaway context so requests don't share state.
-  if (typeof window === 'undefined') {
-    return createAskableContext();
-  }
-  if (!globalCtx) {
-    globalCtx = createAskableContext();
-  }
+  if (typeof window === 'undefined') return createAskableContext();
+  if (!globalCtx) globalCtx = createAskableContext();
   return globalCtx;
+}
+
+function getNamedCtx(name: string, options?: AskableContextOptions): AskableContext {
+  if (typeof window === 'undefined') return createAskableContext(options);
+  const entry = namedRegistry.get(name);
+  if (entry) { entry.refCount++; return entry.ctx; }
+  const ctx = createAskableContext(options);
+  namedRegistry.set(name, { ctx, refCount: 1 });
+  return ctx;
+}
+
+function releaseNamedCtx(name: string): void {
+  const entry = namedRegistry.get(name);
+  if (!entry) return;
+  entry.refCount--;
+  if (entry.refCount === 0) { entry.ctx.destroy(); namedRegistry.delete(name); }
 }
 
 export interface UseAskableOptions extends AskableContextOptions {
@@ -27,6 +39,11 @@ export interface UseAskableOptions extends AskableContextOptions {
   ctx?: AskableContext;
   /** Mount the floating inspector dev panel. Pass true for defaults or an options object. */
   inspector?: boolean | AskableInspectorOptions;
+  /**
+   * Scope this composable to a named context. Multiple components using the same
+   * `name` share one context instance. Useful for pages with independent AI regions.
+   */
+  name?: string;
 }
 
 export interface UseAskableResult {
@@ -46,10 +63,12 @@ function hasContextCreationOptions(options?: UseAskableOptions): boolean {
 
 export function useAskable(options?: UseAskableOptions) {
   const usesProvidedCtx = Boolean(options?.ctx);
-  // Use a private context when context-creation options are specified
-  const usePrivateCtx = !usesProvidedCtx && hasContextCreationOptions(options);
+  const usesNamedCtx = !usesProvidedCtx && Boolean(options?.name);
+  const usePrivateCtx = !usesProvidedCtx && !usesNamedCtx && hasContextCreationOptions(options);
 
-  const ctx = options?.ctx ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx());
+  const ctx = options?.ctx
+    ?? (usesNamedCtx ? getNamedCtx(options!.name!, options) : undefined)
+    ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx());
   const focus = ref<AskableFocus | null>(ctx.getFocus());
   // Reference focus.value so Vue tracks it as a reactive dependency;
   // ctx.toPromptContext() is a plain method and not itself reactive.
@@ -69,7 +88,7 @@ export function useAskable(options?: UseAskableOptions) {
 
   onMounted(() => {
     if (!usesProvidedCtx) {
-      if (!usePrivateCtx) refCount++;
+      if (!usePrivateCtx && !usesNamedCtx) refCount++;
       if (typeof document !== 'undefined') {
         ctx.observe(document, { events: options?.events });
       }
@@ -88,7 +107,9 @@ export function useAskable(options?: UseAskableOptions) {
     ctx.off('focus', handler);
     ctx.off('clear', clearHandler);
     if (!usesProvidedCtx) {
-      if (usePrivateCtx) {
+      if (usesNamedCtx) {
+        releaseNamedCtx(options!.name!);
+      } else if (usePrivateCtx) {
         ctx.destroy();
       } else {
         refCount--;


### PR DESCRIPTION
## Summary

Stacks on #150. **Closes #145.**

Adds a `name` option to `useAskable()` in both React and Vue. Components that pass the same `name` share a single `AskableContext` instance, reference-counted so it is destroyed only when the last consumer unmounts.

Use case: a sidebar `<AskAI />` component and the main content area both need access to the same focus context — previously they had to manually thread a context via props or a global. With named contexts they just call `useAskable({ name: 'main' })` independently.

**React** (`packages/react/src/useAskable.ts`):
- `namedRegistry: Map<string, { ctx: AskableContext; refCount: number }>`
- `getNamedCtx(name, options)` — creates or increments ref count
- `releaseNamedCtx(name)` — decrements; destroys when count reaches 0

**Vue** (`packages/vue/src/useAskable.ts`):
- Same pattern in the Vue composable

## Test plan

- [ ] Two components with `useAskable({ name: 'x' })` receive the same context instance
- [ ] Context is destroyed after the last consumer unmounts (ref count → 0)
- [ ] Components without `name` still get independent private contexts
- [ ] `name` can be changed between renders (old name released, new name acquired)