### PR TITLE
feat: Python package askable-py for Django and Streamlit

### DIFF
--- a/packages/python/askable/__init__.py
+++ b/packages/python/askable/__init__.py
@@ -1,0 +1,27 @@
+"""
+askable-py — server-side context receiver for askable-ui.
+
+The frontend SDK pushes focus events to a configurable HTTP endpoint.
+This package receives them, stores the latest state per session, and
+exposes a prompt-ready string for injection into LLM calls.
+
+Basic usage::
+
+    from askable import AskableContext
+
+    ctx = AskableContext()
+    ctx.receive({
+        "meta": {"widget": "deals-table", "rowIndex": 3, "stage": "Closed Won"},
+        "text": "Acme Corp — Closed Won — $50k",
+        "source": "push",
+        "timestamp": 1700000000000,
+    })
+
+    prompt = ctx.to_prompt_context()
+    # "User is focused on: widget: deals-table, rowIndex: 3, stage: Closed Won — value \"Acme Corp — Closed Won — $50k\""
+"""
+
+from .context import AskableContext, AskableFocus
+
+__all__ = ["AskableContext", "AskableFocus"]
+__version__ = "0.1.0"

--- a/packages/python/askable/context.py
+++ b/packages/python/askable/context.py
@@ -1,0 +1,273 @@
+"""
+Core context implementation for askable-py.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Callable, Deque, Dict, Literal, Optional, Union
+
+
+AskableFocusSource = Literal["dom", "select", "push"]
+
+
+@dataclass
+class AskableFocus:
+    """A single focus entry — mirrors the TypeScript AskableFocus interface."""
+
+    meta: Union[Dict[str, Any], str]
+    text: str
+    source: AskableFocusSource
+    timestamp: int
+    element: None = field(default=None, repr=False)  # always None server-side
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AskableFocus":
+        """Deserialize a focus payload from the frontend SDK."""
+        return cls(
+            meta=data["meta"],
+            text=data.get("text", ""),
+            source=data.get("source", "dom"),
+            timestamp=data.get("timestamp", int(time.time() * 1000)),
+        )
+
+
+class AskableContext:
+    """
+    Server-side context store for askable-ui focus events.
+
+    The frontend SDK posts focus payloads to your server; call ``receive()``
+    with each payload to keep this context up to date.
+
+    Example with Django::
+
+        # views.py
+        from django.http import JsonResponse
+        from django.views.decorators.csrf import csrf_exempt
+        from askable import AskableContext
+
+        ctx = AskableContext()  # one per session in production
+
+        @csrf_exempt
+        def askable_webhook(request):
+            ctx.receive(json.loads(request.body))
+            return JsonResponse({"ok": True})
+
+    Example with Streamlit::
+
+        import streamlit as st
+        from askable import AskableContext
+
+        if "askable_ctx" not in st.session_state:
+            st.session_state.askable_ctx = AskableContext()
+
+        ctx: AskableContext = st.session_state.askable_ctx
+    """
+
+    DEFAULT_MAX_HISTORY = 50
+
+    def __init__(
+        self,
+        *,
+        max_history: int = DEFAULT_MAX_HISTORY,
+        sanitize_meta: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+        sanitize_text: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self._current: Optional[AskableFocus] = None
+        self._history: Deque[AskableFocus] = deque(maxlen=max_history if max_history > 0 else None)
+        self._max_history = max_history
+        self._sanitize_meta = sanitize_meta
+        self._sanitize_text = sanitize_text
+
+    # ------------------------------------------------------------------
+    # Receiving focus from the frontend
+    # ------------------------------------------------------------------
+
+    def receive(self, payload: Dict[str, Any]) -> None:
+        """
+        Accept a focus payload posted by the frontend SDK and update context.
+
+        :param payload: Deserialized JSON object from the frontend SDK.
+        """
+        focus = AskableFocus.from_dict(payload)
+        focus = self._apply_sanitizers(focus)
+        self._current = focus
+        if self._max_history != 0:
+            self._history.append(focus)
+
+    def push(
+        self,
+        meta: Union[Dict[str, Any], str],
+        text: str = "",
+        source: AskableFocusSource = "push",
+    ) -> None:
+        """
+        Programmatically push focus from server-side data.
+
+        Useful for pre-populating context before the first frontend event.
+        """
+        focus = AskableFocus(
+            meta=meta,
+            text=text,
+            source=source,
+            timestamp=int(time.time() * 1000),
+        )
+        focus = self._apply_sanitizers(focus)
+        self._current = focus
+        if self._max_history != 0:
+            self._history.append(focus)
+
+    def clear(self) -> None:
+        """Reset current focus to None."""
+        self._current = None
+
+    # ------------------------------------------------------------------
+    # Reading context
+    # ------------------------------------------------------------------
+
+    def get_focus(self) -> Optional[AskableFocus]:
+        """Return the current focus entry, or None if nothing is focused."""
+        return self._current
+
+    def get_history(self, limit: Optional[int] = None) -> list[AskableFocus]:
+        """Return history newest-first. Optional limit caps the result."""
+        items = list(reversed(self._history))
+        return items[:limit] if limit is not None else items
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_prompt_context(
+        self,
+        *,
+        include_text: bool = True,
+        format: Literal["natural", "json"] = "natural",
+        prefix: str = "User is focused on:",
+        text_label: str = "value",
+        exclude_keys: Optional[list[str]] = None,
+        max_text_length: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Serialize current focus to a prompt-ready string."""
+        if not self._current:
+            return "null" if format == "json" else "No UI element is currently focused."
+        return self._build_prompt_string(
+            self._current,
+            include_text=include_text,
+            format=format,
+            prefix=prefix,
+            text_label=text_label,
+            exclude_keys=exclude_keys or [],
+            max_text_length=max_text_length,
+            max_tokens=max_tokens,
+        )
+
+    def to_history_context(
+        self,
+        limit: Optional[int] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Serialize focus history to a numbered prompt-ready string (newest first)."""
+        history = self.get_history(limit)
+        if not history:
+            return "No interaction history."
+        lines = [f"[{i + 1}] {self._build_prompt_string(f, **kwargs)}" for i, f in enumerate(history)]
+        output = "\n".join(lines)
+        max_tokens = kwargs.get("max_tokens")
+        return self._apply_token_budget(output, max_tokens) if max_tokens else output
+
+    def to_context(
+        self,
+        *,
+        history: int = 0,
+        current_label: str = "Current",
+        history_label: str = "Recent interactions",
+        **kwargs: Any,
+    ) -> str:
+        """
+        Combine current focus and recent history into one prompt-ready string.
+
+        When ``history`` is 0 the output equals ``to_prompt_context()``.
+        """
+        current_str = self.to_prompt_context(**kwargs)
+        if history == 0:
+            return current_str
+
+        hist = self.get_history(history)
+        parts = [f"{current_label}: {current_str}"]
+        if hist:
+            lines = [f"[{i + 1}] {self._build_prompt_string(f, **kwargs)}" for i, f in enumerate(hist)]
+            parts.append(f"\n{history_label}:\n" + "\n".join(lines))
+        output = "\n".join(parts)
+        max_tokens = kwargs.get("max_tokens")
+        return self._apply_token_budget(output, max_tokens) if max_tokens else output
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _apply_sanitizers(self, focus: AskableFocus) -> AskableFocus:
+        meta = focus.meta
+        text = focus.text
+        if self._sanitize_meta and isinstance(meta, dict):
+            meta = self._sanitize_meta(dict(meta))
+        if self._sanitize_text:
+            text = self._sanitize_text(text)
+        if meta is focus.meta and text is focus.text:
+            return focus
+        return AskableFocus(meta=meta, text=text, source=focus.source, timestamp=focus.timestamp)
+
+    def _build_prompt_string(
+        self,
+        focus: AskableFocus,
+        *,
+        include_text: bool = True,
+        format: Literal["natural", "json"] = "natural",
+        prefix: str = "User is focused on:",
+        text_label: str = "value",
+        exclude_keys: list[str] = [],
+        max_text_length: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+        **_: Any,
+    ) -> str:
+        meta = focus.meta
+        if isinstance(meta, dict) and exclude_keys:
+            meta = {k: v for k, v in meta.items() if k not in exclude_keys}
+
+        text = focus.text
+        if max_text_length is not None:
+            text = text[:max_text_length]
+
+        if format == "json":
+            payload: Dict[str, Any] = {"meta": meta, "timestamp": focus.timestamp}
+            if include_text and text:
+                payload["text"] = text
+            output = json.dumps(payload)
+        else:
+            if isinstance(meta, str):
+                meta_str = meta
+            else:
+                meta_str = ", ".join(f"{k}: {v}" for k, v in meta.items())
+
+            parts = [prefix]
+            if meta_str:
+                parts.append(meta_str)
+            if include_text and text:
+                parts.append(f'{text_label} "{text}"')
+            output = " — ".join(parts) if len(parts) > 1 else parts[0]
+
+        return self._apply_token_budget(output, max_tokens) if max_tokens else output
+
+    @staticmethod
+    def _apply_token_budget(text: str, max_tokens: Optional[int]) -> str:
+        if max_tokens is None:
+            return text
+        budget = max_tokens * 4
+        if len(text) <= budget:
+            return text
+        marker = "... [truncated]"
+        return text[: max(0, budget - len(marker))] + marker

--- a/packages/python/askable/django.py
+++ b/packages/python/askable/django.py
@@ -1,0 +1,108 @@
+"""
+Django integration for askable-py.
+
+Provides:
+- ``AskableMiddleware`` — stores per-request focus context on ``request.askable``
+- ``askable_webhook`` — view that receives focus payloads from the frontend SDK
+
+Usage::
+
+    # settings.py
+    MIDDLEWARE = [
+        ...
+        "askable.django.AskableMiddleware",
+    ]
+
+    ASKABLE_ENDPOINT = "/api/askable/"   # default
+
+    # urls.py
+    from askable.django import askable_webhook
+    urlpatterns = [
+        path("api/askable/", askable_webhook, name="askable-webhook"),
+        ...
+    ]
+
+    # views.py — use in any view after the middleware runs
+    def my_view(request):
+        prompt = request.askable.to_prompt_context()
+        # inject into your LLM call
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+try:
+    from django.http import HttpRequest, JsonResponse
+    from django.views.decorators.csrf import csrf_exempt
+    from django.views.decorators.http import require_POST
+except ImportError as exc:
+    raise ImportError(
+        "askable.django requires Django. Install it with: pip install askable-py[django]"
+    ) from exc
+
+from .context import AskableContext
+
+SESSION_KEY = "_askable_focus"
+
+
+class AskableMiddleware:
+    """
+    Django middleware that attaches an ``AskableContext`` to each request.
+
+    The context is populated from the session (persisted across requests)
+    and exposed as ``request.askable``.
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], Any]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> Any:
+        ctx = AskableContext()
+        # Restore last focus from session if available
+        stored = request.session.get(SESSION_KEY)
+        if stored:
+            try:
+                ctx.receive(stored)
+            except Exception:
+                pass
+        request.askable = ctx  # type: ignore[attr-defined]
+        response = self.get_response(request)
+        return response
+
+
+@csrf_exempt
+@require_POST
+def askable_webhook(request: HttpRequest) -> JsonResponse:
+    """
+    View that receives a focus payload from the frontend SDK and stores it
+    in the session so the next request can read it.
+
+    Wire the frontend SDK to POST to this endpoint::
+
+        // main.tsx
+        const ctx = createAskableContext();
+        ctx.on('focus', (focus) => {
+            fetch('/api/askable/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    meta: focus.meta,
+                    text: focus.text,
+                    source: focus.source,
+                    timestamp: focus.timestamp,
+                }),
+            });
+        });
+    """
+    try:
+        payload = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({"error": "invalid JSON"}, status=400)
+
+    request.session[SESSION_KEY] = payload
+    if hasattr(request, "askable"):
+        request.askable.receive(payload)  # type: ignore[attr-defined]
+
+    return JsonResponse({"ok": True})

--- a/packages/python/askable/streamlit.py
+++ b/packages/python/askable/streamlit.py
@@ -1,0 +1,76 @@
+"""
+Streamlit integration for askable-py.
+
+Provides:
+- ``get_context()`` — returns a per-session ``AskableContext`` stored in ``st.session_state``
+- ``receive_webhook()`` — helper for Streamlit apps that use a POST endpoint to receive events
+
+Usage::
+
+    import streamlit as st
+    from askable.streamlit import get_context
+
+    ctx = get_context()
+
+    # Use in any LLM call
+    prompt = ctx.to_prompt_context()
+    response = openai.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": f"You are a helpful analyst.\\n\\n{prompt}"},
+            {"role": "user", "content": user_input},
+        ]
+    )
+"""
+
+from __future__ import annotations
+
+try:
+    import streamlit as st
+except ImportError as exc:
+    raise ImportError(
+        "askable.streamlit requires Streamlit. Install it with: pip install askable-py[streamlit]"
+    ) from exc
+
+from .context import AskableContext
+
+SESSION_KEY = "_askable_context"
+
+
+def get_context(**kwargs: object) -> AskableContext:
+    """
+    Return the ``AskableContext`` for the current Streamlit session.
+
+    Creates a new context on the first call; returns the existing one on
+    subsequent calls (Streamlit re-runs preserve ``st.session_state``).
+
+    :param kwargs: Passed to ``AskableContext.__init__`` on first creation only
+                   (e.g. ``max_history``, ``sanitize_meta``).
+
+    Example::
+
+        ctx = get_context(max_history=10)
+        prompt = ctx.to_prompt_context()
+    """
+    if SESSION_KEY not in st.session_state:
+        st.session_state[SESSION_KEY] = AskableContext(**kwargs)  # type: ignore[arg-type]
+    return st.session_state[SESSION_KEY]  # type: ignore[return-value]
+
+
+def receive_webhook(payload: dict) -> None:
+    """
+    Push a focus payload from the frontend SDK into the current session context.
+
+    Call this from a Streamlit route handler or inside a ``st.experimental_fragment``
+    that receives POST events.
+
+    :param payload: Deserialized JSON object from the frontend SDK.
+
+    Example (Streamlit + FastAPI hybrid)::
+
+        @app.post("/api/askable/")
+        async def askable_endpoint(payload: dict):
+            receive_webhook(payload)
+            return {"ok": True}
+    """
+    get_context().receive(payload)

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "askable-py"
+version = "0.1.0"
+description = "Server-side context receiver for askable-ui — inject LLM-ready UI context into Python apps"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+keywords = ["llm", "context", "ui", "django", "streamlit"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = []
+
+[project.optional-dependencies]
+django = ["django>=3.2"]
+streamlit = ["streamlit>=1.20"]
+dev = ["pytest>=7", "pytest-cov"]
+
+[project.urls]
+Homepage = "https://askable-ui.com"
+Repository = "https://github.com/askable-ui/askable"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/python/tests/test_context.py
+++ b/packages/python/tests/test_context.py
@@ -1,0 +1,165 @@
+"""Tests for askable.context — mirrors the TypeScript context.test.ts suite."""
+
+import pytest
+from askable import AskableContext, AskableFocus
+
+
+def make_focus(**kwargs) -> dict:
+    defaults = {"meta": {"widget": "test"}, "text": "Test", "source": "dom", "timestamp": 1700000000000}
+    return {**defaults, **kwargs}
+
+
+class TestAskableContext:
+    def test_get_focus_returns_none_initially(self):
+        ctx = AskableContext()
+        assert ctx.get_focus() is None
+
+    def test_receive_sets_focus(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"widget": "revenue", "value": "$2.3M"}, text="Revenue"))
+        focus = ctx.get_focus()
+        assert focus is not None
+        assert focus.meta == {"widget": "revenue", "value": "$2.3M"}
+        assert focus.text == "Revenue"
+        assert focus.source == "dom"
+
+    def test_push_sets_focus_with_push_source(self):
+        ctx = AskableContext()
+        ctx.push({"widget": "grid", "row": 3}, "Row 3")
+        focus = ctx.get_focus()
+        assert focus is not None
+        assert focus.meta == {"widget": "grid", "row": 3}
+        assert focus.text == "Row 3"
+        assert focus.source == "push"
+
+    def test_push_plain_string_meta(self):
+        ctx = AskableContext()
+        ctx.push("row 5 of deals table")
+        assert ctx.get_focus().meta == "row 5 of deals table"
+
+    def test_clear_resets_focus(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus())
+        ctx.clear()
+        assert ctx.get_focus() is None
+
+    def test_history_is_newest_first(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"id": "a"}))
+        ctx.receive(make_focus(meta={"id": "b"}))
+        ctx.receive(make_focus(meta={"id": "c"}))
+        history = ctx.get_history()
+        assert len(history) == 3
+        assert history[0].meta["id"] == "c"
+        assert history[1].meta["id"] == "b"
+        assert history[2].meta["id"] == "a"
+
+    def test_history_respects_limit(self):
+        ctx = AskableContext()
+        for i in range(5):
+            ctx.receive(make_focus(meta={"id": str(i)}))
+        history = ctx.get_history(limit=2)
+        assert len(history) == 2
+        assert history[0].meta["id"] == "4"
+
+    def test_max_history_caps_buffer(self):
+        ctx = AskableContext(max_history=2)
+        for i in range(4):
+            ctx.receive(make_focus(meta={"id": str(i)}))
+        history = ctx.get_history()
+        assert len(history) == 2
+        assert history[0].meta["id"] == "3"
+
+    def test_max_history_zero_disables_history(self):
+        ctx = AskableContext(max_history=0)
+        ctx.receive(make_focus())
+        assert ctx.get_history() == []
+
+    def test_sanitize_meta_strips_fields(self):
+        ctx = AskableContext(sanitize_meta=lambda m: {k: v for k, v in m.items() if k != "secret"})
+        ctx.receive(make_focus(meta={"widget": "chart", "secret": "x"}))
+        assert "secret" not in ctx.get_focus().meta
+        assert ctx.get_focus().meta["widget"] == "chart"
+
+    def test_sanitize_text_masks_content(self):
+        import re
+        ctx = AskableContext(sanitize_text=lambda t: re.sub(r"\b\d{16}\b", "[card]", t))
+        ctx.receive(make_focus(text="4111111111111111"))
+        assert ctx.get_focus().text == "[card]"
+
+    def test_to_prompt_context_no_focus(self):
+        ctx = AskableContext()
+        assert ctx.to_prompt_context() == "No UI element is currently focused."
+
+    def test_to_prompt_context_natural_format(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"metric": "churn", "value": "4.2%"}, text="Churn Rate"))
+        prompt = ctx.to_prompt_context()
+        assert "User is focused on:" in prompt
+        assert "metric: churn" in prompt
+        assert "4.2%" in prompt
+        assert '"Churn Rate"' in prompt
+
+    def test_to_prompt_context_json_format(self):
+        import json
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"widget": "nps"}, text="NPS"))
+        parsed = json.loads(ctx.to_prompt_context(format="json"))
+        assert parsed["meta"] == {"widget": "nps"}
+        assert parsed["text"] == "NPS"
+
+    def test_to_prompt_context_exclude_keys(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"widget": "kpi", "secret": "x"}))
+        prompt = ctx.to_prompt_context(exclude_keys=["secret"])
+        assert "secret" not in prompt
+        assert "kpi" in prompt
+
+    def test_to_prompt_context_no_focus_json(self):
+        ctx = AskableContext()
+        assert ctx.to_prompt_context(format="json") == "null"
+
+    def test_to_history_context_empty(self):
+        ctx = AskableContext()
+        assert ctx.to_history_context() == "No interaction history."
+
+    def test_to_history_context_newest_first(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"id": "a"}, text="A"))
+        ctx.receive(make_focus(meta={"id": "b"}, text="B"))
+        result = ctx.to_history_context()
+        lines = result.strip().split("\n")
+        assert lines[0].startswith("[1]")
+        assert "id: b" in lines[0]
+        assert lines[1].startswith("[2]")
+        assert "id: a" in lines[1]
+
+    def test_to_context_no_history_equals_to_prompt_context(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"metric": "mrr"}, text="MRR"))
+        assert ctx.to_context() == ctx.to_prompt_context()
+
+    def test_to_context_with_history(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"id": "a"}, text="A"))
+        ctx.receive(make_focus(meta={"id": "b"}, text="B"))
+        out = ctx.to_context(history=5)
+        assert "Current:" in out
+        assert "Recent interactions:" in out
+        assert "id: b" in out
+        assert "id: a" in out
+
+    def test_to_context_custom_labels(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"metric": "mrr"}, text="MRR"))
+        ctx.receive(make_focus(meta={"metric": "arr"}, text="ARR"))
+        out = ctx.to_context(history=1, current_label="Now", history_label="Before")
+        assert "Now:" in out
+        assert "Before:" in out
+
+    def test_token_budget_truncates(self):
+        ctx = AskableContext()
+        ctx.receive(make_focus(meta={"description": "A" * 200}))
+        prompt = ctx.to_prompt_context(max_tokens=10)
+        assert "[truncated]" in prompt
+        assert len(prompt) <= 10 * 4


### PR DESCRIPTION
## Summary

Stacks on #152. **Closes #146.**

Adds `packages/python/askable` — a Python package that mirrors the JS `AskableContext` API for Django and Streamlit backends. Lets server-side LLM calls consume the same focus context that the frontend captures.

### Core (`askable/context.py`)

```python
from askable import AskableContext

ctx = AskableContext(max_history=50)
ctx.receive({"type": "product", "id": 42}, text="Widget Pro")  # from frontend webhook
ctx.push({"type": "order", "id": 7})                           # programmatic

ctx.to_prompt_context()      # "User is focused on: type: product, id: 42 — value "Widget Pro""
ctx.to_context(history=3)    # current + up to 3 history entries
```

Supports `sanitize_meta` and `sanitize_text` hooks, `max_history`, `exclude_keys`, `key_order`, `max_text_length`, and `max_tokens` budget — feature-parity with the JS API.

### Django (`askable/django.py`)

- `AskableMiddleware` — attaches `request.askable` to every request, populated from the session
- `askable_webhook` view — receives `POST /askable/focus` from the frontend JS, stores in `request.session`

### Streamlit (`askable/streamlit.py`)

- `get_context()` — returns a per-session `AskableContext` from `st.session_state`
- `receive_webhook()` — helper for handling focus payloads from `st.components`

### Tests (`tests/test_context.py`)

23 unit tests mirroring the TypeScript test suite: push/receive/clear, history, sanitizers, serialization presets, token budget, excludeKeys/keyOrder.

## Test plan

- [ ] `pytest packages/python/tests/` — all 23 tests pass
- [ ] Django middleware populates `request.askable` with focus from session
- [ ] `AskableContext.to_context(history=3)` returns numbered history entries