### PR TITLE
fix(react): make inspector option reactive in useAskable

### DIFF
--- a/packages/react/src/useAskable.ts
+++ b/packages/react/src/useAskable.ts
@@ -54,6 +54,8 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
   );
   const [focus, setFocus] = useState<AskableFocus | null>(() => ctx.current.getFocus());
 
+  const inspectorKey = JSON.stringify(options?.inspector ?? false);
+
   useEffect(() => {
     const current = ctx.current;
 
@@ -91,7 +93,7 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
         }
       }
     };
-  }, [options?.events, usesProvidedCtx, usePrivateCtx]);
+  }, [options?.events, usesProvidedCtx, usePrivateCtx, inspectorKey]);
 
   return {
     focus,


### PR DESCRIPTION
## Summary
- Add `inspectorKey` (stable JSON serialization of `options.inspector`) to the `useEffect` dependency array
- Toggling `{ inspector: true/false }` after mount now correctly mounts/unmounts the inspector panel

Closes #139