### PR TITLE
test(e2e): add Playwright coverage for push(), source, and toContext()

### DIFF
--- a/e2e/observer.spec.ts
+++ b/e2e/observer.spec.ts
@@ -296,6 +296,188 @@ test.describe('clear() and history', () => {
   });
 });
 
+test.describe('push() API', () => {
+  test('push() sets focus with meta and text', async ({ harness }) => {
+    const page = await harness(`<div id="root"></div>`);
+
+    await page.evaluate(() => {
+      (window as any).ctx.push({ widget: 'deals-table', rowIndex: 3 }, 'Acme Corp');
+    });
+
+    const focus = await page.evaluate(() => {
+      const f = (window as any).ctx.getFocus();
+      return f ? { meta: f.meta, text: f.text, source: f.source, hasElement: !!f.element } : null;
+    });
+
+    expect(focus).not.toBeNull();
+    expect(focus!.meta).toEqual({ widget: 'deals-table', rowIndex: 3 });
+    expect(focus!.text).toBe('Acme Corp');
+    expect(focus!.source).toBe('push');
+    expect(focus!.hasElement).toBe(false);
+  });
+
+  test('push() with plain string meta', async ({ harness }) => {
+    const page = await harness(`<div id="root"></div>`);
+
+    await page.evaluate(() => {
+      (window as any).ctx.push('row-label');
+    });
+
+    const meta = await page.evaluate(() => (window as any).ctx.getFocus()?.meta);
+    expect(meta).toBe('row-label');
+  });
+
+  test('push() emits focus event', async ({ harness }) => {
+    const page = await harness(`<div id="root"></div>`);
+
+    const eventData = await page.evaluate(() => {
+      return new Promise<any>((resolve) => {
+        (window as any).ctx.on('focus', (f: any) => {
+          resolve({ meta: f.meta, source: f.source });
+        });
+        (window as any).ctx.push({ id: 'row-5' }, 'Row data');
+      });
+    });
+
+    expect(eventData.meta).toEqual({ id: 'row-5' });
+    expect(eventData.source).toBe('push');
+  });
+
+  test('push() entries appear in history', async ({ harness }) => {
+    const page = await harness(`<div id="root"></div>`);
+
+    await page.evaluate(() => {
+      (window as any).ctx.push({ id: 'a' }, 'A');
+      (window as any).ctx.push({ id: 'b' }, 'B');
+    });
+
+    const history = await page.evaluate(() =>
+      (window as any).ctx.getHistory().map((f: any) => f.meta.id)
+    );
+
+    expect(history).toEqual(['b', 'a']);
+  });
+
+  test('push() focus renders in toPromptContext()', async ({ harness }) => {
+    const page = await harness(`<div id="root"></div>`);
+
+    await page.evaluate(() => {
+      (window as any).ctx.push({ metric: 'revenue' }, '$2.3M');
+    });
+
+    const prompt = await page.evaluate(() => (window as any).ctx.toPromptContext());
+    expect(prompt).toContain('revenue');
+    expect(prompt).toContain('$2.3M');
+  });
+});
+
+test.describe('source field', () => {
+  test('DOM click sets source to "dom"', async ({ harness }) => {
+    const page = await harness(`
+      <div id="card" data-askable='{"widget":"kpi"}' tabindex="0">KPI</div>
+    `);
+
+    await page.click('#card');
+
+    const source = await page.evaluate(() => (window as any).ctx.getFocus()?.source);
+    expect(source).toBe('dom');
+  });
+
+  test('select() sets source to "select"', async ({ harness }) => {
+    const page = await harness(`
+      <div id="card" data-askable='{"widget":"nps"}'>NPS</div>
+    `);
+
+    await page.evaluate(() => {
+      (window as any).ctx.select(document.getElementById('card'));
+    });
+
+    const source = await page.evaluate(() => (window as any).ctx.getFocus()?.source);
+    expect(source).toBe('select');
+  });
+
+  test('push() sets source to "push"', async ({ harness }) => {
+    const page = await harness(`<div id="root"></div>`);
+
+    await page.evaluate(() => {
+      (window as any).ctx.push({ id: 'row' });
+    });
+
+    const source = await page.evaluate(() => (window as any).ctx.getFocus()?.source);
+    expect(source).toBe('push');
+  });
+
+  test('source is preserved in history across mixed origins', async ({ harness }) => {
+    const page = await harness(
+      `<div id="card" data-askable='{"widget":"dom-card"}' tabindex="0">Card</div>`,
+      `window.ctx.unobserve(); window.ctx.observe(document, { events: ['click'] });`,
+    );
+
+    await page.click('#card');
+    await page.evaluate(() => {
+      (window as any).ctx.select(document.getElementById('card')!);
+      (window as any).ctx.push({ via: 'push' });
+    });
+
+    const sources = await page.evaluate(() =>
+      (window as any).ctx.getHistory().map((f: any) => f.source)
+    );
+    // newest first: push, select, dom
+    expect(sources).toEqual(['push', 'select', 'dom']);
+  });
+});
+
+test.describe('toContext() combined output', () => {
+  test('without history matches toPromptContext() with label', async ({ harness }) => {
+    const page = await harness(`
+      <div id="card" data-askable='{"metric":"churn"}' tabindex="0">Churn</div>
+    `);
+
+    await page.click('#card');
+
+    const [toCtx, prompt] = await page.evaluate(() => [
+      (window as any).ctx.toContext(),
+      (window as any).ctx.toPromptContext(),
+    ]);
+
+    expect(toCtx).toBe(`Current: ${prompt}`);
+  });
+
+  test('with history includes labeled sections', async ({ harness }) => {
+    const page = await harness(`
+      <div id="a" data-askable='{"id":"a"}' tabindex="0">A</div>
+      <div id="b" data-askable='{"id":"b"}' tabindex="0">B</div>
+    `);
+
+    await page.click('#a');
+    await page.click('#b');
+
+    const output = await page.evaluate(() =>
+      (window as any).ctx.toContext({ history: 5 })
+    );
+
+    expect(output).toContain('Current:');
+    expect(output).toContain('Recent interactions:');
+    expect(output).toContain('[1]');
+  });
+
+  test('respects custom labels', async ({ harness }) => {
+    const page = await harness(`<div id="root"></div>`);
+
+    await page.evaluate(() => {
+      (window as any).ctx.push({ id: 'a' }, 'A');
+      (window as any).ctx.push({ id: 'b' }, 'B');
+    });
+
+    const output = await page.evaluate(() =>
+      (window as any).ctx.toContext({ history: 5, currentLabel: 'Now', historyLabel: 'Before' })
+    );
+
+    expect(output).toMatch(/^Now:/);
+    expect(output).toContain('Before:');
+  });
+});
+
 test.describe('toPromptContext() serialization', () => {
   test('natural format — default', async ({ harness }) => {
     const page = await harness(`

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -881,6 +881,103 @@ describe('createAskableContext', () => {
     });
   });
 
+  describe('toContext() combined method', () => {
+    it('returns current focus with label when history is 0', () => {
+      const el = makeEl({ metric: 'revenue' }, '$2.3M');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const output = ctx.toContext();
+      expect(output).toMatch(/^Current:/);
+      expect(output).toContain('revenue');
+      expect(output).not.toContain('Recent interactions');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('includes history section when history > 0', () => {
+      const el1 = makeEl({ id: 'a' }, 'A');
+      const el2 = makeEl({ id: 'b' }, 'B');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el1.click();
+      el2.click();
+
+      const output = ctx.toContext({ history: 5 });
+      expect(output).toContain('Current:');
+      expect(output).toContain('Recent interactions:');
+      expect(output).toContain('[1]');
+      expect(output).toContain('[2]');
+
+      ctx.destroy();
+      cleanup(el1);
+      cleanup(el2);
+    });
+
+    it('respects custom labels', () => {
+      const el = makeEl({ id: 'a' }, 'A');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      ctx.push({ id: 'b' }, 'B');
+
+      const output = ctx.toContext({
+        history: 5,
+        currentLabel: 'Now',
+        historyLabel: 'Before',
+      });
+      expect(output).toMatch(/^Now:/);
+      expect(output).toContain('Before:');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('matches toPromptContext() when no history requested', () => {
+      const el = makeEl({ metric: 'churn' }, 'Churn Rate');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const toContextOutput = ctx.toContext();
+      const promptOutput = ctx.toPromptContext();
+      // toContext wraps with "Current: " prefix
+      expect(toContextOutput).toBe(`Current: ${promptOutput}`);
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('respects maxTokens', () => {
+      const ctx = createAskableContext();
+      ctx.push({ description: 'A'.repeat(200) });
+
+      const output = ctx.toContext({ maxTokens: 10 });
+      expect(output).toContain('[truncated]');
+      expect(output.length).toBeLessThanOrEqual(40);
+
+      ctx.destroy();
+    });
+
+    it('passes prompt options through to serialization', () => {
+      const el = makeEl({ metric: 'churn', secret: 'x' }, 'Churn');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const output = ctx.toContext({ excludeKeys: ['secret'], includeText: false });
+      expect(output).toContain('churn');
+      expect(output).not.toContain('secret');
+      expect(output).not.toContain('Churn');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+  });
+
   it('observe() is a no-op when called outside a browser environment', () => {
     const win = globalThis.window;
     Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -3,6 +3,7 @@ import { buildFocus, Observer } from './observer.js';
 import type {
   AskableContext,
   AskableContextOptions,
+  AskableContextOutputOptions,
   AskableEventHandler,
   AskableEventName,
   AskableFocus,
@@ -139,6 +140,27 @@ export class AskableContextImpl implements AskableContext {
     if (history.length === 0) return 'No interaction history.';
     const lines = history.map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
     const output = lines.join('\n');
+    return this.applyTokenBudget(output, resolved.maxTokens);
+  }
+
+  toContext(options?: AskableContextOutputOptions): string {
+    const { history: historyCount = 0, currentLabel = 'Current', historyLabel = 'Recent interactions', ...promptOptions } = options ?? {};
+    const resolved = this.resolveOptions(promptOptions);
+
+    const currentLine = `${currentLabel}: ${this.buildPromptString(this.currentFocus, resolved)}`;
+
+    if (historyCount <= 0) {
+      return this.applyTokenBudget(currentLine, resolved.maxTokens);
+    }
+
+    const historyEntries = this.getHistory(historyCount);
+    if (historyEntries.length === 0) {
+      return this.applyTokenBudget(currentLine, resolved.maxTokens);
+    }
+
+    const historyLines = historyEntries
+      .map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
+    const output = `${currentLine}\n\n${historyLabel}:\n${historyLines.join('\n')}`;
     return this.applyTokenBudget(output, resolved.maxTokens);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type {
 export type {
   AskableContext,
   AskableContextOptions,
+  AskableContextOutputOptions,
   AskableEvent,
   AskableEventHandler,
   AskableEventMap,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,6 +156,15 @@ export interface AskableSerializedFocus {
   timestamp: number;
 }
 
+export interface AskableContextOutputOptions extends AskablePromptContextOptions {
+  /** Number of history entries to include. Defaults to 0 (current focus only). */
+  history?: number;
+  /** Label for the current focus section. Defaults to "Current". */
+  currentLabel?: string;
+  /** Label for the history section. Defaults to "Recent interactions". */
+  historyLabel?: string;
+}
+
 export interface AskableContext {
   /** Observe a DOM subtree for [data-askable] elements */
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void;
@@ -181,6 +190,8 @@ export interface AskableContext {
   toPromptContext(options?: AskablePromptContextOptions): string;
   /** Serialize focus history to a prompt-ready string (newest first). Optional limit caps the entries returned. */
   toHistoryContext(limit?: number, options?: AskablePromptContextOptions): string;
+  /** Combined current focus + history in a single prompt-ready string */
+  toContext(options?: AskableContextOutputOptions): string;
   /** Clean up all listeners and observers */
   destroy(): void;
 }


### PR DESCRIPTION
## Summary
- 13 new E2E tests across 3 suites: push() API, source field, toContext() output
- Tests verify cross-browser behavior for programmatic focus, source tracking, and combined context output
- All 34 E2E tests pass on Chromium

## Test plan
- [x] 34/34 Playwright tests pass (Chromium)

Closes #141

> Includes changes from #157 and #158 (source field + push + toContext)