### PR TITLE
docs: add push(), source field, toContext(), and third-party library guide

### DIFF
--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
         {
           text: 'Integrations',
           items: [
+            { text: 'Third-Party Libraries', link: '/guide/third-party-libraries' },
             { text: 'CopilotKit', link: '/guide/copilotkit' },
             { text: 'Python Packages', link: '/guide/python' },
           ],

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -113,9 +113,10 @@ Returns the current `AskableFocus`, or `null` if no element has been interacted 
 ```ts
 const focus = ctx.getFocus();
 if (focus) {
+  console.log(focus.source);    // 'dom' | 'select' | 'push'
   console.log(focus.meta);      // Record<string, unknown> | string
   console.log(focus.text);      // trimmed textContent
-  console.log(focus.element);   // HTMLElement
+  console.log(focus.element);   // HTMLElement | undefined (undefined for push())
   console.log(focus.timestamp); // Unix ms
 }
 ```
@@ -155,7 +156,7 @@ ctx.on('clear', () => console.log('Focus cleared'));
 
 | Event | Payload | Fires when |
 |---|---|---|
-| `'focus'` | `AskableFocus` | A `[data-askable]` element is clicked, hovered, focused, or `select()` is called |
+| `'focus'` | `AskableFocus` | A `[data-askable]` element is clicked, hovered, focused, `select()` is called, or `push()` is called |
 | `'clear'` | `null` | `ctx.clear()` is called |
 
 ---
@@ -168,6 +169,27 @@ Programmatically set focus to any `HTMLElement`. Fires the `'focus'` event and u
 const el = document.querySelector('[data-askable]') as HTMLElement;
 ctx.select(el);
 ```
+
+---
+
+### `push(meta, text?)`
+
+Set focus from data alone — no DOM element required. Fires the `'focus'` event and updates history. The resulting `AskableFocus` has `source: 'push'` and `element: undefined`.
+
+This is the idiomatic solution for libraries that manage their own DOM (AG Grid, TanStack Table, chart libraries, etc.) where you cannot add `data-askable` attributes to internal elements.
+
+```ts
+// Object meta
+ctx.push({ widget: 'deals-table', rowIndex: 3, company: 'Acme' }, 'Acme Corp — Closed Won');
+
+// String meta
+ctx.push('row-label');
+
+// No text
+ctx.push({ chart: 'revenue', period: 'Q3' });
+```
+
+Sanitizers (`sanitizeMeta`, `sanitizeText`) apply to `push()` the same way they apply to DOM-sourced focus.
 
 ---
 
@@ -215,6 +237,38 @@ ctx.toHistoryContext(5, { excludeKeys: ['_id'], maxTokens: 200 });
 ```
 
 **Returns:** `string` — `'No interaction history.'` when history is empty.
+
+---
+
+### `toContext(options?)`
+
+Combined current focus + history in a single prompt-ready string. When `history` is 0 or omitted, output is equivalent to `toPromptContext()` prefixed with a label.
+
+```ts
+ctx.toContext();
+// → "Current: User is focused on: — metric: revenue — value "Revenue""
+
+ctx.toContext({ history: 5 });
+// → "Current: User is focused on: — metric: revenue — value "Revenue"
+//
+//    Recent interactions:
+//    [1] User is focused on: — widget: chart — value "Churn"
+//    [2] User is focused on: — page: settings"
+
+ctx.toContext({ history: 3, currentLabel: 'Now', historyLabel: 'Before' });
+// Custom section labels
+```
+
+**Options (`AskableContextOutputOptions`):**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `history` | `number` | `0` | Number of history entries to include |
+| `currentLabel` | `string` | `'Current'` | Label for the current focus section |
+| `historyLabel` | `string` | `'Recent interactions'` | Label for the history section |
+| _...all `AskablePromptContextOptions`_ | | | Passed through to serialization |
+
+**Returns:** `string`
 
 ---
 

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -6,7 +6,9 @@ All types are exported from `@askable-ui/core`.
 import type {
   AskableContext,
   AskableContextOptions,
+  AskableContextOutputOptions,
   AskableFocus,
+  AskableFocusSource,
   AskableSerializedFocus,
   AskablePromptContextOptions,
   AskablePromptFormat,
@@ -47,18 +49,36 @@ interface AskableContextOptions {
 
 ---
 
+## `AskableFocusSource`
+
+Indicates how focus was initiated.
+
+```ts
+type AskableFocusSource = 'dom' | 'select' | 'push';
+```
+
+| Value | Set by |
+|---|---|
+| `'dom'` | User interaction (click, hover, keyboard focus) via the Observer |
+| `'select'` | `ctx.select(element)` — explicit "Ask AI" button patterns |
+| `'push'` | `ctx.push(meta, text)` — programmatic focus without a DOM element |
+
+---
+
 ## `AskableFocus`
 
 The shape of focus state objects returned by `getFocus()`, `getHistory()`, and passed to `'focus'` event handlers.
 
 ```ts
 interface AskableFocus {
+  /** How focus was initiated. */
+  source: AskableFocusSource;
   /** Parsed data-askable value. JSON → object; plain string → string. */
   meta: Record<string, unknown> | string;
   /** Trimmed textContent of the element. */
   text: string;
-  /** The DOM element itself. */
-  element: HTMLElement;
+  /** The DOM element. Undefined when set via push(). */
+  element?: HTMLElement;
   /** Unix timestamp (ms) when focus was set. */
   timestamp: number;
 }
@@ -111,6 +131,23 @@ interface AskablePromptContextOptions {
   prefix?: string;                 // Prefix in natural format. Default: 'User is focused on:'
   textLabel?: string;              // Label for text. Default: 'value'
   maxTokens?: number;              // Token budget (4 chars/token). Appends [truncated] if exceeded.
+}
+```
+
+---
+
+## `AskableContextOutputOptions`
+
+Options accepted by `toContext()`. Extends `AskablePromptContextOptions`.
+
+```ts
+interface AskableContextOutputOptions extends AskablePromptContextOptions {
+  /** Number of history entries to include. Default: 0 (current focus only). */
+  history?: number;
+  /** Label for the current focus section. Default: 'Current' */
+  currentLabel?: string;
+  /** Label for the history section. Default: 'Recent interactions' */
+  historyLabel?: string;
 }
 ```
 

--- a/site/docs/guide/focus-history.md
+++ b/site/docs/guide/focus-history.md
@@ -8,12 +8,25 @@
 const focus = ctx.getFocus();
 
 if (focus) {
+  focus.source     // 'dom' | 'select' | 'push'
   focus.meta       // Record<string, unknown> | string
   focus.text       // trimmed textContent of the element
-  focus.element    // the HTMLElement itself
+  focus.element    // the HTMLElement (undefined when set via push())
   focus.timestamp  // Unix ms when focus was set
 }
 ```
+
+### Focus source
+
+Every focus entry includes a `source` field that tells you how it was initiated:
+
+| Source | Set by | Use case |
+|---|---|---|
+| `'dom'` | User click, hover, or keyboard focus | Passive observation |
+| `'select'` | `ctx.select(element)` | "Ask AI" button patterns |
+| `'push'` | `ctx.push(meta, text)` | Third-party libraries (AG Grid, charts, etc.) |
+
+Use this to differentiate behavior — e.g., suppress auto-suggestions for `push` events, or show a different UI for explicit `select` actions.
 
 ## History
 
@@ -89,6 +102,47 @@ async function ask(userMessage: string) {
 }
 ```
 
+## Combined context with `toContext()`
+
+`toContext()` returns current focus + optional history in a single string — no manual concatenation needed:
+
+```ts
+// Current focus only (history defaults to 0)
+ctx.toContext();
+// → "Current: User is focused on: metric: revenue — value "Revenue""
+
+// Include recent interactions
+ctx.toContext({ history: 5 });
+// → "Current: User is focused on: metric: revenue — value "Revenue"
+//
+//    Recent interactions:
+//    [1] User is focused on: widget: chart — value "Churn"
+//    [2] User is focused on: page: settings"
+
+// Custom labels
+ctx.toContext({ history: 3, currentLabel: 'Active', historyLabel: 'Previous' });
+```
+
+All `AskablePromptContextOptions` (presets, `excludeKeys`, `maxTokens`, etc.) are passed through.
+
+## Programmatic focus with `push()`
+
+Use `ctx.push(meta, text?)` to set focus from data alone — no DOM element required. This is the idiomatic solution for third-party libraries that render their own DOM (AG Grid, TanStack Table, chart libraries, etc.).
+
+```ts
+ctx.push({ widget: 'deals-table', rowIndex: 3, company: 'Acme' }, 'Acme Corp — Closed Won');
+
+// String meta
+ctx.push('highlighted-row');
+
+// No text
+ctx.push({ chart: 'revenue', period: 'Q3' });
+```
+
+`push()` fires the `'focus'` event, updates history, and respects sanitizers — just like `select()` and DOM interactions. The resulting focus has `source: 'push'` and `element: undefined`.
+
+See the [Third-Party Libraries guide](/guide/third-party-libraries) for full integration examples with AG Grid, TanStack Table, and chart libraries.
+
 ## Programmatic focus with `select()`
 
 Use `ctx.select(element)` to set focus without waiting for a user interaction. This is the foundation of the **"Ask AI" button pattern** — you set context explicitly when the user clicks a dedicated button, rather than relying on passive hover or focus.
@@ -125,8 +179,8 @@ chatPanel.addEventListener('close', () => ctx.clear());
 
 ```ts
 ctx.on('focus', (focus) => {
-  // fires on every new focus (click, hover, focus event, or select())
-  console.log('New focus:', focus.meta);
+  // fires on every new focus (click, hover, focus event, select(), or push())
+  console.log('New focus:', focus.meta, 'via', focus.source);
 });
 
 ctx.on('clear', () => {

--- a/site/docs/guide/select.md
+++ b/site/docs/guide/select.md
@@ -10,8 +10,9 @@ Passive observation (hover/click/focus) is great for automatically tracking what
 |---|---|
 | Passive observation | Always-on context — user browsing a dashboard, hover-to-ask interactions |
 | `select()` | "Ask AI" button next to a widget; right-click → explain; keyboard shortcut for current selection |
+| `push()` | Third-party libraries (AG Grid, charts) where you can't annotate DOM elements — see [Third-Party Libraries](/guide/third-party-libraries) |
 
-Use both together: passive observation sets context as the user browses, and `select()` lets them explicitly pin a specific element before asking a question.
+Use them together: passive observation sets context as the user browses, `select()` lets them explicitly pin a specific element, and `push()` covers libraries that own their DOM. Each sets a different `source` field (`'dom'`, `'select'`, `'push'`) so you can differentiate behavior.
 
 ## Basic usage
 

--- a/site/docs/guide/serialization.md
+++ b/site/docs/guide/serialization.md
@@ -1,6 +1,6 @@
 # Prompt Serialization
 
-`toPromptContext()` and `toHistoryContext()` accept an `AskablePromptContextOptions` object to control exactly how context is serialized.
+`toPromptContext()`, `toHistoryContext()`, and `toContext()` accept an `AskablePromptContextOptions` object to control exactly how context is serialized.
 
 ## Presets
 
@@ -24,7 +24,7 @@ ctx.toPromptContext({ preset: 'compact', includeText: true });
 // compact but with text included
 ```
 
-Presets work with all serialization methods: `toPromptContext()`, `toHistoryContext()`, and `serializeFocus()`.
+Presets work with all serialization methods: `toPromptContext()`, `toHistoryContext()`, `toContext()`, and `serializeFocus()`.
 
 ## Default output
 
@@ -153,3 +153,28 @@ Use this to:
 | `prefix` | `string` | `'User is focused on:'` | Prefix in natural format |
 | `textLabel` | `string` | `'value'` | Label for text in natural format |
 | `maxTokens` | `number` | — | Token budget (4 chars/token estimate). Appends `[truncated]` if exceeded. |
+
+## `toContext()` — combined output
+
+Instead of manually concatenating `toPromptContext()` and `toHistoryContext()`, use `toContext()` to get both in a single call:
+
+```ts
+// Replaces this:
+const systemPrompt = [
+  'Current selection:',
+  ctx.toPromptContext(),
+  '',
+  'Recent interactions:',
+  ctx.toHistoryContext(5),
+].join('\n');
+
+// With this:
+const systemPrompt = ctx.toContext({ history: 5 });
+```
+
+All prompt options pass through:
+
+```ts
+ctx.toContext({ history: 3, preset: 'compact', maxTokens: 300 });
+ctx.toContext({ history: 5, currentLabel: 'Active', historyLabel: 'Previous' });
+```

--- a/site/docs/guide/third-party-libraries.md
+++ b/site/docs/guide/third-party-libraries.md
@@ -1,0 +1,262 @@
+# Third-Party Libraries
+
+Libraries like AG Grid, TanStack Table, and chart libraries render their own DOM — you can't add `data-askable` attributes to internal rows or data points. Use `ctx.push()` to set focus from event callbacks instead.
+
+## When to use `push()` vs `data-askable`
+
+| Approach | When to use |
+|---|---|
+| `data-askable` attributes | You control the markup — custom tables, cards, lists |
+| `ctx.push(meta, text)` | The library owns the DOM — AG Grid, TanStack, Recharts, etc. |
+
+Both approaches produce the same `AskableFocus` objects, fire the same events, and work with all serialization methods.
+
+## AG Grid
+
+Wire AG Grid's event callbacks to `push()`:
+
+### Row click tracking
+
+```tsx
+import { useAskable } from '@askable-ui/react';
+
+function DealsTable({ rowData, columnDefs }) {
+  const { ctx } = useAskable();
+
+  return (
+    <AgGridReact
+      rowData={rowData}
+      columnDefs={columnDefs}
+      onRowClicked={(event) => {
+        ctx.push(
+          { widget: 'deals-table', rowIndex: event.rowIndex, ...event.data },
+          `${event.data.company} — ${event.data.stage}`
+        );
+      }}
+    />
+  );
+}
+```
+
+### Cell-level keyboard navigation
+
+```tsx
+<AgGridReact
+  rowData={rowData}
+  columnDefs={columnDefs}
+  onCellFocused={(event) => {
+    const row = event.api.getDisplayedRowAtIndex(event.rowIndex);
+    if (row?.data) {
+      ctx.push(
+        { widget: 'deals-table', rowIndex: event.rowIndex, column: event.column?.colId },
+        String(row.data[event.column?.colId] ?? '')
+      );
+    }
+  }}
+/>
+```
+
+### Row selection tracking
+
+```tsx
+<AgGridReact
+  rowData={rowData}
+  columnDefs={columnDefs}
+  rowSelection="multiple"
+  onSelectionChanged={(event) => {
+    const selected = event.api.getSelectedRows();
+    if (selected.length === 1) {
+      ctx.push(
+        { widget: 'deals-table', ...selected[0] },
+        selected[0].company
+      );
+    } else if (selected.length > 1) {
+      ctx.push(
+        { widget: 'deals-table', selectedCount: selected.length },
+        `${selected.length} rows selected`
+      );
+    }
+  }}
+/>
+```
+
+## TanStack Table
+
+Use TanStack Table's row click handlers with `push()`:
+
+```tsx
+import { useAskable } from '@askable-ui/react';
+import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+
+function DataTable({ data, columns }) {
+  const { ctx } = useAskable();
+  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+
+  return (
+    <table>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr
+            key={row.id}
+            onClick={() => {
+              ctx.push(
+                { widget: 'data-table', rowIndex: row.index, ...row.original },
+                Object.values(row.original).join(' — ')
+              );
+            }}
+          >
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+```
+
+## Chart libraries (Recharts, Chart.js, etc.)
+
+Push context when a user clicks or hovers a data point:
+
+### Recharts
+
+```tsx
+import { BarChart, Bar } from 'recharts';
+
+function RevenueChart({ data }) {
+  const { ctx } = useAskable();
+
+  return (
+    <BarChart data={data}>
+      <Bar
+        dataKey="revenue"
+        onClick={(entry) => {
+          ctx.push(
+            { chart: 'revenue', period: entry.month },
+            `${entry.month}: $${entry.revenue}`
+          );
+        }}
+      />
+    </BarChart>
+  );
+}
+```
+
+### Chart.js (via react-chartjs-2)
+
+```tsx
+import { Bar } from 'react-chartjs-2';
+
+function SalesChart({ chartData }) {
+  const { ctx } = useAskable();
+
+  return (
+    <Bar
+      data={chartData}
+      options={{
+        onClick: (_event, elements) => {
+          if (elements.length > 0) {
+            const { index } = elements[0];
+            const label = chartData.labels[index];
+            const value = chartData.datasets[0].data[index];
+            ctx.push({ chart: 'sales', label, value }, `${label}: ${value}`);
+          }
+        },
+      }}
+    />
+  );
+}
+```
+
+## Custom components (you control the markup)
+
+When you control the rendered HTML, use `data-askable` directly — no `push()` needed:
+
+```tsx
+function CustomTable({ rows }) {
+  return (
+    <table>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr
+            key={row.id}
+            data-askable={JSON.stringify({ widget: 'table', rowIndex: i, ...row })}
+            data-askable-text={`${row.company} — ${row.stage}`}
+          >
+            <td>{row.company}</td>
+            <td>{row.stage}</td>
+            <td>{row.value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+```
+
+Clicks and hovers are tracked automatically — zero extra JavaScript.
+
+## Vue and Svelte
+
+The same `push()` pattern works in all frameworks:
+
+::: code-group
+
+```vue [Vue]
+<script setup>
+import { useAskable } from '@askable-ui/vue';
+
+const { ctx } = useAskable();
+
+function onRowClicked(event) {
+  ctx.push(
+    { widget: 'deals-table', rowIndex: event.rowIndex, ...event.data },
+    event.data.company
+  );
+}
+</script>
+
+<template>
+  <ag-grid-vue :rowData="rowData" @row-clicked="onRowClicked" />
+</template>
+```
+
+```svelte [Svelte]
+<script>
+  import { createAskableStore } from '@askable-ui/svelte';
+
+  const { ctx } = createAskableStore();
+
+  function onRowClicked(event) {
+    ctx.push(
+      { widget: 'deals-table', rowIndex: event.detail.rowIndex, ...event.detail.data },
+      event.detail.data.company
+    );
+  }
+</script>
+
+<AgGridSvelte {rowData} on:rowClicked={onRowClicked} />
+```
+
+:::
+
+## Filtering by source
+
+Use the `source` field to differentiate behavior based on how focus was set:
+
+```ts
+ctx.on('focus', (focus) => {
+  if (focus.source === 'push') {
+    // Programmatic — maybe update a sidebar without auto-opening chat
+    updateSidebar(ctx.toPromptContext());
+  } else if (focus.source === 'select') {
+    // Explicit "Ask AI" — open the chat panel
+    openChatPanel(ctx.toContext({ history: 5 }));
+  }
+  // 'dom' — passive observation, update context silently
+});
+```


### PR DESCRIPTION
## Summary
- New guide page: **Third-Party Libraries** — full integration examples for AG Grid, TanStack Table, Recharts, and Chart.js using `push()`
- Updated **API Reference** (`core.md`, `types.md`) with `push()`, `toContext()`, `AskableFocusSource`, `AskableContextOutputOptions`
- Updated **Focus & History** guide with source field, `push()`, and `toContext()` sections
- Updated **Serialization** guide with `toContext()` combined output
- Updated **select()** guide with `push()` comparison and source field explanation
- Added Third-Party Libraries to sidebar navigation

## Files changed
- `site/docs/guide/third-party-libraries.md` (new)
- `site/docs/api/core.md`
- `site/docs/api/types.md`
- `site/docs/guide/focus-history.md`
- `site/docs/guide/select.md`
- `site/docs/guide/serialization.md`
- `site/docs/.vitepress/config.ts`