### PR TITLE
feat(core): add named scoped contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ No page scraping. No DOM serialization. No prompt bloat. **Lightweight and zero-
 ```tsx
 const { ctx, promptContext } = useAskable();
 // promptContext updates whenever the user clicks, hovers, or focuses
+
+const { ctx: tableCtx } = useAskable({ name: 'table' });
+const { ctx: chartCtx } = useAskable({ name: 'chart' });
+// named contexts stay isolated for multi-region pages
 ```
 
 **3. Inject** — at the AI boundary, one line

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -14,6 +14,28 @@ function cleanup(el: HTMLElement) {
 }
 
 describe('createAskableContext', () => {
+  it('reuses the same named context instance in the browser', () => {
+    const tableA = createAskableContext({ name: 'table' });
+    const tableB = createAskableContext({ name: 'table' });
+    const chart = createAskableContext({ name: 'chart' });
+
+    expect(tableA).toBe(tableB);
+    expect(chart).not.toBe(tableA);
+
+    tableA.destroy();
+    chart.destroy();
+  });
+
+  it('keeps unnamed contexts independent', () => {
+    const first = createAskableContext();
+    const second = createAskableContext();
+
+    expect(first).not.toBe(second);
+
+    first.destroy();
+    second.destroy();
+  });
+
   it('returns an object with the expected methods', () => {
     const ctx = createAskableContext();
     expect(typeof ctx.observe).toBe('function');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,7 +26,25 @@ export type {
 import { AskableContextImpl } from './context.js';
 import type { AskableContext, AskableContextOptions } from './types.js';
 
+const namedContexts = new Map<string, AskableContext>();
+
 /** Create a new AskableContext instance */
 export function createAskableContext(options?: AskableContextOptions): AskableContext {
-  return new AskableContextImpl(options);
+  const name = options?.name?.trim();
+
+  if (typeof window === 'undefined' || !name) {
+    return new AskableContextImpl(options);
+  }
+
+  const existing = namedContexts.get(name);
+  if (existing) return existing;
+
+  const ctx = new AskableContextImpl(options);
+  const originalDestroy = ctx.destroy.bind(ctx);
+  ctx.destroy = () => {
+    namedContexts.delete(name);
+    originalDestroy();
+  };
+  namedContexts.set(name, ctx);
+  return ctx;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -112,6 +112,11 @@ export interface AskablePromptContextOptions {
  */
 export interface AskableContextOptions {
   /**
+   * Optional name for reusing a shared context instance across the same page/runtime.
+   * Unnamed contexts remain independent.
+   */
+  name?: string;
+  /**
    * Custom text extractor called for each focused element.
    * Receives the DOM element, returns the text to use as `AskableFocus.text`.
    * Defaults to `el.textContent?.trim() ?? ''`.

--- a/packages/react/src/__tests__/useAskable.test.tsx
+++ b/packages/react/src/__tests__/useAskable.test.tsx
@@ -164,6 +164,55 @@ describe('useAskable', () => {
     ctxB.destroy();
   });
 
+  it('reuses the same named shared context across consumers', async () => {
+    const seen: AskableContext[] = [];
+
+    function NamedConsumer({ label }: { label: string }) {
+      const { ctx } = useAskable({ name: 'table' });
+      useEffect(() => {
+        seen.push(ctx);
+      }, [ctx]);
+      return <span data-testid={`named-${label}`}>ready</span>;
+    }
+
+    const first = render(<NamedConsumer label="one" />);
+    await flushMicrotasks();
+
+    const second = render(<NamedConsumer label="two" />);
+    await flushMicrotasks();
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBe(seen[1]);
+
+    second.unmount();
+    first.unmount();
+  });
+
+  it('keeps different named shared contexts isolated', async () => {
+    const seen: AskableContext[] = [];
+
+    function NamedConsumer({ name }: { name: string }) {
+      const { ctx } = useAskable({ name });
+      useEffect(() => {
+        seen.push(ctx);
+      }, [ctx]);
+      return null;
+    }
+
+    const view = render(
+      <>
+        <NamedConsumer name="table" />
+        <NamedConsumer name="chart" />
+      </>
+    );
+    await flushMicrotasks();
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).not.toBe(seen[1]);
+
+    view.unmount();
+  });
+
   it('observes the shared global context only once for multiple consumers with the same events', async () => {
     let capturedCtx: ReturnType<typeof createAskableContext> | null = null;
 

--- a/packages/react/src/useAskable.ts
+++ b/packages/react/src/useAskable.ts
@@ -15,22 +15,27 @@ function getEventsKey(events?: AskableEvent[]): string {
   return normalizeEvents(events).join('|');
 }
 
-function getGlobalCtx(events?: AskableEvent[]): AskableContext {
+function getSharedKey(name?: string, events?: AskableEvent[]): string {
+  const scope = name?.trim() ? `name:${name.trim()}` : 'global';
+  return `${scope}::${getEventsKey(events)}`;
+}
+
+function getGlobalCtx(options?: UseAskableOptions): AskableContext {
   // During SSR (no window), never persist to the module-level singleton —
   // each render gets a fresh throwaway context so requests don't share state.
   if (typeof window === 'undefined') {
-    return createAskableContext();
+    return createAskableContext(options);
   }
-  const key = getEventsKey(events);
+  const key = getSharedKey(options?.name, options?.events);
   const existing = globalCtxByEvents.get(key);
   if (existing) return existing;
-  const ctx = createAskableContext();
+  const ctx = createAskableContext(options);
   globalCtxByEvents.set(key, ctx);
   return ctx;
 }
 
-function retainGlobalCtx(ctx: AskableContext, events?: AskableEvent[]): void {
-  const key = getEventsKey(events);
+function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEvent[]): void {
+  const key = getSharedKey(name, events);
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) + 1;
   globalRefCountByEvents.set(key, nextCount);
   if (nextCount === 1 && typeof document !== 'undefined') {
@@ -38,8 +43,8 @@ function retainGlobalCtx(ctx: AskableContext, events?: AskableEvent[]): void {
   }
 }
 
-function releaseGlobalCtx(events?: AskableEvent[]): void {
-  const key = getEventsKey(events);
+function releaseGlobalCtx(name?: string, events?: AskableEvent[]): void {
+  const key = getSharedKey(name, events);
   const ctx = globalCtxByEvents.get(key);
   if (!ctx) return;
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) - 1;
@@ -81,16 +86,17 @@ function hasContextCreationOptions(options?: UseAskableOptions): boolean {
 
 export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const usesProvidedCtx = Boolean(options?.ctx);
-  // Use a private context when context-creation options are specified
-  const usePrivateCtx = !usesProvidedCtx && hasContextCreationOptions(options);
+  const usesNamedSharedCtx = !usesProvidedCtx && Boolean(options?.name?.trim());
+  // Use a private context when context-creation options are specified without a shared name
+  const usePrivateCtx = !usesProvidedCtx && !usesNamedSharedCtx && hasContextCreationOptions(options);
 
-  const eventsKey = getEventsKey(options?.events);
+  const sharedKey = getSharedKey(options?.name, options?.events);
   const privateCtxRef = useRef<AskableContext | null>(null);
 
   const sharedCtx = useMemo<AskableContext | null>(() => {
     if (options?.ctx || usePrivateCtx) return null;
-    return getGlobalCtx(options?.events);
-  }, [options?.ctx, usePrivateCtx, eventsKey]);
+    return getGlobalCtx(options);
+  }, [options?.ctx, usePrivateCtx, sharedKey]);
 
   if (!options?.ctx && usePrivateCtx && !privateCtxRef.current) {
     privateCtxRef.current = createAskableContext(options);
@@ -117,7 +123,7 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
           current.observe(document, { events: options?.events });
         }
       } else {
-        retainGlobalCtx(current, options?.events);
+        retainGlobalCtx(current, options?.name, options?.events);
       }
     }
 
@@ -143,11 +149,11 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
             privateCtxRef.current = null;
           }
         } else {
-          releaseGlobalCtx(options?.events);
+          releaseGlobalCtx(options?.name, options?.events);
         }
       }
     };
-  }, [ctx, eventsKey, usesProvidedCtx, usePrivateCtx, inspectorKey]);
+  }, [ctx, sharedKey, usesProvidedCtx, usePrivateCtx, inspectorKey]);
 
   return {
     focus,

--- a/packages/svelte/src/__tests__/store.test.ts
+++ b/packages/svelte/src/__tests__/store.test.ts
@@ -75,6 +75,19 @@ describe('createAskableStore', () => {
     expect(get(store.focus)).toBeNull();
   });
 
+  it('reuses the same named context across stores', () => {
+    const tableA = createAskableStore({ name: 'table' });
+    const tableB = createAskableStore({ name: 'table' });
+    const chart = createAskableStore({ name: 'chart' });
+
+    expect(tableA.ctx).toBe(tableB.ctx);
+    expect(chart.ctx).not.toBe(tableA.ctx);
+
+    tableA.destroy();
+    tableB.destroy();
+    chart.destroy();
+  });
+
   it('accepts a scoped ctx and reflects events from it', async () => {
     const { createAskableContext } = await import('@askable-ui/core');
     const scopedCtx = createAskableContext();

--- a/packages/svelte/src/askable.ts
+++ b/packages/svelte/src/askable.ts
@@ -1,8 +1,8 @@
 import { writable, derived, readonly } from 'svelte/store';
 import { createAskableContext, createAskableInspector } from '@askable-ui/core';
-import type { AskableEvent, AskableFocus, AskableContext, AskableInspectorOptions } from '@askable-ui/core';
+import type { AskableEvent, AskableFocus, AskableContext, AskableInspectorOptions, AskableContextOptions } from '@askable-ui/core';
 
-export interface AskableStoreOptions {
+export interface AskableStoreOptions extends Pick<AskableContextOptions, 'name'> {
   events?: AskableEvent[];
   ctx?: AskableContext;
   inspector?: boolean | AskableInspectorOptions;
@@ -17,7 +17,7 @@ export interface AskableStore {
 
 export function createAskableStore(options?: AskableStoreOptions) {
   const usesProvidedCtx = Boolean(options?.ctx);
-  const ctx = options?.ctx ?? createAskableContext();
+  const ctx = options?.ctx ?? createAskableContext(options?.name ? { name: options.name } : undefined);
 
   if (!usesProvidedCtx && typeof document !== 'undefined') {
     ctx.observe(document, { events: options?.events });

--- a/packages/vue/src/__tests__/useAskable.test.ts
+++ b/packages/vue/src/__tests__/useAskable.test.ts
@@ -139,6 +139,32 @@ describe('useAskable (Vue)', () => {
     expect(wrapper2.text()).toBe('null');
   });
 
+  it('reuses the same named shared context across consumers', async () => {
+    const seen: unknown[] = [];
+
+    const NamedConsumer = defineComponent({
+      name: 'NamedConsumer',
+      props: { label: { type: String, required: true } },
+      setup() {
+        const { ctx } = useAskable({ name: 'table' });
+        seen.push(ctx);
+        return {};
+      },
+      template: `<span>ready</span>`,
+    });
+
+    const wrapperA = track(mount(NamedConsumer, { attachTo: document.body, props: { label: 'one' } }));
+    await flushAll();
+    const wrapperB = track(mount(NamedConsumer, { attachTo: document.body, props: { label: 'two' } }));
+    await flushAll();
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBe(seen[1]);
+
+    wrapperB.unmount();
+    wrapperA.unmount();
+  });
+
   it('observes the shared global context only once for multiple consumers with the same events', async () => {
     let capturedCtx: ReturnType<typeof import('@askable-ui/core').createAskableContext> | null = null;
 

--- a/packages/vue/src/useAskable.ts
+++ b/packages/vue/src/useAskable.ts
@@ -15,22 +15,27 @@ function getEventsKey(events?: AskableEvent[]): string {
   return normalizeEvents(events).join('|');
 }
 
-function getGlobalCtx(events?: AskableEvent[]): AskableContext {
+function getSharedKey(name?: string, events?: AskableEvent[]): string {
+  const scope = name?.trim() ? `name:${name.trim()}` : 'global';
+  return `${scope}::${getEventsKey(events)}`;
+}
+
+function getGlobalCtx(options?: UseAskableOptions): AskableContext {
   // During SSR (no window), never persist to the module-level singleton —
   // each render gets a fresh throwaway context so requests don't share state.
   if (typeof window === 'undefined') {
-    return createAskableContext();
+    return createAskableContext(options);
   }
-  const key = getEventsKey(events);
+  const key = getSharedKey(options?.name, options?.events);
   const existing = globalCtxByEvents.get(key);
   if (existing) return existing;
-  const ctx = createAskableContext();
+  const ctx = createAskableContext(options);
   globalCtxByEvents.set(key, ctx);
   return ctx;
 }
 
-function retainGlobalCtx(ctx: AskableContext, events?: AskableEvent[]): void {
-  const key = getEventsKey(events);
+function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEvent[]): void {
+  const key = getSharedKey(name, events);
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) + 1;
   globalRefCountByEvents.set(key, nextCount);
   if (nextCount === 1 && typeof document !== 'undefined') {
@@ -38,8 +43,8 @@ function retainGlobalCtx(ctx: AskableContext, events?: AskableEvent[]): void {
   }
 }
 
-function releaseGlobalCtx(events?: AskableEvent[]): void {
-  const key = getEventsKey(events);
+function releaseGlobalCtx(name?: string, events?: AskableEvent[]): void {
+  const key = getSharedKey(name, events);
   const ctx = globalCtxByEvents.get(key);
   if (!ctx) return;
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) - 1;
@@ -81,10 +86,11 @@ function hasContextCreationOptions(options?: UseAskableOptions): boolean {
 
 export function useAskable(options?: UseAskableOptions) {
   const usesProvidedCtx = Boolean(options?.ctx);
-  // Use a private context when context-creation options are specified
-  const usePrivateCtx = !usesProvidedCtx && hasContextCreationOptions(options);
+  const usesNamedSharedCtx = !usesProvidedCtx && Boolean(options?.name?.trim());
+  // Use a private context when context-creation options are specified without a shared name
+  const usePrivateCtx = !usesProvidedCtx && !usesNamedSharedCtx && hasContextCreationOptions(options);
 
-  const ctx = options?.ctx ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx(options?.events));
+  const ctx = options?.ctx ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx(options));
   const focus = ref<AskableFocus | null>(ctx.getFocus());
   // Reference focus.value so Vue tracks it as a reactive dependency;
   // ctx.toPromptContext() is a plain method and not itself reactive.
@@ -109,7 +115,7 @@ export function useAskable(options?: UseAskableOptions) {
           ctx.observe(document, { events: options?.events });
         }
       } else {
-        retainGlobalCtx(ctx, options?.events);
+        retainGlobalCtx(ctx, options?.name, options?.events);
       }
     }
     ctx.on('focus', handler);
@@ -129,7 +135,7 @@ export function useAskable(options?: UseAskableOptions) {
       if (usePrivateCtx) {
         ctx.destroy();
       } else {
-        releaseGlobalCtx(options?.events);
+        releaseGlobalCtx(options?.name, options?.events);
       }
     }
   });

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -39,7 +39,7 @@ import { Askable } from '@askable-ui/react';
 
 ## `useAskable(options?)`
 
-Hook that provides reactive access to a shared `AskableContext` for the requested `events` configuration. Observation starts after mount; additional consumers with the same `events` reuse the existing observer instead of re-observing the document. Differing `events` configurations get isolated shared contexts, each destroyed when its last consumer unmounts.
+Hook that provides reactive access to a shared `AskableContext` for the requested `events` configuration. Observation starts after mount; additional consumers with the same `events` reuse the existing observer instead of re-observing the document. Differing `events` configurations get isolated shared contexts, each destroyed when its last consumer unmounts. Pass `name` to scope that shared lifecycle to a specific UI region (for example `table` vs `chart`).
 
 ```ts
 import { useAskable } from '@askable-ui/react';
@@ -51,8 +51,9 @@ const { focus, promptContext, ctx } = useAskable();
 
 | Option | Type | Description |
 |---|---|---|
+| `name` | `string` | Optional shared context name for region-scoped context reuse |
 | `events` | `AskableEvent[]` | Trigger events. Default: `['click', 'hover', 'focus']` |
-| `ctx` | `AskableContext` | Provide a custom context instead of the global singleton |
+| `ctx` | `AskableContext` | Provide a custom context instead of the shared singleton |
 
 **Returns:**
 

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -30,6 +30,11 @@ Options passed to `createAskableContext()`.
 ```ts
 interface AskableContextOptions {
   /**
+   * Optional shared context name. Contexts with the same name reuse one instance
+   * in the same page/runtime; unnamed contexts remain independent.
+   */
+  name?: string;
+  /**
    * Custom text extractor. Defaults to el.textContent?.trim() ?? ''
    * Applied at capture time.
    */

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -35,7 +35,7 @@ Renders a wrapper element with `data-askable` managed reactively from `:meta`.
 
 ## `useAskable(options?)`
 
-Composable that provides reactive access to a shared `AskableContext` for the requested `events` configuration. Observation starts in `onMounted()`; additional consumers with the same `events` reuse the existing observer instead of re-observing the document. Differing `events` configurations get isolated shared contexts, each destroyed when its last consumer unmounts.
+Composable that provides reactive access to a shared `AskableContext` for the requested `events` configuration. Observation starts in `onMounted()`; additional consumers with the same `events` reuse the existing observer instead of re-observing the document. Differing `events` configurations get isolated shared contexts, each destroyed when its last consumer unmounts. Pass `name` to scope that shared lifecycle to a specific UI region (for example `table` vs `chart`).
 
 ```ts
 import { useAskable } from '@askable-ui/vue';
@@ -50,6 +50,7 @@ const { focus, promptContext, ctx } = useAskable();
 
 | Option | Type | Description |
 |---|---|---|
+| `name` | `string` | Optional shared context name for region-scoped context reuse |
 | `events` | `AskableEvent[]` | Trigger events. Default: `['click', 'hover', 'focus']` |
 
 **Returns:**


### PR DESCRIPTION
## Summary
- add named context reuse in `createAskableContext({ name })` for browser runtimes
- scope shared React and Vue hook instances by `name` plus `events`
- pass named contexts through Svelte stores and document region-scoped usage

## Test Plan
- [x] `npm run build`
- [x] `npm test`

Closes #145
