### PR TITLE
feat(core): add combined toContext() method

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -881,6 +881,103 @@ describe('createAskableContext', () => {
     });
   });
 
+  describe('toContext() combined method', () => {
+    it('returns current focus with label when history is 0', () => {
+      const el = makeEl({ metric: 'revenue' }, '$2.3M');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const output = ctx.toContext();
+      expect(output).toMatch(/^Current:/);
+      expect(output).toContain('revenue');
+      expect(output).not.toContain('Recent interactions');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('includes history section when history > 0', () => {
+      const el1 = makeEl({ id: 'a' }, 'A');
+      const el2 = makeEl({ id: 'b' }, 'B');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el1.click();
+      el2.click();
+
+      const output = ctx.toContext({ history: 5 });
+      expect(output).toContain('Current:');
+      expect(output).toContain('Recent interactions:');
+      expect(output).toContain('[1]');
+      expect(output).toContain('[2]');
+
+      ctx.destroy();
+      cleanup(el1);
+      cleanup(el2);
+    });
+
+    it('respects custom labels', () => {
+      const el = makeEl({ id: 'a' }, 'A');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      ctx.push({ id: 'b' }, 'B');
+
+      const output = ctx.toContext({
+        history: 5,
+        currentLabel: 'Now',
+        historyLabel: 'Before',
+      });
+      expect(output).toMatch(/^Now:/);
+      expect(output).toContain('Before:');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('matches toPromptContext() when no history requested', () => {
+      const el = makeEl({ metric: 'churn' }, 'Churn Rate');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const toContextOutput = ctx.toContext();
+      const promptOutput = ctx.toPromptContext();
+      // toContext wraps with "Current: " prefix
+      expect(toContextOutput).toBe(`Current: ${promptOutput}`);
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('respects maxTokens', () => {
+      const ctx = createAskableContext();
+      ctx.push({ description: 'A'.repeat(200) });
+
+      const output = ctx.toContext({ maxTokens: 10 });
+      expect(output).toContain('[truncated]');
+      expect(output.length).toBeLessThanOrEqual(40);
+
+      ctx.destroy();
+    });
+
+    it('passes prompt options through to serialization', () => {
+      const el = makeEl({ metric: 'churn', secret: 'x' }, 'Churn');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const output = ctx.toContext({ excludeKeys: ['secret'], includeText: false });
+      expect(output).toContain('churn');
+      expect(output).not.toContain('secret');
+      expect(output).not.toContain('Churn');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+  });
+
   it('observe() is a no-op when called outside a browser environment', () => {
     const win = globalThis.window;
     Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -3,6 +3,7 @@ import { buildFocus, Observer } from './observer.js';
 import type {
   AskableContext,
   AskableContextOptions,
+  AskableContextOutputOptions,
   AskableEventHandler,
   AskableEventName,
   AskableFocus,
@@ -139,6 +140,27 @@ export class AskableContextImpl implements AskableContext {
     if (history.length === 0) return 'No interaction history.';
     const lines = history.map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
     const output = lines.join('\n');
+    return this.applyTokenBudget(output, resolved.maxTokens);
+  }
+
+  toContext(options?: AskableContextOutputOptions): string {
+    const { history: historyCount = 0, currentLabel = 'Current', historyLabel = 'Recent interactions', ...promptOptions } = options ?? {};
+    const resolved = this.resolveOptions(promptOptions);
+
+    const currentLine = `${currentLabel}: ${this.buildPromptString(this.currentFocus, resolved)}`;
+
+    if (historyCount <= 0) {
+      return this.applyTokenBudget(currentLine, resolved.maxTokens);
+    }
+
+    const historyEntries = this.getHistory(historyCount);
+    if (historyEntries.length === 0) {
+      return this.applyTokenBudget(currentLine, resolved.maxTokens);
+    }
+
+    const historyLines = historyEntries
+      .map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
+    const output = `${currentLine}\n\n${historyLabel}:\n${historyLines.join('\n')}`;
     return this.applyTokenBudget(output, resolved.maxTokens);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type {
 export type {
   AskableContext,
   AskableContextOptions,
+  AskableContextOutputOptions,
   AskableEvent,
   AskableEventHandler,
   AskableEventMap,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,6 +156,15 @@ export interface AskableSerializedFocus {
   timestamp: number;
 }
 
+export interface AskableContextOutputOptions extends AskablePromptContextOptions {
+  /** Number of history entries to include. Defaults to 0 (current focus only). */
+  history?: number;
+  /** Label for the current focus section. Defaults to "Current". */
+  currentLabel?: string;
+  /** Label for the history section. Defaults to "Recent interactions". */
+  historyLabel?: string;
+}
+
 export interface AskableContext {
   /** Observe a DOM subtree for [data-askable] elements */
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void;
@@ -181,6 +190,8 @@ export interface AskableContext {
   toPromptContext(options?: AskablePromptContextOptions): string;
   /** Serialize focus history to a prompt-ready string (newest first). Optional limit caps the entries returned. */
   toHistoryContext(limit?: number, options?: AskablePromptContextOptions): string;
+  /** Combined current focus + history in a single prompt-ready string */
+  toContext(options?: AskableContextOutputOptions): string;
   /** Clean up all listeners and observers */
   destroy(): void;
 }


### PR DESCRIPTION
## Summary
- Add `toContext()` that returns current focus + optional history in a single prompt-ready string
- Configurable `currentLabel`, `historyLabel`, and `history` count
- When `history` is 0 or omitted, output equals `toPromptContext()` with label prefix
- New `AskableContextOutputOptions` type exported from core

## Test plan
- [x] 6 new tests covering toContext() API
- [x] All 115 core tests pass

Closes #144

> Includes changes from #157 (source field + push)