### PR TITLE
feat(core): add source field and push() method

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -754,6 +754,133 @@ describe('createAskableContext', () => {
     });
   });
 
+  describe('source field', () => {
+    it('DOM interactions set source to "dom"', () => {
+      const el = makeEl({ id: 'test' }, 'Test');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      expect(ctx.getFocus()!.source).toBe('dom');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('select() sets source to "select"', () => {
+      const el = makeEl({ id: 'test' }, 'Test');
+      const ctx = createAskableContext();
+      ctx.select(el);
+
+      expect(ctx.getFocus()!.source).toBe('select');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('push() sets source to "push"', () => {
+      const ctx = createAskableContext();
+      ctx.push({ widget: 'chart' }, 'Revenue');
+
+      expect(ctx.getFocus()!.source).toBe('push');
+
+      ctx.destroy();
+    });
+  });
+
+  describe('push() method', () => {
+    it('sets focus with meta object and text', () => {
+      const ctx = createAskableContext();
+      ctx.push({ widget: 'deals-table', rowIndex: 3 }, 'Acme Corp');
+
+      const focus = ctx.getFocus();
+      expect(focus).not.toBeNull();
+      expect(focus!.meta).toEqual({ widget: 'deals-table', rowIndex: 3 });
+      expect(focus!.text).toBe('Acme Corp');
+      expect(focus!.element).toBeUndefined();
+      expect(typeof focus!.timestamp).toBe('number');
+
+      ctx.destroy();
+    });
+
+    it('sets focus with string meta', () => {
+      const ctx = createAskableContext();
+      ctx.push('plain-string-meta');
+
+      expect(ctx.getFocus()!.meta).toBe('plain-string-meta');
+      expect(ctx.getFocus()!.text).toBe('');
+
+      ctx.destroy();
+    });
+
+    it('emits a focus event', () => {
+      const ctx = createAskableContext();
+      const handler = vi.fn();
+      ctx.on('focus', handler);
+
+      ctx.push({ id: 'row-5' }, 'Row data');
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler.mock.calls[0][0].meta).toEqual({ id: 'row-5' });
+      expect(handler.mock.calls[0][0].source).toBe('push');
+
+      ctx.destroy();
+    });
+
+    it('adds entries to history', () => {
+      const ctx = createAskableContext();
+      ctx.push({ id: 'a' }, 'A');
+      ctx.push({ id: 'b' }, 'B');
+
+      const history = ctx.getHistory();
+      expect(history).toHaveLength(2);
+      expect((history[0].meta as Record<string, unknown>).id).toBe('b');
+      expect((history[1].meta as Record<string, unknown>).id).toBe('a');
+
+      ctx.destroy();
+    });
+
+    it('respects maxHistory', () => {
+      const ctx = createAskableContext({ maxHistory: 2 });
+      ctx.push({ id: 'a' });
+      ctx.push({ id: 'b' });
+      ctx.push({ id: 'c' });
+
+      const history = ctx.getHistory();
+      expect(history).toHaveLength(2);
+      expect((history[0].meta as Record<string, unknown>).id).toBe('c');
+
+      ctx.destroy();
+    });
+
+    it('toPromptContext() works with push()-set focus', () => {
+      const ctx = createAskableContext();
+      ctx.push({ metric: 'revenue' }, '$2.3M');
+
+      const prompt = ctx.toPromptContext();
+      expect(prompt).toContain('User is focused on');
+      expect(prompt).toContain('revenue');
+      expect(prompt).toContain('$2.3M');
+
+      ctx.destroy();
+    });
+
+    it('sanitizeMeta and sanitizeText apply to push()', () => {
+      const ctx = createAskableContext({
+        sanitizeMeta: ({ secret, ...safe }) => safe,
+        sanitizeText: (t) => t.toUpperCase(),
+      });
+
+      ctx.push({ widget: 'table', secret: 'x' }, 'hello');
+
+      const focus = ctx.getFocus();
+      expect((focus!.meta as Record<string, unknown>).secret).toBeUndefined();
+      expect(focus!.text).toBe('HELLO');
+
+      ctx.destroy();
+    });
+  });
+
   it('observe() is a no-op when called outside a browser environment', () => {
     const win = globalThis.window;
     Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -88,15 +88,33 @@ export class AskableContextImpl implements AskableContext {
 
   select(element: HTMLElement): void {
     const rawFocus = buildFocus(element, this.textExtractor);
-    const focus = rawFocus ? this.applySanitizers(rawFocus) : null;
-    if (focus) {
-      this.currentFocus = focus;
-      if (this.maxHistory > 0) {
-        this.history.push(focus);
-        if (this.history.length > this.maxHistory) this.history.shift();
-      }
-      this.emitter.emit('focus', focus);
+    if (!rawFocus) return;
+    const focus = this.applySanitizers({ ...rawFocus, source: 'select' });
+    this.currentFocus = focus;
+    if (this.maxHistory > 0) {
+      this.history.push(focus);
+      if (this.history.length > this.maxHistory) this.history.shift();
     }
+    this.emitter.emit('focus', focus);
+  }
+
+  push(meta: Record<string, unknown> | string, text?: string): void {
+    const sanitizedMeta = this.sanitizeMetaFn && typeof meta !== 'string'
+      ? this.sanitizeMetaFn(meta) : meta;
+    const sanitizedText = this.sanitizeTextFn && text
+      ? this.sanitizeTextFn(text) : (text ?? '');
+    const focus: AskableFocus = {
+      source: 'push',
+      meta: sanitizedMeta,
+      text: sanitizedText,
+      timestamp: Date.now(),
+    };
+    this.currentFocus = focus;
+    if (this.maxHistory > 0) {
+      this.history.push(focus);
+      if (this.history.length > this.maxHistory) this.history.shift();
+    }
+    this.emitter.emit('focus', focus);
   }
 
   clear(): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export type {
   AskableEventMap,
   AskableEventName,
   AskableFocus,
+  AskableFocusSource,
   AskableObserveOptions,
   AskablePromptContextOptions,
   AskablePromptFormat,

--- a/packages/core/src/inspector.ts
+++ b/packages/core/src/inspector.ts
@@ -53,17 +53,21 @@ function buildPanelHTML(focus: AskableFocus | null, promptContext: string): stri
     `;
   }
 
-  const tag = focus.element.tagName.toLowerCase();
-  const id = focus.element.id ? `#${escapeHtml(focus.element.id)}` : '';
-  const cls = focus.element.className
-    ? `.${String(focus.element.className).trim().split(/\s+/).slice(0, 2).map(escapeHtml).join('.')}`
+  const el = focus.element;
+  const tag = el ? el.tagName.toLowerCase() : null;
+  const id = el?.id ? `#${escapeHtml(el.id)}` : '';
+  const cls = el?.className
+    ? `.${String(el.className).trim().split(/\s+/).slice(0, 2).map(escapeHtml).join('.')}`
     : '';
 
   return `
-    <div style="margin-bottom:8px">
+    ${tag ? `<div style="margin-bottom:8px">
       <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Element</span><br>
       <code style="color:#e6edf3">&lt;${escapeHtml(tag)}${id}${cls}&gt;</code>
-    </div>
+    </div>` : `<div style="margin-bottom:8px">
+      <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Source</span><br>
+      <code style="color:#e6edf3">${escapeHtml(focus.source)}</code>
+    </div>`}
     <div style="margin-bottom:8px">
       <span style="color:#7ee787;font-size:10px;text-transform:uppercase;letter-spacing:.05em">Meta</span><br>
       <pre style="color:#e6edf3;margin:4px 0;white-space:pre-wrap;word-break:break-all">${renderMeta(focus.meta)}</pre>
@@ -163,7 +167,7 @@ export function createAskableInspector(
   function update(focus: AskableFocus | null) {
     const promptContext = ctx.toPromptContext(promptOptions);
     body.innerHTML = buildPanelHTML(focus, promptContext);
-    if (focus && focus.element.isConnected) applyHighlight(focus.element);
+    if (focus?.element?.isConnected) applyHighlight(focus.element);
     else clearHighlight();
   }
 

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -38,6 +38,7 @@ export function buildFocus(el: HTMLElement, textExtractor?: (el: HTMLElement) =>
     ? textOverride
     : textExtractor ? textExtractor(el) : extractText(el);
   return {
+    source: 'dom',
     meta: parseMeta(raw),
     text,
     element: el,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,10 +1,15 @@
+/** How focus was initiated */
+export type AskableFocusSource = 'dom' | 'select' | 'push';
+
 export interface AskableFocus {
+  /** How focus was initiated */
+  source: AskableFocusSource;
   /** Parsed data-askable attribute (JSON object or raw string) */
   meta: Record<string, unknown> | string;
   /** Trimmed textContent of the element */
   text: string;
-  /** The DOM element itself */
-  element: HTMLElement;
+  /** The DOM element (undefined when set via push()) */
+  element?: HTMLElement;
   /** Unix timestamp (ms) of when focus was set */
   timestamp: number;
 }
@@ -166,6 +171,8 @@ export interface AskableContext {
   off<K extends AskableEventName>(event: K, handler: AskableEventHandler<K>): void;
   /** Programmatically select an element — use for explicit "Ask AI" buttons */
   select(element: HTMLElement): void;
+  /** Set focus from data alone — no DOM element required. Ideal for virtualizing table libraries. */
+  push(meta: Record<string, unknown> | string, text?: string): void;
   /** Reset the current focus to null and emit a 'clear' event */
   clear(): void;
   /** Serialize current focus to structured prompt-ready data */


### PR DESCRIPTION
## Summary
- Add `AskableFocusSource` type (`'dom' | 'select' | 'push'`) to `AskableFocus`
- Make `element` optional (`undefined` when set via `push()`)
- Implement `ctx.push(meta, text?)` for programmatic focus without a DOM element — the idiomatic solution for virtualizing table libraries (AG Grid, TanStack, etc.)
- Guard inspector element access for push()-sourced focus
- 10 new tests covering source field and push() API

## Test plan
- [x] All 109 core tests pass (10 new)
- [x] All 63 framework adapter tests (React/Vue/Svelte) pass unchanged

Closes #143