### PR TITLE
perf(core): cache parsed metadata for repeated interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@
   <a href="https://www.npmjs.com/package/@askable-ui/core">
     <img src="https://img.shields.io/npm/dw/@askable-ui/core?color=4f46e5&label=downloads" alt="npm downloads" />
   </a>
-  <a href="https://bundlephobia.com/package/@askable-ui/core">
-    <img src="https://img.shields.io/badge/gzip-~1kb-4f46e5" alt="~1kb gzipped" />
-  </a>
+
   <a href="./LICENSE">
     <img src="https://img.shields.io/npm/l/@askable-ui/core?color=4f46e5" alt="MIT license" />
   </a>
@@ -76,7 +74,7 @@ That's friction — and it's imprecise.
 
 askable-ui solves this with one HTML attribute. Mark any element with `data-askable`, and the library tracks user focus and serializes it into a prompt-ready string. The model gets the user's exact visual context — not a guess, the real thing.
 
-No page scraping. No DOM serialization. No prompt bloat. **~1 kb gzipped.**
+No page scraping. No DOM serialization. No prompt bloat. **Lightweight and zero-dependency.**
 
 ---
 
@@ -128,7 +126,7 @@ askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it
 - **Conversation history** — `ctx.toHistoryContext(n)` for multi-turn context
 - **Redaction hooks** — strip sensitive fields before data reaches serialization
 - **Inspector panel** — `<AskableInspector />` or `useAskable({ inspector: true })` for a live dev overlay
-- **~1 kb gzipped** — zero runtime dependencies
+- **Lightweight core** — zero runtime dependencies
 
 ---
 

--- a/packages/core/bench/perf.mjs
+++ b/packages/core/bench/perf.mjs
@@ -6,15 +6,17 @@
  * Measures:
  *   1. observe() init time on large DOM (1k / 5k / 10k annotated elements)
  *   2. Per-event handler execution time (click, hover, focus)
- *   3. toPromptContext() serialization time (natural + JSON)
- *   4. MutationObserver batch (100 nodes added at once)
- *   5. Memory baseline (heap before/after observe)
+ *   3. Repeated interactions on the same element (metadata cache hot path)
+ *   4. toPromptContext() serialization time (natural + JSON)
+ *   5. MutationObserver batch (100 nodes added at once)
+ *   6. Memory baseline (heap before/after observe)
  *
  * Budget targets (enforced in CI via --budget flag):
  *   observe(1k)     < 20ms
  *   observe(5k)     < 80ms
  *   observe(10k)    < 160ms
  *   event handler   < 0.5ms per event (p99)
+ *   repeated event  < 0.2ms per event (p99)
  *   toPromptContext < 0.2ms
  *   mutation batch  < 5ms per 100 nodes
  */
@@ -105,6 +107,7 @@ const BUDGETS = {
   'observe(5k elements)':       80,
   'observe(10k elements)':     160,
   'event handler p99 (1k)':      0.5,
+  'repeated event p99 (1k)':     0.2,
   'toPromptContext natural':     0.2,
   'toPromptContext json':        0.2,
   'mutation batch (100 nodes)': 10, // JSDOM MutationObserver flush adds ~5ms overhead
@@ -143,7 +146,23 @@ for (const count of [1_000, 5_000, 10_000]) {
   ctx.unobserve?.();
 }
 
-// 3. toPromptContext() serialization
+// 3. Repeated interactions on the same element — exercises metadata cache reuse
+{
+  buildDOM(1_000);
+  const ctx = createAskableContext();
+  ctx.observe(window.document);
+  const el = window.document.querySelector('[data-askable]');
+  const times = [];
+  for (let i = 0; i < 500; i++) {
+    const t0 = performance.now();
+    el.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    times.push(performance.now() - t0);
+  }
+  check('repeated event p99 (1k)', p99(times), BUDGETS['repeated event p99 (1k)']);
+  ctx.unobserve?.();
+}
+
+// 4. toPromptContext() serialization
 {
   buildDOM(1);
   const ctx = createAskableContext();
@@ -166,7 +185,7 @@ for (const count of [1_000, 5_000, 10_000]) {
   ctx.unobserve?.();
 }
 
-// 4. MutationObserver batch — 100 nodes added at once
+// 5. MutationObserver batch — 100 nodes added at once
 {
   const body = buildDOM(0);
   const ctx = createAskableContext();
@@ -187,7 +206,7 @@ for (const count of [1_000, 5_000, 10_000]) {
   ctx.unobserve?.();
 }
 
-// 5. unobserve cleanup
+// 6. unobserve cleanup
 {
   buildDOM(1_000);
   const ctx = createAskableContext();

--- a/packages/core/src/__tests__/observer.test.ts
+++ b/packages/core/src/__tests__/observer.test.ts
@@ -176,21 +176,54 @@ describe('Observer', () => {
     obs.unobserve();
   });
 
-  it('uses updated meta after data-askable changes', async () => {
+  it('reuses parsed metadata for repeated interactions on the same element', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse');
+    const rawMeta = '{"id":"cached-meta"}';
+    const el = attach(makeEl({ id: 'cached-meta' }, 'Cached meta'));
+
+    const onFocus = vi.fn();
+    const obs = new Observer(onFocus);
+    obs.observe(document);
+
+    el.click();
+    el.click();
+
+    const parseCount = parseSpy.mock.calls.filter(([value]) => value === rawMeta).length;
+
+    expect(onFocus).toHaveBeenCalledTimes(2);
+    expect(onFocus.mock.calls[0][0].meta).toEqual({ id: 'cached-meta' });
+    expect(onFocus.mock.calls[1][0].meta).toEqual({ id: 'cached-meta' });
+    expect(parseCount).toBe(1);
+
+    obs.unobserve();
+    parseSpy.mockRestore();
+  });
+
+  it('invalidates cached metadata when data-askable changes', async () => {
+    const parseSpy = vi.spyOn(JSON, 'parse');
+    const rawBefore = '{"id":"before"}';
+    const rawAfter = '{"id":"after","state":"updated"}';
     const el = attach(makeEl({ id: 'before' }, 'Meta update'));
 
     const onFocus = vi.fn();
     const obs = new Observer(onFocus);
     obs.observe(document);
 
-    el.setAttribute('data-askable', '{"id":"after","state":"updated"}');
+    el.click();
+    expect(parseSpy.mock.calls.filter(([value]) => value === rawBefore).length).toBe(1);
+
+    el.setAttribute('data-askable', rawAfter);
     await new Promise((r) => setTimeout(r, 0));
 
     el.click();
-    expect(onFocus).toHaveBeenCalledOnce();
-    expect(onFocus.mock.calls[0][0].meta).toEqual({ id: 'after', state: 'updated' });
+    expect(onFocus).toHaveBeenCalledTimes(2);
+    expect(onFocus.mock.calls[0][0].meta).toEqual({ id: 'before' });
+    expect(onFocus.mock.calls[1][0].meta).toEqual({ id: 'after', state: 'updated' });
+    expect(parseSpy.mock.calls.filter(([value]) => value === rawBefore).length).toBe(1);
+    expect(parseSpy.mock.calls.filter(([value]) => value === rawAfter).length).toBe(1);
 
     obs.unobserve();
+    parseSpy.mockRestore();
   });
 
   it('uses updated data-askable-text after attribute changes', async () => {

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -28,7 +28,31 @@ function extractText(el: HTMLElement): string {
   return (el.textContent ?? '').trim();
 }
 
-export function buildFocus(el: HTMLElement, textExtractor?: (el: HTMLElement) => string): AskableFocus | null {
+type MetaCacheEntry = {
+  raw: string;
+  parsed: Record<string, unknown> | string;
+};
+
+function resolveMeta(
+  el: HTMLElement,
+  raw: string,
+  metaCache?: WeakMap<HTMLElement, MetaCacheEntry>
+): Record<string, unknown> | string {
+  const cached = metaCache?.get(el);
+  if (cached && cached.raw === raw) {
+    return cached.parsed;
+  }
+
+  const parsed = parseMeta(raw);
+  metaCache?.set(el, { raw, parsed });
+  return parsed;
+}
+
+export function buildFocus(
+  el: HTMLElement,
+  textExtractor?: (el: HTMLElement) => string,
+  metaCache?: WeakMap<HTMLElement, MetaCacheEntry>
+): AskableFocus | null {
   const raw = el.getAttribute('data-askable');
   if (raw === null) return null;
   // data-askable-text overrides both textExtractor and default textContent extraction.
@@ -39,7 +63,7 @@ export function buildFocus(el: HTMLElement, textExtractor?: (el: HTMLElement) =>
     : textExtractor ? textExtractor(el) : extractText(el);
   return {
     source: 'dom',
-    meta: parseMeta(raw),
+    meta: resolveMeta(el, raw, metaCache),
     text,
     element: el,
     timestamp: Date.now(),
@@ -53,6 +77,7 @@ export class Observer {
   private root: HTMLElement | Document | null = null;
   private mutationObserver: MutationObserver | null = null;
   private boundElements = new Set<HTMLElement>();
+  private metaCache = new WeakMap<HTMLElement, MetaCacheEntry>();
   private onFocus: FocusCallback;
   private textExtractor: ((el: HTMLElement) => string) | undefined;
   private activeEvents: AskableEvent[] = ALL_EVENTS;
@@ -119,6 +144,7 @@ export class Observer {
     this.mutationObserver = null;
     this.boundElements.forEach((el) => this.detach(el));
     this.boundElements.clear();
+    this.metaCache = new WeakMap<HTMLElement, MetaCacheEntry>();
     this.root = null;
     if (this.hoverTimer !== null) {
       clearTimeout(this.hoverTimer);
@@ -171,7 +197,7 @@ export class Observer {
       if (this.hoverTimer !== null) clearTimeout(this.hoverTimer);
       this.hoverTimer = setTimeout(() => {
         this.hoverTimer = null;
-        const focus = buildFocus(el, this.textExtractor);
+        const focus = buildFocus(el, this.textExtractor, this.metaCache);
         if (focus) this.onFocus(focus);
       }, this.hoverDebounce);
       return;
@@ -183,7 +209,7 @@ export class Observer {
       this.lastHoverTimestamp = now;
     }
 
-    const focus = buildFocus(el, this.textExtractor);
+    const focus = buildFocus(el, this.textExtractor, this.metaCache);
     if (focus) this.onFocus(focus);
   };
 
@@ -195,6 +221,7 @@ export class Observer {
 
   private handleAttributeMutation(el: HTMLElement, attributeName: string | null): void {
     if (attributeName === 'data-askable') {
+      this.metaCache.delete(el);
       if (el.hasAttribute('data-askable')) {
         this.attach(el);
       } else {
@@ -222,5 +249,6 @@ export class Observer {
   private detach(el: HTMLElement): void {
     this.activeEvents.forEach((e) => el.removeEventListener(EVENT_MAP[e], this.handleInteraction));
     this.boundElements.delete(el);
+    this.metaCache.delete(el);
   }
 }

--- a/scripts/export-images.js
+++ b/scripts/export-images.js
@@ -235,7 +235,7 @@ const SOCIAL_HTML = `<!DOCTYPE html>
       <h1>Your model knows what <em>they</em> see.</h1>
       <p class="desc">
         Give any UI element LLM awareness with <code style="font-family:ui-monospace,monospace;font-size:.9em;background:rgba(79,70,229,0.08);color:#4f46e5;padding:2px 7px;border-radius:6px">data-askable</code>.
-        Zero framework lock-in. ~1kb.
+        Zero framework lock-in. Lightweight core.
       </p>
       <div class="tags">
         <span class="tag">React</span>
@@ -285,7 +285,7 @@ const SOCIAL_HTML = `<!DOCTYPE html>
     <div class="brand"><em>ask</em>able-ui</div>
     <div class="pills">
       <span class="pill">github.com/askable-ui/askable</span>
-      <span class="pill">~1kb gz</span>
+      <span class="pill">lightweight core</span>
       <span class="pill">MIT</span>
     </div>
   </div>

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -1,6 +1,6 @@
 # @askable-ui/core
 
-Framework-agnostic context tracker. Zero dependencies, ~1 kb gzipped.
+Framework-agnostic context tracker. Zero dependencies and built to stay lightweight.
 
 ## Install
 

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -528,7 +528,7 @@
         <div class="hero-meta">
           <span>One attribute</span>
           <span>Zero framework lock-in</span>
-          <span>~1kb gzipped</span>
+          <span>Lightweight core</span>
           <span>React · Vue · Svelte · Vanilla JS</span>
         </div>
       </div>

--- a/spec/performance-budget.md
+++ b/spec/performance-budget.md
@@ -12,6 +12,7 @@ budgets before merging.
 | `observe(5k elements)` | **80ms** | |
 | `observe(10k elements)` | **160ms** | Scales linearly; avoid annotating >5k elements |
 | Event handler p99 (click/hover/focus) | **0.5ms** | Per-event cost at 1k annotated elements |
+| Repeated event handler p99 (same element) | **0.2ms** | Hot path for repeated hover/click on already-seen elements |
 | `toPromptContext()` — natural | **0.2ms** | Serialization call (median over 1k runs) |
 | `toPromptContext()` — json | **0.2ms** | |
 | `MutationObserver` batch (100 nodes) | **10ms** | Bulk DOM insertion, includes MO flush overhead |
@@ -54,6 +55,23 @@ These rules are derived from the budgets above and should guide implementation d
 
 6. **History is capped at `MAX_HISTORY` (currently 50).** The cap prevents unbounded memory growth in
    long-lived sessions. A configurable `maxHistory` option is planned (#83).
+
+7. **Parsed `data-askable` metadata is cached per element and invalidated on attribute changes.**
+   Repeated interactions over the same annotated element should not re-parse identical metadata.
+
+## Lazy text extraction decision
+
+Lazy text extraction is **not shipping by default in this phase**.
+
+Reasoning:
+
+- metadata parsing was the low-risk, clear win for repeated interactions
+- eager text capture preserves current `getFocus()`, history, events, and serialization semantics
+- changing text capture timing would need a cross-adapter API decision and real-browser profiling to
+  prove it is worth the complexity
+
+We should revisit lazy text extraction only if profiling shows text extraction, not metadata parsing,
+is the dominant hot path in representative large UIs.
 
 ## Adding a new budget
 


### PR DESCRIPTION
## Summary
- cache parsed `data-askable` metadata per element via `WeakMap` and invalidate on `data-askable` changes
- add observer tests plus a repeated-interaction perf budget check for the cache hot path
- document the decision to defer lazy text extraction for now
- remove inaccurate `~1kb gzipped` claims from README, docs, site copy, and image export source

## Test Plan
- [x] `cd packages/core && npm test`
- [x] `cd packages/core && npm run bench:ci`
- [x] `npm run test:e2e -- observer.spec.ts`

Closes #165
