### PR TITLE
docs: add react-native site docs

### DIFF
--- a/site/docs/api/react-native.md
+++ b/site/docs/api/react-native.md
@@ -1,0 +1,78 @@
+# @askable-ui/react-native
+
+React Native bindings for askable-ui.
+
+This initial slice focuses on explicit mobile interactions: `useAskable()` provides a context backed by `@askable-ui/core`, and `<Askable />` turns `onPress` / `onLongPress` interactions into prompt-ready focus updates.
+
+## Install
+
+```bash
+npm install @askable-ui/react-native @askable-ui/core
+```
+
+---
+
+## `<Askable>`
+
+Clones a single React Native pressable child and merges focus updates into its `onPress` and `onLongPress` handlers.
+
+```tsx
+import { Pressable, Text } from 'react-native';
+import { Askable, useAskable } from '@askable-ui/react-native';
+
+function RevenueCard() {
+  const { ctx } = useAskable();
+
+  return (
+    <Askable ctx={ctx} meta={{ widget: 'revenue' }} text="Revenue card">
+      <Pressable>
+        <Text>Revenue</Text>
+      </Pressable>
+    </Askable>
+  );
+}
+```
+
+**Props:**
+
+| Prop | Type | Description |
+|---|---|---|
+| `ctx` | `AskableContext` | Context instance that receives focus updates |
+| `meta` | `Record<string, unknown> \| string` | Metadata pushed into the context on press |
+| `text` | `string` | Optional human-readable label stored alongside `meta` |
+| `children` | `ReactElement` | A single child that accepts `onPress` / `onLongPress` props |
+
+---
+
+## `useAskable(options?)`
+
+Returns a React Native-friendly wrapper around an `AskableContext`.
+
+```ts
+import { useAskable } from '@askable-ui/react-native';
+
+const { focus, promptContext, ctx } = useAskable();
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `ctx` | `AskableContext` | Reuse an existing context instead of creating a new one |
+| `name` | `string` | Optional context name passed through to `createAskableContext()` |
+| `viewport` | `boolean` | Optional viewport-aware core context mode |
+| `events` | `AskableEvent[]` | Forwarded to the underlying core context |
+
+**Returns:**
+
+| Value | Type | Description |
+|---|---|---|
+| `focus` | `AskableFocus \| null` | Current focus created by press-driven updates |
+| `promptContext` | `string` | Natural-language context string for your LLM prompt |
+| `ctx` | `AskableContext` | Full context instance for `push()`, `clear()`, `toHistoryContext()`, etc. |
+
+## Notes
+
+- This adapter currently covers press-driven context updates.
+- Navigation integration and ScrollView visibility tracking are planned follow-up work.
+- Existing child `onPress` / `onLongPress` handlers are preserved and still run.

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -8,6 +8,10 @@
 npm install @askable-ui/react @askable-ui/core
 ```
 
+```bash [React Native]
+npm install @askable-ui/react-native @askable-ui/core
+```
+
 ```bash [Vue]
 npm install @askable-ui/vue @askable-ui/core
 ```
@@ -48,6 +52,23 @@ import { Askable } from '@askable-ui/react';
 </Askable>
 ```
 
+```tsx [React Native]
+import { Pressable, Text } from 'react-native';
+import { Askable, useAskable } from '@askable-ui/react-native';
+
+function RevenueCard() {
+  const { ctx } = useAskable();
+
+  return (
+    <Askable ctx={ctx} meta={{ metric: 'revenue', delta: '-12%', period: 'Q3' }} text="Revenue card">
+      <Pressable>
+        <Text>Revenue</Text>
+      </Pressable>
+    </Askable>
+  );
+}
+```
+
 ```vue [Vue]
 <Askable :meta="{ metric: 'revenue', delta: '-12%', period: 'Q3' }">
   <RevenueChart />
@@ -75,6 +96,13 @@ function App() {
   const { promptContext } = useAskable(); // starts observing automatically
   // ...
 }
+```
+
+```ts [React Native]
+import { useAskable } from '@askable-ui/react-native';
+
+const { promptContext } = useAskable();
+// promptContext updates when Askable-wrapped press targets are pressed or long-pressed
 ```
 
 ```ts [Vue]

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -23,7 +23,7 @@ features:
 
   - icon: ⚡
     title: Framework-native bindings
-    details: First-class hooks and components for React, Vue, and Svelte. Each binding is reactive, SSR-safe, and ships zero runtime dependencies beyond @askable-ui/core.
+    details: First-class hooks and components for React, React Native, Vue, and Svelte. Web bindings are reactive and SSR-safe; React Native ships a focused press-driven adapter on top of @askable-ui/core.
 
   - icon: 🎯
     title: Precision control
@@ -58,6 +58,23 @@ function Dashboard({ data }) {
   return (
     <Askable meta={{ metric: 'revenue', delta: data.delta }}>
       <RevenueChart data={data} />
+    </Askable>
+  );
+}
+```
+
+```tsx [React Native]
+import { Pressable, Text } from 'react-native';
+import { useAskable, Askable } from '@askable-ui/react-native';
+
+function RevenueCard() {
+  const { ctx, promptContext } = useAskable();
+
+  return (
+    <Askable ctx={ctx} meta={{ metric: 'revenue' }} text="Revenue card">
+      <Pressable>
+        <Text>Revenue</Text>
+      </Pressable>
     </Askable>
   );
 }


### PR DESCRIPTION
## Summary
- add a dedicated React Native API docs page
- add React Native examples to the docs homepage quick-look section
- add React Native install and usage snippets to getting started

## Why
`@askable-ui/react-native` is now live on npm, but the docs site still only surfaced React, Vue, and Svelte. This makes the new package hard to discover and inconsistent with the README.

## Validation
- reviewed the docs diff for homepage, getting-started, and API coverage
- confirmed `@askable-ui/react-native@0.4.1` is live on npm

Partial progress toward #125.
