### PR TITLE
feat(react-native): add visibility tracking hook

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,4 +3,4 @@
 This directory contains runnable or in-progress example apps for Askable.
 
 - `copilotkit-react/` — scaffold for the React-based Askable integration example
-- `react-native-expo/` — runnable Expo example showing screen-aware and press-aware mobile context capture
+- `react-native-expo/` — runnable Expo example showing screen-aware, visibility-aware, and press-aware mobile context capture

--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -3,6 +3,7 @@ import { NavigationContainer, useIsFocused } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
 import {
+  FlatList,
   Pressable,
   SafeAreaView,
   ScrollView,
@@ -11,7 +12,7 @@ import {
   View,
 } from 'react-native';
 import type { AskableContext } from '@askable-ui/core';
-import { Askable, useAskable, useAskableScreen } from '@askable-ui/react-native';
+import { Askable, useAskable, useAskableScreen, useAskableVisibility } from '@askable-ui/react-native';
 
 type RootStackParamList = {
   Dashboard: undefined;
@@ -54,7 +55,17 @@ const insightActions = [
     meta: { panel: 'launch-feedback', question: 'Summarize launch feedback themes' },
     text: 'Launch feedback summary panel',
   },
+  {
+    title: 'Review retention outliers',
+    caption: 'Three enterprise accounts dipped below their 90-day baseline.',
+    meta: { panel: 'retention-outliers', question: 'What changed for the at-risk accounts?' },
+    text: 'Retention outliers panel',
+  },
 ] as const;
+
+const insightViewabilityConfig = {
+  itemVisiblePercentThreshold: 70,
+};
 
 function PromptContextPanel({ promptContext }: { promptContext: string }) {
   return (
@@ -127,26 +138,40 @@ function InsightsScreen({
     text: 'Insights analysis screen',
   });
 
-  return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
-      <Text style={styles.eyebrow}>Navigation-aware context</Text>
-      <Text style={styles.title}>Insights</Text>
-      <Text style={styles.subtitle}>
-        Each screen pushes its own metadata while focused. Press any action card to refine the
-        context further.
-      </Text>
+  const { onViewableItemsChanged } = useAskableVisibility({
+    ctx,
+    active: isFocused,
+    getMeta: (item) => ({ ...item.meta, visible: true, source: 'list-viewability' }),
+    getText: (item) => `${item.title} is currently leading the visible insights list`,
+  });
 
-      {insightActions.map((action) => (
-        <Askable key={action.title} ctx={ctx} meta={action.meta} text={action.text}>
+  return (
+    <FlatList
+      data={insightActions}
+      contentContainerStyle={styles.screenContent}
+      keyExtractor={(item) => item.title}
+      onViewableItemsChanged={onViewableItemsChanged}
+      viewabilityConfig={insightViewabilityConfig}
+      ListHeaderComponent={
+        <>
+          <Text style={styles.eyebrow}>Navigation-aware + visibility-aware context</Text>
+          <Text style={styles.title}>Insights</Text>
+          <Text style={styles.subtitle}>
+            Each screen pushes its own metadata while focused. Scroll the list to see the currently
+            visible card lead askable context, then tap an action card to refine it further.
+          </Text>
+        </>
+      }
+      renderItem={({ item }) => (
+        <Askable key={item.title} ctx={ctx} meta={item.meta} text={item.text}>
           <Pressable style={styles.card}>
-            <Text style={styles.cardTitle}>{action.title}</Text>
-            <Text style={styles.cardCaption}>{action.caption}</Text>
+            <Text style={styles.cardTitle}>{item.title}</Text>
+            <Text style={styles.cardCaption}>{item.caption}</Text>
           </Pressable>
         </Askable>
-      ))}
-
-      <PromptContextPanel promptContext={promptContext} />
-    </ScrollView>
+      )}
+      ListFooterComponent={<PromptContextPanel promptContext={promptContext} />}
+    />
   );
 }
 

--- a/examples/react-native-expo/README.md
+++ b/examples/react-native-expo/README.md
@@ -6,6 +6,7 @@ A runnable Expo app that demonstrates how `@askable-ui/react-native` captures mo
 
 - Shared `AskableContext` created with `useAskable()`
 - Screen-level context updates with `useAskableScreen()` and React Navigation's `useIsFocused()`
+- Visibility-driven list context updates with `useAskableVisibility()`
 - Press-driven focus updates with `<Askable>` wrappers around `Pressable` cards
 - A live prompt preview panel showing what an AI layer would receive
 
@@ -26,7 +27,8 @@ Then open the project in Expo Go, an iOS simulator, or an Android emulator.
 3. Notice the **Prompt context** panel update with the selected card metadata.
 4. Open the **Insights** screen.
 5. Notice the screen-level context changes because `useAskableScreen()` is bound to navigation focus.
-6. Tap an insight action card to further refine the prompt context.
+6. Scroll the insights list and watch the leading visible card update context through `useAskableVisibility()`.
+7. Tap an insight action card to further refine the prompt context.
 
 ## Key integration snippet
 
@@ -40,6 +42,15 @@ useAskableScreen({
   meta: { screen: 'Insights', section: 'analysis' },
   text: 'Insights analysis screen',
 });
+
+const { onViewableItemsChanged } = useAskableVisibility({
+  ctx,
+  active: isFocused,
+  getMeta: (item) => ({ ...item.meta, visible: true }),
+  getText: (item) => `${item.title} is visible`,
+});
+
+<FlatList onViewableItemsChanged={onViewableItemsChanged} /* ... */ />;
 
 <Askable ctx={ctx} meta={{ panel: 'dropoff-analysis' }} text="Drop-off analysis panel">
   <Pressable>{/* ... */}</Pressable>

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -6,6 +6,7 @@ React Native bindings for askable.
 
 - `useAskable()` hook backed by `@askable-ui/core`
 - `useAskableScreen()` hook for screen/navigation-aware context updates
+- `useAskableVisibility()` hook for FlatList / SectionList visibility-driven context updates
 - `<Askable ctx={...}>` wrapper that turns `onPress` / `onLongPress` into context updates
 - Runnable Expo example in [`examples/react-native-expo`](../../examples/react-native-expo)
 
@@ -48,5 +49,41 @@ export function RevenueScreen() {
   });
 
   return null;
+}
+```
+
+## List visibility awareness
+
+Use `useAskableVisibility()` with `FlatList` / `SectionList` viewability callbacks to mirror the top visible item into askable context while the user scrolls.
+
+```tsx
+import { FlatList, Text, View } from 'react-native';
+import { useAskable, useAskableVisibility } from '@askable-ui/react-native';
+
+const products = [
+  { id: 'p-1', title: 'Revenue Dashboard' },
+  { id: 'p-2', title: 'Pipeline Summary' },
+];
+
+export function ProductList() {
+  const { ctx } = useAskable();
+  const { onViewableItemsChanged } = useAskableVisibility({
+    ctx,
+    getMeta: (item) => ({ productId: item.id }),
+    getText: (item) => item.title,
+  });
+
+  return (
+    <FlatList
+      data={products}
+      keyExtractor={(item) => item.id}
+      onViewableItemsChanged={onViewableItemsChanged}
+      renderItem={({ item }) => (
+        <View>
+          <Text>{item.title}</Text>
+        </View>
+      )}
+    />
+  );
 }
 ```

--- a/packages/react-native/src/__tests__/useAskable.test.tsx
+++ b/packages/react-native/src/__tests__/useAskable.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { useAskable, useAskableScreen } from '../index';
+import { useAskable, useAskableScreen, useAskableVisibility } from '../index';
 import type { AskableContext } from '@askable-ui/core';
 
 describe('useAskable (React Native)', () => {
@@ -97,6 +97,127 @@ describe('useAskable (React Native)', () => {
 
     act(() => {
       renderer!.update(<Consumer active={false} />);
+    });
+
+    expect(seenCtx!.getFocus()).toBeNull();
+  });
+
+  it('pushes the first visible item from viewability updates into the shared askable context', () => {
+    let seenCtx: AskableContext | null = null;
+    let onViewableItemsChanged: ((info: { viewableItems: Array<{ item: unknown; index?: number | null; isViewable?: boolean }> }) => void) | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      onViewableItemsChanged = useAskableVisibility({
+        ctx,
+        getMeta: (item) => ({ productId: (item as { id: string }).id }),
+        getText: (item) => (item as { title: string }).title,
+      }).onViewableItemsChanged;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      onViewableItemsChanged!({
+        viewableItems: [
+          { item: { id: 'p-1', title: 'Revenue Dashboard' }, index: 0, isViewable: true },
+          { item: { id: 'p-2', title: 'Pipeline Summary' }, index: 1, isViewable: true },
+        ],
+      });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { productId: 'p-1' },
+      text: 'Revenue Dashboard',
+      source: 'push',
+    });
+  });
+
+  it('clears visibility context when no items remain visible', () => {
+    let seenCtx: AskableContext | null = null;
+    let onViewableItemsChanged: ((info: { viewableItems: Array<{ item: unknown; index?: number | null; isViewable?: boolean }> }) => void) | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      onViewableItemsChanged = useAskableVisibility({
+        ctx,
+        getMeta: (item) => ({ productId: (item as { id: string }).id }),
+        getText: (item) => (item as { title: string }).title,
+      }).onViewableItemsChanged;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      onViewableItemsChanged!({
+        viewableItems: [{ item: { id: 'p-1', title: 'Revenue Dashboard' }, index: 0, isViewable: true }],
+      });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { productId: 'p-1' },
+      text: 'Revenue Dashboard',
+      source: 'push',
+    });
+
+    act(() => {
+      onViewableItemsChanged!({ viewableItems: [] });
+    });
+
+    expect(seenCtx!.getFocus()).toBeNull();
+  });
+
+  it('ignores visibility updates while inactive and clears existing focus on blur by default', () => {
+    let seenCtx: AskableContext | null = null;
+    let onViewableItemsChanged: ((info: { viewableItems: Array<{ item: unknown; index?: number | null; isViewable?: boolean }> }) => void) | null = null;
+    let renderer: TestRenderer.ReactTestRenderer;
+
+    function Consumer({ active }: { active: boolean }) {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      onViewableItemsChanged = useAskableVisibility({
+        ctx,
+        active,
+        getMeta: (item) => ({ productId: (item as { id: string }).id }),
+        getText: (item) => (item as { title: string }).title,
+      }).onViewableItemsChanged;
+      return null;
+    }
+
+    act(() => {
+      renderer = TestRenderer.create(<Consumer active={true} />);
+    });
+
+    act(() => {
+      onViewableItemsChanged!({
+        viewableItems: [{ item: { id: 'p-1', title: 'Revenue Dashboard' }, index: 0, isViewable: true }],
+      });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { productId: 'p-1' },
+      text: 'Revenue Dashboard',
+      source: 'push',
+    });
+
+    act(() => {
+      renderer!.update(<Consumer active={false} />);
+    });
+
+    expect(seenCtx!.getFocus()).toBeNull();
+
+    act(() => {
+      onViewableItemsChanged!({
+        viewableItems: [{ item: { id: 'p-2', title: 'Pipeline Summary' }, index: 1, isViewable: true }],
+      });
     });
 
     expect(seenCtx!.getFocus()).toBeNull();

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,6 +1,13 @@
 export { Askable } from './Askable.js';
 export { useAskable } from './useAskable.js';
 export { useAskableScreen } from './useAskableScreen.js';
+export { useAskableVisibility } from './useAskableVisibility.js';
 export type { AskableProps } from './Askable.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
 export type { UseAskableScreenOptions } from './useAskableScreen.js';
+export type {
+  AskableViewToken,
+  AskableViewabilityInfo,
+  UseAskableVisibilityOptions,
+  UseAskableVisibilityResult,
+} from './useAskableVisibility.js';

--- a/packages/react-native/src/useAskableVisibility.ts
+++ b/packages/react-native/src/useAskableVisibility.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from 'react';
+import { createAskableContext } from '@askable-ui/core';
+import type { AskableContext, AskableContextOptions } from '@askable-ui/core';
+
+export interface AskableViewToken<Item = unknown> {
+  item?: Item;
+  key?: string | null;
+  index?: number | null;
+  isViewable?: boolean;
+  section?: unknown;
+}
+
+export interface AskableViewabilityInfo<Item = unknown> {
+  viewableItems: AskableViewToken<Item>[];
+  changed?: AskableViewToken<Item>[];
+}
+
+export interface UseAskableVisibilityOptions<Item = unknown> extends AskableContextOptions {
+  /** Provide an existing context instead of creating a new one. */
+  ctx?: AskableContext;
+  /** Whether visibility updates should currently affect the context. */
+  active?: boolean;
+  /** Whether to clear the context when visibility tracking becomes inactive. */
+  clearOnBlur?: boolean;
+  /** Map a visible item into the metadata pushed into askable. */
+  getMeta: (item: Item, token: AskableViewToken<Item>) => Record<string, unknown> | string;
+  /** Optional label stored alongside the visible item metadata. */
+  getText?: (item: Item, token: AskableViewToken<Item>) => string;
+  /** Pick which currently visible item should win focus. Defaults to the first viewable item. */
+  selectViewable?: (tokens: AskableViewToken<Item>[]) => AskableViewToken<Item> | null;
+}
+
+export interface UseAskableVisibilityResult<Item = unknown> {
+  ctx: AskableContext;
+  onViewableItemsChanged: (info: AskableViewabilityInfo<Item>) => void;
+  clearVisibleItem: () => void;
+}
+
+function defaultSelectViewable<Item>(tokens: AskableViewToken<Item>[]): AskableViewToken<Item> | null {
+  return tokens.find((token) => token.item !== undefined && token.isViewable !== false) ?? null;
+}
+
+export function useAskableVisibility<Item = unknown>(
+  options: UseAskableVisibilityOptions<Item>
+): UseAskableVisibilityResult<Item> {
+  const {
+    active = true,
+    clearOnBlur = true,
+    ctx,
+    getMeta,
+    getText,
+    selectViewable = defaultSelectViewable,
+  } = options;
+  const [visibilityCtx] = useState<AskableContext>(() => ctx ?? createAskableContext(options));
+
+  const clearVisibleItem = useCallback(() => {
+    visibilityCtx.clear();
+  }, [visibilityCtx]);
+
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: AskableViewabilityInfo<Item>) => {
+      if (!active) {
+        return;
+      }
+
+      const selected = selectViewable(viewableItems);
+      if (!selected || selected.item === undefined) {
+        clearVisibleItem();
+        return;
+      }
+
+      const item = selected.item;
+      visibilityCtx.push(getMeta(item, selected), getText?.(item, selected) ?? '');
+    },
+    [active, clearVisibleItem, getMeta, getText, selectViewable, visibilityCtx]
+  );
+
+  useEffect(() => {
+    if (!active && clearOnBlur) {
+      visibilityCtx.clear();
+    }
+  }, [active, clearOnBlur, visibilityCtx]);
+
+  useEffect(() => {
+    return () => {
+      if (!ctx) {
+        visibilityCtx.destroy();
+      }
+    };
+  }, [ctx, visibilityCtx]);
+
+  return {
+    ctx: visibilityCtx,
+    onViewableItemsChanged,
+    clearVisibleItem,
+  };
+}

--- a/site/docs/api/react-native.md
+++ b/site/docs/api/react-native.md
@@ -2,7 +2,7 @@
 
 React Native bindings for askable-ui.
 
-This initial slice focuses on explicit mobile interactions: `useAskable()` provides a context backed by `@askable-ui/core`, `useAskableScreen()` lets you mirror screen focus into that context, and `<Askable />` turns `onPress` / `onLongPress` interactions into prompt-ready focus updates.
+This initial slice focuses on explicit mobile interactions: `useAskable()` provides a context backed by `@askable-ui/core`, `useAskableScreen()` lets you mirror screen focus into that context, `useAskableVisibility()` mirrors viewability updates from mobile lists, and `<Askable />` turns `onPress` / `onLongPress` interactions into prompt-ready focus updates.
 
 A runnable Expo reference app lives in [`examples/react-native-expo`](https://github.com/askable-ui/askable/tree/main/examples/react-native-expo).
 
@@ -107,9 +107,57 @@ function RevenueScreen() {
 | `clearOnBlur` | `boolean` | Clear the context when the screen becomes inactive. Default: `true` |
 | `name` / `viewport` / `events` | Core options | Forwarded when the hook creates its own context |
 
+## `useAskableVisibility(options)`
+
+Mirrors `FlatList` / `SectionList` viewability callbacks into the shared `AskableContext`.
+
+```tsx
+import { FlatList, Text, View } from 'react-native';
+import { useAskable, useAskableVisibility } from '@askable-ui/react-native';
+
+const rows = [
+  { id: 'deal-1', title: 'Enterprise renewal' },
+  { id: 'deal-2', title: 'Expansion pipeline' },
+];
+
+function DealsList() {
+  const { ctx } = useAskable();
+  const { onViewableItemsChanged } = useAskableVisibility({
+    ctx,
+    getMeta: (item) => ({ dealId: item.id }),
+    getText: (item) => item.title,
+  });
+
+  return (
+    <FlatList
+      data={rows}
+      keyExtractor={(item) => item.id}
+      onViewableItemsChanged={onViewableItemsChanged}
+      renderItem={({ item }) => (
+        <View>
+          <Text>{item.title}</Text>
+        </View>
+      )}
+    />
+  );
+}
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `ctx` | `AskableContext` | Reuse an existing context instead of creating a new one |
+| `active` | `boolean` | Whether visibility updates should currently affect focus. Default: `true` |
+| `clearOnBlur` | `boolean` | Clear existing visibility focus when tracking becomes inactive. Default: `true` |
+| `getMeta` | `(item, token) => Record<string, unknown> \| string` | Maps the visible row into askable metadata |
+| `getText` | `(item, token) => string` | Optional human-readable label stored alongside the metadata |
+| `selectViewable` | `(tokens) => token \| null` | Override which visible token should win focus. Default: the first visible item |
+| `name` / `viewport` / `events` | Core options | Forwarded when the hook creates its own context |
+
 ## Notes
 
-- This adapter currently covers press-driven interactions plus lightweight screen-awareness.
+- This adapter currently covers press-driven interactions, lightweight screen-awareness, and list viewability callbacks.
 - `useAskableScreen()` is designed to pair with React Navigation's `useIsFocused()` or a similar focus signal.
-- ScrollView visibility tracking is still planned follow-up work.
+- `useAskableVisibility()` is ideal for `FlatList` / `SectionList`; raw `ScrollView` measurement is still follow-up work.
 - Existing child `onPress` / `onLongPress` handlers are preserved and still run.


### PR DESCRIPTION
## Summary
- add `useAskableVisibility()` to mirror React Native list viewability callbacks into askable context
- cover the new hook with React Native adapter tests for visible-item selection, clearing, and inactive state
- document the API and update the Expo example/docs to show visibility-aware mobile context

## Test Plan
- [x] `zsh -lc 'cd ~/projects/askable && npm run build'`
- [x] `zsh -lc 'cd ~/projects/askable && npm test'`

Advances #125
