### PR TITLE
feat: add react-native screen awareness hook

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -2,9 +2,10 @@
 
 React Native bindings for askable.
 
-## First slice
+## Current slice
 
 - `useAskable()` hook backed by `@askable-ui/core`
+- `useAskableScreen()` hook for screen/navigation-aware context updates
 - `<Askable ctx={...}>` wrapper that turns `onPress` / `onLongPress` into context updates
 
 ## Example
@@ -23,5 +24,28 @@ export function RevenueCard() {
       </Pressable>
     </Askable>
   );
+}
+```
+
+## Screen awareness
+
+Use `useAskableScreen()` to push the active screen into context. It is designed to pair cleanly with React Navigation's `useIsFocused()` without forcing a hard dependency on React Navigation inside this package.
+
+```tsx
+import { useIsFocused } from '@react-navigation/native';
+import { useAskable, useAskableScreen } from '@askable-ui/react-native';
+
+export function RevenueScreen() {
+  const isFocused = useIsFocused();
+  const { ctx, promptContext } = useAskable();
+
+  useAskableScreen({
+    ctx,
+    active: isFocused,
+    meta: { screen: 'RevenueScreen' },
+    text: 'Revenue screen',
+  });
+
+  return null;
 }
 ```

--- a/packages/react-native/src/__tests__/useAskable.test.tsx
+++ b/packages/react-native/src/__tests__/useAskable.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { useAskable } from '../useAskable';
+import { useAskable, useAskableScreen } from '../index';
 import type { AskableContext } from '@askable-ui/core';
 
 describe('useAskable (React Native)', () => {
@@ -41,5 +41,64 @@ describe('useAskable (React Native)', () => {
       text: 'Revenue card',
       source: 'push',
     });
+  });
+
+  it('pushes active screen context into the shared askable context', () => {
+    let seenCtx: AskableContext | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      useAskableScreen({
+        ctx,
+        meta: { screen: 'RevenueScreen' },
+        text: 'Revenue screen',
+        active: true,
+      });
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { screen: 'RevenueScreen' },
+      text: 'Revenue screen',
+      source: 'push',
+    });
+  });
+
+  it('clears screen context when the screen becomes inactive', () => {
+    let seenCtx: AskableContext | null = null;
+    let renderer: TestRenderer.ReactTestRenderer;
+
+    function Consumer({ active }: { active: boolean }) {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      useAskableScreen({
+        ctx,
+        meta: { screen: 'RevenueScreen' },
+        text: 'Revenue screen',
+        active,
+      });
+      return null;
+    }
+
+    act(() => {
+      renderer = TestRenderer.create(<Consumer active={true} />);
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { screen: 'RevenueScreen' },
+      text: 'Revenue screen',
+      source: 'push',
+    });
+
+    act(() => {
+      renderer!.update(<Consumer active={false} />);
+    });
+
+    expect(seenCtx!.getFocus()).toBeNull();
   });
 });

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,4 +1,6 @@
 export { Askable } from './Askable.js';
 export { useAskable } from './useAskable.js';
+export { useAskableScreen } from './useAskableScreen.js';
 export type { AskableProps } from './Askable.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
+export type { UseAskableScreenOptions } from './useAskableScreen.js';

--- a/packages/react-native/src/useAskableScreen.ts
+++ b/packages/react-native/src/useAskableScreen.ts
@@ -1,0 +1,43 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createAskableContext } from '@askable-ui/core';
+import type { AskableContext, AskableContextOptions } from '@askable-ui/core';
+
+export interface UseAskableScreenOptions extends AskableContextOptions {
+  /** Provide an existing context instead of creating a new one. */
+  ctx?: AskableContext;
+  /** Screen metadata to push when the screen is active. */
+  meta: Record<string, unknown> | string;
+  /** Optional human-readable text stored alongside the screen metadata. */
+  text?: string;
+  /** Whether this screen is currently active/focused. */
+  active?: boolean;
+  /** Whether to clear the context when the screen becomes inactive. */
+  clearOnBlur?: boolean;
+}
+
+export function useAskableScreen(options: UseAskableScreenOptions): AskableContext {
+  const { active = true, clearOnBlur = true, ctx, meta, text = '' } = options;
+  const [screenCtx] = useState<AskableContext>(() => ctx ?? createAskableContext(options));
+  const metaKey = useMemo(
+    () => (typeof meta === 'string' ? meta : JSON.stringify(meta)),
+    [meta]
+  );
+
+  useEffect(() => {
+    if (active) {
+      screenCtx.push(meta, text);
+    } else if (clearOnBlur) {
+      screenCtx.clear();
+    }
+  }, [active, clearOnBlur, metaKey, screenCtx, text]);
+
+  useEffect(() => {
+    return () => {
+      if (!ctx) {
+        screenCtx.destroy();
+      }
+    };
+  }, [ctx, screenCtx]);
+
+  return screenCtx;
+}

--- a/site/docs/api/react-native.md
+++ b/site/docs/api/react-native.md
@@ -2,7 +2,7 @@
 
 React Native bindings for askable-ui.
 
-This initial slice focuses on explicit mobile interactions: `useAskable()` provides a context backed by `@askable-ui/core`, and `<Askable />` turns `onPress` / `onLongPress` interactions into prompt-ready focus updates.
+This initial slice focuses on explicit mobile interactions: `useAskable()` provides a context backed by `@askable-ui/core`, `useAskableScreen()` lets you mirror screen focus into that context, and `<Askable />` turns `onPress` / `onLongPress` interactions into prompt-ready focus updates.
 
 ## Install
 
@@ -71,8 +71,43 @@ const { focus, promptContext, ctx } = useAskable();
 | `promptContext` | `string` | Natural-language context string for your LLM prompt |
 | `ctx` | `AskableContext` | Full context instance for `push()`, `clear()`, `toHistoryContext()`, etc. |
 
+## `useAskableScreen(options)`
+
+Pushes screen-level context into the shared `AskableContext` while a screen is active.
+
+```tsx
+import { useIsFocused } from '@react-navigation/native';
+import { useAskable, useAskableScreen } from '@askable-ui/react-native';
+
+function RevenueScreen() {
+  const isFocused = useIsFocused();
+  const { ctx } = useAskable();
+
+  useAskableScreen({
+    ctx,
+    active: isFocused,
+    meta: { screen: 'RevenueScreen' },
+    text: 'Revenue screen',
+  });
+
+  return null;
+}
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `ctx` | `AskableContext` | Reuse an existing context instead of creating a new one |
+| `meta` | `Record<string, unknown> \| string` | Screen metadata pushed when the screen is active |
+| `text` | `string` | Optional label stored alongside the screen metadata |
+| `active` | `boolean` | Whether the screen is currently focused. Default: `true` |
+| `clearOnBlur` | `boolean` | Clear the context when the screen becomes inactive. Default: `true` |
+| `name` / `viewport` / `events` | Core options | Forwarded when the hook creates its own context |
+
 ## Notes
 
-- This adapter currently covers press-driven context updates.
-- Navigation integration and ScrollView visibility tracking are planned follow-up work.
+- This adapter currently covers press-driven interactions plus lightweight screen-awareness.
+- `useAskableScreen()` is designed to pair with React Navigation's `useIsFocused()` or a similar focus signal.
+- ScrollView visibility tracking is still planned follow-up work.
 - Existing child `onPress` / `onLongPress` handlers are preserved and still run.


### PR DESCRIPTION
## Summary
- add `useAskableScreen()` to the React Native adapter
- let RN apps push screen-level context when a screen is focused
- document the intended pairing with React Navigation's `useIsFocused()`
- add tests for active-screen push and blur clearing behavior

## Why
The initial React Native slice shipped press-driven context updates, but issue #125 also calls for navigation awareness. This PR adds a small, shippable screen-awareness layer without taking a hard dependency on React Navigation inside the package.

## Validation
- `npm test -w packages/react-native`
- `npm run build -w packages/react-native`
- `npm run build`
- `npm test`

No version bump included. Partial progress toward #125.
