### PR TITLE
fix: bump vitepress and vite to resolve known CVEs

### DIFF
--- a/examples/copilotkit-react/package.json
+++ b/examples/copilotkit-react/package.json
@@ -17,6 +17,6 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.4.5",
-    "vite": "^5.4.19"
+    "vite": "^6.3.3"
   }
 }

--- a/site/docs/package.json
+++ b/site/docs/package.json
@@ -8,6 +8,6 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "vitepress": "^1.3.4"
+    "vitepress": "^1.6.4"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade `vitepress` from `^1.3.4` to `^1.6.4` in `site/docs/`
- Upgrade `vite` from `^5.4.19` to `^6.3.3` in `examples/copilotkit-react/`
- Resolves Dependabot alerts for vite path traversal, lodash code injection/prototype pollution, and prismjs DOM clobbering

The 3 remaining moderate alerts are all the esbuild dev-server advisory (GHSA-67mh-4wv8-2f99) which has no upstream fix. These are dev-only tools with zero impact on published packages.

Closes #140