### PR TITLE
feat: adapter packages for AG Grid and TanStack Table

### DIFF
--- a/packages/ag-grid/package.json
+++ b/packages/ag-grid/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@askable-ui/ag-grid",
+  "version": "0.1.0",
+  "description": "AG Grid adapter for askable — row-level LLM context tracking without DOM annotation",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/askable-ui/askable.git",
+    "directory": "packages/ag-grid"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run"
+  },
+  "keywords": ["llm", "context", "ag-grid", "table", "askable"],
+  "homepage": "https://askable-ui.com",
+  "license": "MIT",
+  "peerDependencies": {
+    "@askable-ui/core": ">=0.4.0"
+  },
+  "devDependencies": {
+    "@askable-ui/core": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/ag-grid/src/index.ts
+++ b/packages/ag-grid/src/index.ts
@@ -1,0 +1,126 @@
+import type { AskableContext } from '@askable-ui/core';
+
+/**
+ * Parameters passed to the `meta` and `text` callbacks for each row event.
+ */
+export interface AgGridRowParams<TData = unknown> {
+  /** The row data object */
+  data: TData;
+  /** Zero-based row index in the current rendered order */
+  rowIndex: number;
+  /** Column ID, only set for cell-level events like `onCellFocused` */
+  colId?: string;
+}
+
+export interface AgGridAdapterOptions<TData = unknown> {
+  /**
+   * Map a row to the metadata injected into the LLM context.
+   * Keep values small — only what the AI needs to understand the row.
+   *
+   * @example
+   * meta: ({ data, rowIndex }) => ({
+   *   widget: 'deals-table',
+   *   rowIndex,
+   *   id: data.id,
+   *   stage: data.stage,
+   * })
+   */
+  meta: (params: AgGridRowParams<TData>) => Record<string, unknown>;
+  /**
+   * Optional human-readable text for the row, used as the `text` field in the focus entry.
+   * Defaults to an empty string when omitted.
+   *
+   * @example
+   * text: ({ data }) => `${data.company} — ${data.stage} — ${data.value}`
+   */
+  text?: (params: AgGridRowParams<TData>) => string;
+}
+
+export interface AgGridAdapterHandle<TData = unknown> {
+  /**
+   * Wire to `gridOptions.onRowClicked` or `<AgGridReact onRowClicked={...} />`.
+   * Fires when the user clicks any cell in a row.
+   */
+  onRowClicked(params: { data: TData; rowIndex: number }): void;
+  /**
+   * Wire to `gridOptions.onCellFocused` or `<AgGridReact onCellFocused={...} />`.
+   * Fires when the user moves keyboard focus to a cell.
+   *
+   * Requires the AG Grid API to look up the row node by index.
+   */
+  onCellFocused(params: {
+    rowIndex: number | null;
+    column: { getColId(): string } | null;
+    api: { getRowNode(rowIndex: number): { data: TData } | null };
+  }): void;
+  /**
+   * Wire to `gridOptions.onRowSelected` or `<AgGridReact onRowSelected={...} />`.
+   * Only pushes context when the row becomes selected (not deselected).
+   */
+  onRowSelected(params: {
+    data: TData;
+    rowIndex: number;
+    node: { isSelected(): boolean };
+  }): void;
+}
+
+/**
+ * Create an AG Grid adapter that drives `ctx.push()` from AG Grid's own event
+ * callbacks. Use this when you cannot annotate AG Grid rows with `data-askable`
+ * because AG Grid renders its own internal DOM.
+ *
+ * @example
+ * ```tsx
+ * import { createAgGridAdapter } from '@askable-ui/ag-grid';
+ * import { useAskable } from '@askable-ui/react';
+ *
+ * function DealsTable({ rows }) {
+ *   const { ctx } = useAskable();
+ *   const adapter = createAgGridAdapter(ctx, {
+ *     meta: ({ data, rowIndex }) => ({ widget: 'deals-table', rowIndex, id: data.id }),
+ *     text: ({ data }) => `${data.company} — ${data.stage} — ${data.value}`,
+ *   });
+ *
+ *   return (
+ *     <AgGridReact
+ *       rowData={rows}
+ *       onRowClicked={adapter.onRowClicked}
+ *       onCellFocused={adapter.onCellFocused}
+ *     />
+ *   );
+ * }
+ * ```
+ */
+export function createAgGridAdapter<TData = unknown>(
+  ctx: AskableContext,
+  options: AgGridAdapterOptions<TData>
+): AgGridAdapterHandle<TData> {
+  function pushRow(params: AgGridRowParams<TData>): void {
+    ctx.push(
+      options.meta(params),
+      options.text ? options.text(params) : ''
+    );
+  }
+
+  return {
+    onRowClicked(params) {
+      pushRow({ data: params.data, rowIndex: params.rowIndex });
+    },
+
+    onCellFocused(params) {
+      if (params.rowIndex === null) return;
+      const node = params.api.getRowNode(params.rowIndex);
+      if (!node) return;
+      pushRow({
+        data: node.data,
+        rowIndex: params.rowIndex,
+        colId: params.column?.getColId(),
+      });
+    },
+
+    onRowSelected(params) {
+      if (!params.node.isSelected()) return;
+      pushRow({ data: params.data, rowIndex: params.rowIndex });
+    },
+  };
+}

--- a/packages/ag-grid/tsconfig.json
+++ b/packages/ag-grid/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/tanstack-table/package.json
+++ b/packages/tanstack-table/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@askable-ui/tanstack-table",
+  "version": "0.1.0",
+  "description": "TanStack Table adapter for askable — row-level LLM context tracking without DOM annotation",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/askable-ui/askable.git",
+    "directory": "packages/tanstack-table"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run"
+  },
+  "keywords": ["llm", "context", "tanstack-table", "react-table", "table", "askable"],
+  "homepage": "https://askable-ui.com",
+  "license": "MIT",
+  "peerDependencies": {
+    "@askable-ui/core": ">=0.4.0",
+    "@tanstack/table-core": ">=8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@tanstack/table-core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@askable-ui/core": "workspace:*",
+    "@tanstack/table-core": "^8.0.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/tanstack-table/src/index.ts
+++ b/packages/tanstack-table/src/index.ts
@@ -1,0 +1,105 @@
+import type { AskableContext } from '@askable-ui/core';
+
+/**
+ * Minimal Row interface — compatible with `@tanstack/table-core` Row<TData>
+ * without requiring the package as a hard dependency.
+ */
+export interface TanStackRow<TData = unknown> {
+  original: TData;
+  index: number;
+  id: string;
+}
+
+export interface TanStackTableAdapterOptions<TData = unknown> {
+  /**
+   * Map a TanStack Table row to the metadata injected into the LLM context.
+   *
+   * @example
+   * meta: (row) => ({ widget: 'users-table', rowIndex: row.index, id: row.original.id })
+   */
+  meta: (row: TanStackRow<TData>) => Record<string, unknown>;
+  /**
+   * Optional human-readable text for the row.
+   * Defaults to an empty string when omitted.
+   *
+   * @example
+   * text: (row) => `${row.original.name} — ${row.original.email}`
+   */
+  text?: (row: TanStackRow<TData>) => string;
+}
+
+export interface TanStackTableAdapterHandle<TData = unknown> {
+  /**
+   * Call this inside your row's `onClick` handler.
+   *
+   * @example
+   * <tr onClick={() => adapter.onRowClick(row)}>
+   */
+  onRowClick(row: TanStackRow<TData>): void;
+  /**
+   * Returns props to spread onto a `<tr>` element — convenience wrapper
+   * around `onRowClick` that returns `{ onClick }`.
+   *
+   * @example
+   * <tr {...adapter.getRowProps(row)}>
+   */
+  getRowProps(row: TanStackRow<TData>): { onClick(): void };
+}
+
+/**
+ * Create a TanStack Table adapter that drives `ctx.push()` from row interactions.
+ * Use this when rendering rows with TanStack Table (including virtual mode) where
+ * you cannot annotate `<tr>` elements with `data-askable`.
+ *
+ * @example
+ * ```tsx
+ * import { createTanStackTableAdapter } from '@askable-ui/tanstack-table';
+ * import { useAskable } from '@askable-ui/react';
+ *
+ * function UsersTable({ data }) {
+ *   const { ctx } = useAskable();
+ *   const adapter = createTanStackTableAdapter(ctx, {
+ *     meta: (row) => ({ widget: 'users-table', rowIndex: row.index, id: row.original.id }),
+ *     text: (row) => `${row.original.name} — ${row.original.email}`,
+ *   });
+ *
+ *   return (
+ *     <table>
+ *       <tbody>
+ *         {table.getRowModel().rows.map((row) => (
+ *           <tr key={row.id} {...adapter.getRowProps(row)}>
+ *             {row.getVisibleCells().map((cell) => (
+ *               <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+ *             ))}
+ *           </tr>
+ *         ))}
+ *       </tbody>
+ *     </table>
+ *   );
+ * }
+ * ```
+ */
+export function createTanStackTableAdapter<TData = unknown>(
+  ctx: AskableContext,
+  options: TanStackTableAdapterOptions<TData>
+): TanStackTableAdapterHandle<TData> {
+  function pushRow(row: TanStackRow<TData>): void {
+    ctx.push(
+      options.meta(row),
+      options.text ? options.text(row) : ''
+    );
+  }
+
+  return {
+    onRowClick(row) {
+      pushRow(row);
+    },
+    getRowProps(row) {
+      return {
+        onClick() {
+          pushRow(row);
+        },
+      };
+    },
+  };
+}

--- a/packages/tanstack-table/tsconfig.json
+++ b/packages/tanstack-table/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}


### PR DESCRIPTION
## Summary

Stacks on #151. **Closes #142.**

Introduces two thin adapter packages that solve the virtualizing-table row-tracking problem: AG Grid and TanStack Table render their own DOM, so `data-askable` attributes can't be placed on row elements. These adapters wire the libraries' own event callbacks to `ctx.push()`.

### `@askable-ui/ag-grid` (`packages/ag-grid/`)

```ts
const adapter = createAgGridAdapter(ctx, {
  meta: ({ data, rowIndex }) => ({ id: data.id, row: rowIndex }),
  text: ({ data }) => data.name,
});

// Wire into AG Grid gridOptions:
<AgGridReact onRowClicked={adapter.onRowClicked} onCellFocused={adapter.onCellFocused} />
```

Handles: `onRowClicked`, `onCellFocused`, `onRowSelected`.

### `@askable-ui/tanstack-table` (`packages/tanstack-table/`)

```ts
const adapter = createTanStackTableAdapter(ctx, {
  meta: (row) => ({ id: row.original.id }),
  text: (row) => row.original.name,
});

// In your row render:
<tr {...adapter.getRowProps(row)}>
```

Handles: `onRowClick`, `getRowProps` (returns `{ onClick }` spread onto `<tr>`).

## Test plan

- [ ] `createAgGridAdapter` — `onRowClicked` calls `ctx.push()` with correct meta/text
- [ ] `createAgGridAdapter` — `onCellFocused` looks up the row via `params.api.getRowNode()`
- [ ] `createTanStackTableAdapter` — `getRowProps` returns an onClick that calls `ctx.push()`
- [ ] Both packages ship with correct `package.json` and `tsconfig.json`