### PR TITLE
feat(core): add viewport-aware context APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ const { ctx, promptContext } = useAskable();
 const { ctx: tableCtx } = useAskable({ name: 'table' });
 const { ctx: chartCtx } = useAskable({ name: 'chart' });
 // named contexts stay isolated for multi-region pages
+
+const { ctx: screenCtx } = useAskable({ viewport: true });
+// screenCtx.toViewportContext() serializes currently visible annotated elements
 ```
 
 **3. Inject** — at the AI boundary, one line
@@ -128,6 +131,7 @@ askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it
 - **SSR safe** — defers to client lifecycle, no `window is not defined`
 - **"Ask AI" button** — `ctx.select(element)` pins focus to any element programmatically
 - **Conversation history** — `ctx.toHistoryContext(n)` for multi-turn context
+- **Viewport awareness** — `ctx.getVisibleElements()` / `ctx.toViewportContext()` for on-screen context
 - **Redaction hooks** — strip sensitive fields before data reaches serialization
 - **Inspector panel** — `<AskableInspector />` or `useAskable({ inspector: true })` for a live dev overlay
 - **Lightweight core** — zero runtime dependencies

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createAskableContext } from '../index.js';
 
 function makeEl(meta: object | string, text = 'Hello'): HTMLElement {
@@ -12,6 +12,44 @@ function makeEl(meta: object | string, text = 'Hello'): HTMLElement {
 function cleanup(el: HTMLElement) {
   document.body.removeChild(el);
 }
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  callback: IntersectionObserverCallback;
+  observed = new Set<Element>();
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe = (el: Element) => {
+    this.observed.add(el);
+  };
+
+  unobserve = (el: Element) => {
+    this.observed.delete(el);
+  };
+
+  disconnect = () => {
+    this.observed.clear();
+  };
+
+  trigger(entries: Array<{ target: Element; isIntersecting: boolean }>) {
+    this.callback(
+      entries.map((entry) => ({
+        target: entry.target,
+        isIntersecting: entry.isIntersecting,
+        intersectionRatio: entry.isIntersecting ? 1 : 0,
+      })) as IntersectionObserverEntry[],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+afterEach(() => {
+  MockIntersectionObserver.instances = [];
+});
 
 describe('createAskableContext', () => {
   it('reuses the same named context instance in the browser', () => {
@@ -44,6 +82,8 @@ describe('createAskableContext', () => {
     expect(typeof ctx.off).toBe('function');
     expect(typeof ctx.toPromptContext).toBe('function');
     expect(typeof (ctx as any).serializeFocus).toBe('function');
+    expect(typeof (ctx as any).getVisibleElements).toBe('function');
+    expect(typeof (ctx as any).toViewportContext).toBe('function');
     expect(typeof ctx.destroy).toBe('function');
     ctx.destroy();
   });
@@ -53,6 +93,33 @@ describe('createAskableContext', () => {
     ctx.observe(document);
     expect(ctx.getFocus()).toBeNull();
     ctx.destroy();
+  });
+
+  it('tracks visible annotated elements when viewport mode is enabled', () => {
+    const originalIntersectionObserver = globalThis.IntersectionObserver;
+    globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+    const first = makeEl({ widget: 'table' }, 'Table');
+    const second = makeEl({ widget: 'chart' }, 'Chart');
+    const ctx = createAskableContext({ viewport: true });
+    ctx.observe(document);
+
+    const observer = MockIntersectionObserver.instances[0];
+    observer.trigger([
+      { target: first, isIntersecting: true },
+      { target: second, isIntersecting: true },
+    ]);
+
+    const visible = (ctx as any).getVisibleElements();
+    expect(visible).toHaveLength(2);
+    expect(visible.map((item: { meta: Record<string, unknown> }) => item.meta.widget)).toEqual(['table', 'chart']);
+    expect((ctx as any).toViewportContext()).toContain('table');
+    expect((ctx as any).toViewportContext()).toContain('chart');
+
+    ctx.destroy();
+    cleanup(first);
+    cleanup(second);
+    globalThis.IntersectionObserver = originalIntersectionObserver;
   });
 
   it('getFocus() returns correct data after simulated click', () => {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -26,6 +26,9 @@ export class AskableContextImpl implements AskableContext {
   private observer: Observer;
   private currentFocus: AskableFocus | null = null;
   private history: AskableFocus[] = [];
+  private visibleElements = new Set<HTMLElement>();
+  private intersectionObserver: IntersectionObserver | null = null;
+  private viewportEnabled: boolean;
   private maxHistory: number;
   private textExtractor: ((el: HTMLElement) => string) | undefined;
   private sanitizeMetaFn: ((meta: Record<string, unknown>) => Record<string, unknown>) | undefined;
@@ -35,6 +38,7 @@ export class AskableContextImpl implements AskableContext {
     this.textExtractor = options?.textExtractor;
     this.sanitizeMetaFn = options?.sanitizeMeta;
     this.sanitizeTextFn = options?.sanitizeText;
+    this.viewportEnabled = options?.viewport ?? false;
     this.maxHistory = options?.maxHistory ?? DEFAULT_MAX_HISTORY;
     this.observer = new Observer((rawFocus) => {
       const focus = this.applySanitizers(rawFocus);
@@ -44,7 +48,13 @@ export class AskableContextImpl implements AskableContext {
         if (this.history.length > this.maxHistory) this.history.shift();
       }
       this.emitter.emit('focus', focus);
-    }, this.textExtractor);
+    }, this.textExtractor, {
+      onAttach: (el) => this.intersectionObserver?.observe(el),
+      onDetach: (el) => {
+        this.intersectionObserver?.unobserve(el);
+        this.visibleElements.delete(el);
+      },
+    });
   }
 
   private applySanitizers(focus: AskableFocus): AskableFocus {
@@ -57,6 +67,21 @@ export class AskableContextImpl implements AskableContext {
   }
 
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void {
+    if (this.viewportEnabled && typeof IntersectionObserver !== 'undefined') {
+      this.intersectionObserver?.disconnect();
+      this.visibleElements.clear();
+      this.intersectionObserver = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          const el = entry.target as HTMLElement;
+          if (entry.isIntersecting) {
+            this.visibleElements.add(el);
+          } else {
+            this.visibleElements.delete(el);
+          }
+        });
+      });
+    }
+
     this.observer.observe(
       root,
       options?.events,
@@ -67,6 +92,9 @@ export class AskableContextImpl implements AskableContext {
   }
 
   unobserve(): void {
+    this.intersectionObserver?.disconnect();
+    this.intersectionObserver = null;
+    this.visibleElements.clear();
     this.observer.unobserve();
   }
 
@@ -77,6 +105,13 @@ export class AskableContextImpl implements AskableContext {
   getHistory(limit?: number): AskableFocus[] {
     const hist = this.history.slice().reverse();
     return limit !== undefined ? hist.slice(0, limit) : hist;
+  }
+
+  getVisibleElements(): AskableFocus[] {
+    return Array.from(this.visibleElements)
+      .map((el) => buildFocus(el, this.textExtractor))
+      .filter((focus): focus is AskableFocus => Boolean(focus))
+      .map((focus) => this.applySanitizers(focus));
   }
 
   on<K extends AskableEventName>(event: K, handler: AskableEventHandler<K>): void {
@@ -143,6 +178,17 @@ export class AskableContextImpl implements AskableContext {
     return this.applyTokenBudget(output, resolved.maxTokens);
   }
 
+  toViewportContext(options?: AskablePromptContextOptions): string {
+    const resolved = this.resolveOptions(options);
+    const visible = this.getVisibleElements();
+    if (visible.length === 0) return resolved.format === 'json' ? '[]' : 'No annotated UI elements are currently visible.';
+    if (resolved.format === 'json') {
+      return JSON.stringify(visible.map((focus) => this.serializeFocusFrom(focus, resolved)));
+    }
+    const lines = visible.map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
+    return this.applyTokenBudget(lines.join('\n'), resolved.maxTokens);
+  }
+
   toContext(options?: AskableContextOutputOptions): string {
     const { history: historyCount = 0, currentLabel = 'Current', historyLabel = 'Recent interactions', ...promptOptions } = options ?? {};
     const resolved = this.resolveOptions(promptOptions);
@@ -165,10 +211,11 @@ export class AskableContextImpl implements AskableContext {
   }
 
   destroy(): void {
-    this.observer.unobserve();
+    this.unobserve();
     this.emitter.clear();
     this.currentFocus = null;
     this.history = [];
+    this.visibleElements.clear();
   }
 
   private normalizeMeta(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,15 +36,16 @@ export function createAskableContext(options?: AskableContextOptions): AskableCo
     return new AskableContextImpl(options);
   }
 
-  const existing = namedContexts.get(name);
+  const key = `${name}::viewport:${options?.viewport ? 'on' : 'off'}`;
+  const existing = namedContexts.get(key);
   if (existing) return existing;
 
   const ctx = new AskableContextImpl(options);
   const originalDestroy = ctx.destroy.bind(ctx);
   ctx.destroy = () => {
-    namedContexts.delete(name);
+    namedContexts.delete(key);
     originalDestroy();
   };
-  namedContexts.set(name, ctx);
+  namedContexts.set(key, ctx);
   return ctx;
 }

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -1,6 +1,10 @@
 import type { AskableFocus, AskableEvent, AskableTargetStrategy } from './types.js';
 
 type FocusCallback = (focus: AskableFocus) => void;
+type ObserverLifecycleCallbacks = {
+  onAttach?: (el: HTMLElement) => void;
+  onDetach?: (el: HTMLElement) => void;
+};
 
 const EVENT_MAP: Record<AskableEvent, string> = {
   click: 'click',
@@ -79,6 +83,7 @@ export class Observer {
   private boundElements = new Set<HTMLElement>();
   private metaCache = new WeakMap<HTMLElement, MetaCacheEntry>();
   private onFocus: FocusCallback;
+  private lifecycleCallbacks: ObserverLifecycleCallbacks;
   private textExtractor: ((el: HTMLElement) => string) | undefined;
   private activeEvents: AskableEvent[] = ALL_EVENTS;
   private targetStrategy: AskableTargetStrategy = 'deepest';
@@ -87,9 +92,14 @@ export class Observer {
   private hoverTimer: ReturnType<typeof setTimeout> | null = null;
   private lastHoverTimestamp = 0;
 
-  constructor(onFocus: FocusCallback, textExtractor?: (el: HTMLElement) => string) {
+  constructor(
+    onFocus: FocusCallback,
+    textExtractor?: (el: HTMLElement) => string,
+    lifecycleCallbacks: ObserverLifecycleCallbacks = {}
+  ) {
     this.onFocus = onFocus;
     this.textExtractor = textExtractor;
+    this.lifecycleCallbacks = lifecycleCallbacks;
   }
 
   observe(
@@ -115,18 +125,18 @@ export class Observer {
       for (const mutation of mutations) {
         if (mutation.type === 'attributes') {
           const target = mutation.target;
-          if (target instanceof HTMLElement) {
+          if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) {
             this.handleAttributeMutation(target, mutation.attributeName);
           }
           continue;
         }
         mutation.addedNodes.forEach((node) => {
-          if (!(node instanceof HTMLElement)) return;
+          if (!(typeof HTMLElement !== 'undefined' && node instanceof HTMLElement)) return;
           if (node.hasAttribute('data-askable')) this.attach(node);
           node.querySelectorAll<HTMLElement>('[data-askable]').forEach((el) => this.attach(el));
         });
         mutation.removedNodes.forEach((node) => {
-          if (node instanceof HTMLElement) this.detachTree(node);
+          if (typeof HTMLElement !== 'undefined' && node instanceof HTMLElement) this.detachTree(node);
         });
       }
     });
@@ -217,6 +227,7 @@ export class Observer {
     if (this.boundElements.has(el)) return;
     this.activeEvents.forEach((e) => el.addEventListener(EVENT_MAP[e], this.handleInteraction));
     this.boundElements.add(el);
+    this.lifecycleCallbacks.onAttach?.(el);
   }
 
   private handleAttributeMutation(el: HTMLElement, attributeName: string | null): void {
@@ -250,5 +261,6 @@ export class Observer {
     this.activeEvents.forEach((e) => el.removeEventListener(EVENT_MAP[e], this.handleInteraction));
     this.boundElements.delete(el);
     this.metaCache.delete(el);
+    this.lifecycleCallbacks.onDetach?.(el);
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -117,6 +117,11 @@ export interface AskableContextOptions {
    */
   name?: string;
   /**
+   * Track which annotated elements are currently visible in the viewport.
+   * Off by default to avoid extra observer overhead.
+   */
+  viewport?: boolean;
+  /**
    * Custom text extractor called for each focused element.
    * Receives the DOM element, returns the text to use as `AskableFocus.text`.
    * Defaults to `el.textContent?.trim() ?? ''`.
@@ -179,6 +184,8 @@ export interface AskableContext {
   getFocus(): AskableFocus | null;
   /** Return the focus history, newest first. Optional limit caps the result. */
   getHistory(limit?: number): AskableFocus[];
+  /** Return all annotated elements currently visible in the viewport. */
+  getVisibleElements(): AskableFocus[];
   /** Subscribe to an event */
   on<K extends AskableEventName>(event: K, handler: AskableEventHandler<K>): void;
   /** Unsubscribe from an event */
@@ -195,6 +202,8 @@ export interface AskableContext {
   toPromptContext(options?: AskablePromptContextOptions): string;
   /** Serialize focus history to a prompt-ready string (newest first). Optional limit caps the entries returned. */
   toHistoryContext(limit?: number, options?: AskablePromptContextOptions): string;
+  /** Serialize visible viewport elements to a prompt-ready string. */
+  toViewportContext(options?: AskablePromptContextOptions): string;
   /** Combined current focus + history in a single prompt-ready string */
   toContext(options?: AskableContextOutputOptions): string;
   /** Clean up all listeners and observers */

--- a/packages/react/src/__tests__/useAskable.test.tsx
+++ b/packages/react/src/__tests__/useAskable.test.tsx
@@ -103,6 +103,24 @@ describe('useAskable', () => {
     expect(prompt).toContain('revenue');
   });
 
+  it('can create a viewport-aware context via hook options', () => {
+    let seenCtx: AskableContext | null = null;
+
+    function ViewportConsumer() {
+      const { ctx } = useAskable({ viewport: true });
+      useEffect(() => {
+        seenCtx = ctx;
+      }, [ctx]);
+      return null;
+    }
+
+    const view = render(<ViewportConsumer />);
+    expect(seenCtx).not.toBeNull();
+    expect(typeof (seenCtx as any).getVisibleElements).toBe('function');
+    expect(typeof (seenCtx as any).toViewportContext).toBe('function');
+    view.unmount();
+  });
+
   it('can use an explicitly provided scoped context', async () => {
     const ctx = createAskableContext();
     ctx.observe(document, { events: ['click'] });

--- a/packages/react/src/useAskable.ts
+++ b/packages/react/src/useAskable.ts
@@ -15,9 +15,10 @@ function getEventsKey(events?: AskableEvent[]): string {
   return normalizeEvents(events).join('|');
 }
 
-function getSharedKey(name?: string, events?: AskableEvent[]): string {
+function getSharedKey(name?: string, events?: AskableEvent[], viewport?: boolean): string {
   const scope = name?.trim() ? `name:${name.trim()}` : 'global';
-  return `${scope}::${getEventsKey(events)}`;
+  const viewportKey = viewport ? 'viewport:on' : 'viewport:off';
+  return `${scope}::${getEventsKey(events)}::${viewportKey}`;
 }
 
 function getGlobalCtx(options?: UseAskableOptions): AskableContext {
@@ -26,7 +27,7 @@ function getGlobalCtx(options?: UseAskableOptions): AskableContext {
   if (typeof window === 'undefined') {
     return createAskableContext(options);
   }
-  const key = getSharedKey(options?.name, options?.events);
+  const key = getSharedKey(options?.name, options?.events, options?.viewport);
   const existing = globalCtxByEvents.get(key);
   if (existing) return existing;
   const ctx = createAskableContext(options);
@@ -34,8 +35,8 @@ function getGlobalCtx(options?: UseAskableOptions): AskableContext {
   return ctx;
 }
 
-function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEvent[]): void {
-  const key = getSharedKey(name, events);
+function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEvent[], viewport?: boolean): void {
+  const key = getSharedKey(name, events, viewport);
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) + 1;
   globalRefCountByEvents.set(key, nextCount);
   if (nextCount === 1 && typeof document !== 'undefined') {
@@ -43,8 +44,8 @@ function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEve
   }
 }
 
-function releaseGlobalCtx(name?: string, events?: AskableEvent[]): void {
-  const key = getSharedKey(name, events);
+function releaseGlobalCtx(name?: string, events?: AskableEvent[], viewport?: boolean): void {
+  const key = getSharedKey(name, events, viewport);
   const ctx = globalCtxByEvents.get(key);
   if (!ctx) return;
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) - 1;
@@ -90,7 +91,7 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
   // Use a private context when context-creation options are specified without a shared name
   const usePrivateCtx = !usesProvidedCtx && !usesNamedSharedCtx && hasContextCreationOptions(options);
 
-  const sharedKey = getSharedKey(options?.name, options?.events);
+  const sharedKey = getSharedKey(options?.name, options?.events, options?.viewport);
   const privateCtxRef = useRef<AskableContext | null>(null);
 
   const sharedCtx = useMemo<AskableContext | null>(() => {
@@ -123,7 +124,7 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
           current.observe(document, { events: options?.events });
         }
       } else {
-        retainGlobalCtx(current, options?.name, options?.events);
+        retainGlobalCtx(current, options?.name, options?.events, options?.viewport);
       }
     }
 
@@ -149,7 +150,7 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
             privateCtxRef.current = null;
           }
         } else {
-          releaseGlobalCtx(options?.name, options?.events);
+          releaseGlobalCtx(options?.name, options?.events, options?.viewport);
         }
       }
     };

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@askable-ui/core': fileURLToPath(new URL('../core/src/index.ts', import.meta.url)),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   resolve: {
     conditions: ['browser'],
+    alias: {
+      '@askable-ui/core': fileURLToPath(new URL('../core/src/index.ts', import.meta.url)),
+    },
   },
   plugins: [svelte({ hot: false, preprocess: vitePreprocess() })],
   test: {

--- a/packages/vue/src/useAskable.ts
+++ b/packages/vue/src/useAskable.ts
@@ -15,9 +15,10 @@ function getEventsKey(events?: AskableEvent[]): string {
   return normalizeEvents(events).join('|');
 }
 
-function getSharedKey(name?: string, events?: AskableEvent[]): string {
+function getSharedKey(name?: string, events?: AskableEvent[], viewport?: boolean): string {
   const scope = name?.trim() ? `name:${name.trim()}` : 'global';
-  return `${scope}::${getEventsKey(events)}`;
+  const viewportKey = viewport ? 'viewport:on' : 'viewport:off';
+  return `${scope}::${getEventsKey(events)}::${viewportKey}`;
 }
 
 function getGlobalCtx(options?: UseAskableOptions): AskableContext {
@@ -26,7 +27,7 @@ function getGlobalCtx(options?: UseAskableOptions): AskableContext {
   if (typeof window === 'undefined') {
     return createAskableContext(options);
   }
-  const key = getSharedKey(options?.name, options?.events);
+  const key = getSharedKey(options?.name, options?.events, options?.viewport);
   const existing = globalCtxByEvents.get(key);
   if (existing) return existing;
   const ctx = createAskableContext(options);
@@ -34,8 +35,8 @@ function getGlobalCtx(options?: UseAskableOptions): AskableContext {
   return ctx;
 }
 
-function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEvent[]): void {
-  const key = getSharedKey(name, events);
+function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEvent[], viewport?: boolean): void {
+  const key = getSharedKey(name, events, viewport);
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) + 1;
   globalRefCountByEvents.set(key, nextCount);
   if (nextCount === 1 && typeof document !== 'undefined') {
@@ -43,8 +44,8 @@ function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEve
   }
 }
 
-function releaseGlobalCtx(name?: string, events?: AskableEvent[]): void {
-  const key = getSharedKey(name, events);
+function releaseGlobalCtx(name?: string, events?: AskableEvent[], viewport?: boolean): void {
+  const key = getSharedKey(name, events, viewport);
   const ctx = globalCtxByEvents.get(key);
   if (!ctx) return;
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) - 1;
@@ -115,7 +116,7 @@ export function useAskable(options?: UseAskableOptions) {
           ctx.observe(document, { events: options?.events });
         }
       } else {
-        retainGlobalCtx(ctx, options?.name, options?.events);
+        retainGlobalCtx(ctx, options?.name, options?.events, options?.viewport);
       }
     }
     ctx.on('focus', handler);
@@ -135,7 +136,7 @@ export function useAskable(options?: UseAskableOptions) {
       if (usePrivateCtx) {
         ctx.destroy();
       } else {
-        releaseGlobalCtx(options?.name, options?.events);
+        releaseGlobalCtx(options?.name, options?.events, options?.viewport);
       }
     }
   });

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@askable-ui/core': fileURLToPath(new URL('../core/src/index.ts', import.meta.url)),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -28,12 +28,16 @@ const ctx = createAskableContext({
   sanitizeMeta: ({ password, ssn, ...safe }) => safe,
   sanitizeText: (text) => text.replace(/\b\d{16}\b/g, '[card]'),
 });
+
+// Track all annotated elements currently visible in the viewport
+const viewportCtx = createAskableContext({ viewport: true });
 ```
 
 **Options (`AskableContextOptions`):**
 
 | Option | Type | Description |
 |---|---|---|
+| `viewport` | `boolean` | Enable viewport tracking via `IntersectionObserver`. Default: `false`. |
 | `textExtractor` | `(el: HTMLElement) => string` | Custom text extractor. Defaults to `el.textContent?.trim()`. Applied at capture time. |
 | `sanitizeMeta` | `(meta: Record<string, unknown>) => Record<string, unknown>` | Redact/transform object meta before storing. Not called for string meta. Applied at capture time. |
 | `sanitizeText` | `(text: string) => string` | Redact/transform text content before storing. Applied at capture time. |

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -52,6 +52,7 @@ const { focus, promptContext, ctx } = useAskable();
 | Option | Type | Description |
 |---|---|---|
 | `name` | `string` | Optional shared context name for region-scoped context reuse |
+| `viewport` | `boolean` | Enable viewport-aware context tracking for this hook's context |
 | `events` | `AskableEvent[]` | Trigger events. Default: `['click', 'hover', 'focus']` |
 | `ctx` | `AskableContext` | Provide a custom context instead of the shared singleton |
 

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -35,6 +35,11 @@ interface AskableContextOptions {
    */
   name?: string;
   /**
+   * Track which annotated elements are currently visible in the viewport.
+   * Off by default to avoid extra observer overhead.
+   */
+  viewport?: boolean;
+  /**
    * Custom text extractor. Defaults to el.textContent?.trim() ?? ''
    * Applied at capture time.
    */

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -51,6 +51,7 @@ const { focus, promptContext, ctx } = useAskable();
 | Option | Type | Description |
 |---|---|---|
 | `name` | `string` | Optional shared context name for region-scoped context reuse |
+| `viewport` | `boolean` | Enable viewport-aware context tracking for this composable's context |
 | `events` | `AskableEvent[]` | Trigger events. Default: `['click', 'hover', 'focus']` |
 
 **Returns:**


### PR DESCRIPTION
## Summary
- add `viewport: true` context support backed by `IntersectionObserver`
- expose `ctx.getVisibleElements()` and `ctx.toViewportContext()` for on-screen context
- keep React and Vue shared hook contexts isolated by viewport mode
- alias core source in adapter Vitest configs so workspace tests use fresh core code
- document viewport-aware usage in README and API docs

## Test Plan
- [x] `npm run build`
- [x] `npm test`

## Versioning
- no version bump in this PR; batch with the next grouped feature/release cut

Closes #123
