### PR TITLE
fix(core): remove AskableContextImpl from public exports

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,3 @@
-export { AskableContextImpl } from './context.js';
 export { createAskableInspector } from './inspector.js';
 export { a11yTextExtractor } from './a11y.js';
 export type {


### PR DESCRIPTION
## Summary

- Removes `AskableContextImpl` from the public re-exports in `@askable-ui/core`
- The implementation class was never intended to be part of the public API; consumers should use the `createAskableContext` factory function instead
- The internal import used by `createAskableContext` is unchanged

Closes #138