### PR TITLE
feat(react-native): add raw ScrollView visibility tracking

### DIFF
--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -12,7 +12,13 @@ import {
   View,
 } from 'react-native';
 import type { AskableContext } from '@askable-ui/core';
-import { Askable, useAskable, useAskableScreen, useAskableVisibility } from '@askable-ui/react-native';
+import {
+  Askable,
+  useAskable,
+  useAskableScreen,
+  useAskableScrollView,
+  useAskableVisibility,
+} from '@askable-ui/react-native';
 
 type RootStackParamList = {
   Dashboard: undefined;
@@ -67,6 +73,9 @@ const insightViewabilityConfig = {
   itemVisiblePercentThreshold: 70,
 };
 
+type DashboardCard = (typeof dashboardCards)[number];
+type InsightAction = (typeof insightActions)[number];
+
 function PromptContextPanel({ promptContext }: { promptContext: string }) {
   return (
     <View style={styles.promptPanel}>
@@ -96,17 +105,25 @@ function DashboardScreen({
     text: 'Dashboard overview screen',
   });
 
+  const { onScroll, createOnItemLayout } = useAskableScrollView<DashboardCard>({
+    ctx,
+    active: isFocused,
+    getMeta: (card) => ({ ...card.meta, visible: true, source: 'scrollview-measurement' }),
+    getText: (card) => `${card.title} is currently leading the dashboard scroll view`,
+  });
+
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
+    <ScrollView contentContainerStyle={styles.screenContent} onScroll={onScroll} scrollEventThrottle={16}>
       <Text style={styles.eyebrow}>React Native + askable-ui</Text>
       <Text style={styles.title}>Dashboard</Text>
       <Text style={styles.subtitle}>
-        Tap a card to push focus into askable context, then inspect the prompt preview below.
+        Scroll the dashboard to mirror the leading visible card into askable context, then tap a
+        card to refine it further.
       </Text>
 
       {dashboardCards.map((card) => (
         <Askable key={card.title} ctx={ctx} meta={card.meta} text={card.text}>
-          <Pressable style={styles.card}>
+          <Pressable style={styles.card} onLayout={createOnItemLayout(card.title, card)}>
             <Text style={styles.cardTitle}>{card.title}</Text>
             <Text style={styles.cardValue}>{card.value}</Text>
           </Pressable>
@@ -138,7 +155,7 @@ function InsightsScreen({
     text: 'Insights analysis screen',
   });
 
-  const { onViewableItemsChanged } = useAskableVisibility({
+  const { onViewableItemsChanged } = useAskableVisibility<InsightAction>({
     ctx,
     active: isFocused,
     getMeta: (item) => ({ ...item.meta, visible: true, source: 'list-viewability' }),

--- a/examples/react-native-expo/README.md
+++ b/examples/react-native-expo/README.md
@@ -6,6 +6,7 @@ A runnable Expo app that demonstrates how `@askable-ui/react-native` captures mo
 
 - Shared `AskableContext` created with `useAskable()`
 - Screen-level context updates with `useAskableScreen()` and React Navigation's `useIsFocused()`
+- Raw `ScrollView` measurement-driven context updates with `useAskableScrollView()`
 - Visibility-driven list context updates with `useAskableVisibility()`
 - Press-driven focus updates with `<Askable>` wrappers around `Pressable` cards
 - A live prompt preview panel showing what an AI layer would receive
@@ -23,8 +24,8 @@ Then open the project in Expo Go, an iOS simulator, or an Android emulator.
 ## Example flow
 
 1. Launch the app on the **Dashboard** screen.
-2. Tap a metric card like **Revenue**.
-3. Notice the **Prompt context** panel update with the selected card metadata.
+2. Scroll the dashboard and watch the leading metric card update context through `useAskableScrollView()`.
+3. Tap a metric card like **Revenue** to refine the prompt context further.
 4. Open the **Insights** screen.
 5. Notice the screen-level context changes because `useAskableScreen()` is bound to navigation focus.
 6. Scroll the insights list and watch the leading visible card update context through `useAskableVisibility()`.
@@ -39,22 +40,24 @@ const isFocused = useIsFocused();
 useAskableScreen({
   ctx,
   active: isFocused,
-  meta: { screen: 'Insights', section: 'analysis' },
-  text: 'Insights analysis screen',
+  meta: { screen: 'Dashboard', section: 'overview' },
+  text: 'Dashboard overview screen',
 });
 
-const { onViewableItemsChanged } = useAskableVisibility({
+const { onScroll, createOnItemLayout } = useAskableScrollView({
   ctx,
   active: isFocused,
-  getMeta: (item) => ({ ...item.meta, visible: true }),
-  getText: (item) => `${item.title} is visible`,
+  getMeta: (card) => ({ ...card.meta, visible: true, source: 'scrollview-measurement' }),
+  getText: (card) => `${card.title} is currently leading the dashboard scroll view`,
 });
 
-<FlatList onViewableItemsChanged={onViewableItemsChanged} /* ... */ />;
-
-<Askable ctx={ctx} meta={{ panel: 'dropoff-analysis' }} text="Drop-off analysis panel">
-  <Pressable>{/* ... */}</Pressable>
-</Askable>;
+<ScrollView onScroll={onScroll} scrollEventThrottle={16}>
+  {dashboardCards.map((card) => (
+    <Askable key={card.title} ctx={ctx} meta={card.meta} text={card.text}>
+      <Pressable onLayout={createOnItemLayout(card.title, card)}>{/* ... */}</Pressable>
+    </Askable>
+  ))}
+</ScrollView>;
 ```
 
 See `App.tsx` for the complete example.

--- a/examples/react-native-expo/tsconfig.json
+++ b/examples/react-native-expo/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@askable-ui/react-native": ["../../packages/react-native/src/index.ts"],
+      "@askable-ui/core": ["../../packages/core/src/index.ts"]
+    }
   }
 }

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -7,6 +7,7 @@ React Native bindings for askable.
 - `useAskable()` hook backed by `@askable-ui/core`
 - `useAskableScreen()` hook for screen/navigation-aware context updates
 - `useAskableVisibility()` hook for FlatList / SectionList visibility-driven context updates
+- `useAskableScrollView()` hook for raw `ScrollView` measurement-driven visibility tracking
 - `<Askable ctx={...}>` wrapper that turns `onPress` / `onLongPress` into context updates
 - Runnable Expo example in [`examples/react-native-expo`](../../examples/react-native-expo)
 
@@ -84,6 +85,41 @@ export function ProductList() {
         </View>
       )}
     />
+  );
+}
+```
+
+## Raw ScrollView tracking
+
+For dashboards or custom feeds built with `ScrollView`, use `useAskableScrollView()` to measure child layouts and mirror the top visible card into askable context.
+
+```tsx
+import { Pressable, ScrollView, Text } from 'react-native';
+import { Askable, useAskable, useAskableScrollView } from '@askable-ui/react-native';
+
+const cards = [
+  { id: 'revenue', title: 'Revenue', meta: { widget: 'revenue' } },
+  { id: 'pipeline', title: 'Pipeline', meta: { widget: 'pipeline' } },
+];
+
+export function Dashboard() {
+  const { ctx } = useAskable();
+  const { onScroll, createOnItemLayout } = useAskableScrollView({
+    ctx,
+    getMeta: (card) => ({ ...card.meta, visible: true }),
+    getText: (card) => `${card.title} is leading the dashboard scroll view`,
+  });
+
+  return (
+    <ScrollView onScroll={onScroll} scrollEventThrottle={16}>
+      {cards.map((card) => (
+        <Askable key={card.id} ctx={ctx} meta={card.meta} text={card.title}>
+          <Pressable onLayout={createOnItemLayout(card.id, card)}>
+            <Text>{card.title}</Text>
+          </Pressable>
+        </Askable>
+      ))}
+    </ScrollView>
   );
 }
 ```

--- a/packages/react-native/src/__tests__/useAskable.test.tsx
+++ b/packages/react-native/src/__tests__/useAskable.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { useAskable, useAskableScreen, useAskableVisibility } from '../index';
+import { useAskable, useAskableScreen, useAskableScrollView, useAskableVisibility } from '../index';
 import type { AskableContext } from '@askable-ui/core';
 
 describe('useAskable (React Native)', () => {
@@ -218,6 +218,126 @@ describe('useAskable (React Native)', () => {
       onViewableItemsChanged!({
         viewableItems: [{ item: { id: 'p-2', title: 'Pipeline Summary' }, index: 1, isViewable: true }],
       });
+    });
+
+    expect(seenCtx!.getFocus()).toBeNull();
+  });
+
+  it('pushes the top visible ScrollView item into the shared askable context', () => {
+    let seenCtx: AskableContext | null = null;
+    let onScroll: ((event: { nativeEvent: { contentOffset?: { y?: number }; layoutMeasurement?: { height?: number } } }) => void) | null = null;
+    let measureItem: ((key: string, item: { id: string; title: string }, layout: { y: number; height: number }) => void) | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      const tracker = useAskableScrollView({
+        ctx,
+        getMeta: (item) => ({ insightId: item.id }),
+        getText: (item) => item.title,
+      });
+      onScroll = tracker.onScroll;
+      measureItem = tracker.measureItem;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      measureItem!('a', { id: 'a', title: 'Revenue Insight' }, { y: 0, height: 120 });
+      measureItem!('b', { id: 'b', title: 'Pipeline Insight' }, { y: 140, height: 120 });
+      onScroll!({ nativeEvent: { contentOffset: { y: 20 }, layoutMeasurement: { height: 160 } } });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { insightId: 'a' },
+      text: 'Revenue Insight',
+      source: 'push',
+    });
+  });
+
+  it('updates ScrollView context as the viewport moves between measured items', () => {
+    let seenCtx: AskableContext | null = null;
+    let onScroll: ((event: { nativeEvent: { contentOffset?: { y?: number }; layoutMeasurement?: { height?: number } } }) => void) | null = null;
+    let measureItem: ((key: string, item: { id: string; title: string }, layout: { y: number; height: number }) => void) | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      const tracker = useAskableScrollView({
+        ctx,
+        getMeta: (item) => ({ insightId: item.id }),
+        getText: (item) => item.title,
+      });
+      onScroll = tracker.onScroll;
+      measureItem = tracker.measureItem;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      measureItem!('a', { id: 'a', title: 'Revenue Insight' }, { y: 0, height: 120 });
+      measureItem!('b', { id: 'b', title: 'Pipeline Insight' }, { y: 140, height: 120 });
+      onScroll!({ nativeEvent: { contentOffset: { y: 20 }, layoutMeasurement: { height: 140 } } });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { insightId: 'a' },
+      text: 'Revenue Insight',
+      source: 'push',
+    });
+
+    act(() => {
+      onScroll!({ nativeEvent: { contentOffset: { y: 150 }, layoutMeasurement: { height: 140 } } });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { insightId: 'b' },
+      text: 'Pipeline Insight',
+      source: 'push',
+    });
+  });
+
+  it('clears ScrollView context when no measured item intersects the viewport', () => {
+    let seenCtx: AskableContext | null = null;
+    let onScroll: ((event: { nativeEvent: { contentOffset?: { y?: number }; layoutMeasurement?: { height?: number } } }) => void) | null = null;
+    let measureItem: ((key: string, item: { id: string; title: string }, layout: { y: number; height: number }) => void) | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      const tracker = useAskableScrollView({
+        ctx,
+        getMeta: (item) => ({ insightId: item.id }),
+        getText: (item) => item.title,
+      });
+      onScroll = tracker.onScroll;
+      measureItem = tracker.measureItem;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      measureItem!('a', { id: 'a', title: 'Revenue Insight' }, { y: 0, height: 120 });
+      onScroll!({ nativeEvent: { contentOffset: { y: 10 }, layoutMeasurement: { height: 100 } } });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({
+      meta: { insightId: 'a' },
+      text: 'Revenue Insight',
+      source: 'push',
+    });
+
+    act(() => {
+      onScroll!({ nativeEvent: { contentOffset: { y: 400 }, layoutMeasurement: { height: 100 } } });
     });
 
     expect(seenCtx!.getFocus()).toBeNull();

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,10 +1,20 @@
 export { Askable } from './Askable.js';
 export { useAskable } from './useAskable.js';
 export { useAskableScreen } from './useAskableScreen.js';
+export { useAskableScrollView } from './useAskableScrollView.js';
 export { useAskableVisibility } from './useAskableVisibility.js';
 export type { AskableProps } from './Askable.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
 export type { UseAskableScreenOptions } from './useAskableScreen.js';
+export type {
+  AskableScrollLayout,
+  AskableScrollNativeEvent,
+  AskableScrollEvent,
+  AskableMeasuredItem,
+  AskableVisibleScrollItem,
+  UseAskableScrollViewOptions,
+  UseAskableScrollViewResult,
+} from './useAskableScrollView.js';
 export type {
   AskableViewToken,
   AskableViewabilityInfo,

--- a/packages/react-native/src/useAskableScrollView.ts
+++ b/packages/react-native/src/useAskableScrollView.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createAskableContext } from '@askable-ui/core';
+import type { AskableContext, AskableContextOptions } from '@askable-ui/core';
+
+export interface AskableScrollLayout {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface AskableScrollNativeEvent {
+  contentOffset?: {
+    x?: number;
+    y?: number;
+  };
+  layoutMeasurement?: {
+    width?: number;
+    height?: number;
+  };
+}
+
+export interface AskableScrollEvent {
+  nativeEvent: AskableScrollNativeEvent;
+}
+
+export interface AskableMeasuredItem<Item = unknown> {
+  key: string;
+  item: Item;
+  layout: AskableScrollLayout;
+}
+
+export interface AskableVisibleScrollItem<Item = unknown> extends AskableMeasuredItem<Item> {
+  viewportTop: number;
+  viewportBottom: number;
+}
+
+export interface UseAskableScrollViewOptions<Item = unknown> extends AskableContextOptions {
+  /** Provide an existing context instead of creating a new one. */
+  ctx?: AskableContext;
+  /** Whether scroll updates should currently affect the context. */
+  active?: boolean;
+  /** Whether to clear the context when tracking becomes inactive. */
+  clearOnBlur?: boolean;
+  /** Map a visible item into the metadata pushed into askable. */
+  getMeta: (item: Item, measured: AskableMeasuredItem<Item>) => Record<string, unknown> | string;
+  /** Optional label stored alongside the visible item metadata. */
+  getText?: (item: Item, measured: AskableMeasuredItem<Item>) => string;
+  /** Pick which visible measured item should win focus. Defaults to the top-most visible item. */
+  selectVisible?: (items: AskableVisibleScrollItem<Item>[]) => AskableVisibleScrollItem<Item> | null;
+}
+
+export interface UseAskableScrollViewResult<Item = unknown> {
+  ctx: AskableContext;
+  onScroll: (event: AskableScrollEvent) => void;
+  measureItem: (key: string, item: Item, layout: AskableScrollLayout) => void;
+  unmeasureItem: (key: string) => void;
+  clearVisibleItem: () => void;
+  createOnItemLayout: (
+    key: string,
+    item: Item
+  ) => (event: { nativeEvent?: { layout?: AskableScrollLayout } }) => void;
+}
+
+function getNumber(value: number | undefined, fallback = 0): number {
+  return Number.isFinite(value) ? (value as number) : fallback;
+}
+
+function defaultSelectVisible<Item>(
+  items: AskableVisibleScrollItem<Item>[]
+): AskableVisibleScrollItem<Item> | null {
+  return items[0] ?? null;
+}
+
+export function useAskableScrollView<Item = unknown>(
+  options: UseAskableScrollViewOptions<Item>
+): UseAskableScrollViewResult<Item> {
+  const {
+    active = true,
+    clearOnBlur = true,
+    ctx,
+    getMeta,
+    getText,
+    selectVisible = defaultSelectVisible,
+  } = options;
+  const [scrollCtx] = useState<AskableContext>(() => ctx ?? createAskableContext(options));
+  const measuredItemsRef = useRef<Map<string, AskableMeasuredItem<Item>>>(new Map());
+  const viewportRef = useRef<{ offsetY: number; height: number } | null>(null);
+
+  const clearVisibleItem = useCallback(() => {
+    scrollCtx.clear();
+  }, [scrollCtx]);
+
+  const syncVisibleItem = useCallback(() => {
+    if (!active) {
+      return;
+    }
+
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return;
+    }
+
+    const viewportTop = viewport.offsetY;
+    const viewportBottom = viewport.offsetY + viewport.height;
+
+    const visibleItems = Array.from(measuredItemsRef.current.values())
+      .filter((entry) => {
+        const top = getNumber(entry.layout.y);
+        const bottom = top + Math.max(getNumber(entry.layout.height), 0);
+        return bottom > viewportTop && top < viewportBottom;
+      })
+      .sort((left, right) => getNumber(left.layout.y) - getNumber(right.layout.y))
+      .map((entry) => ({
+        ...entry,
+        viewportTop,
+        viewportBottom,
+      }));
+
+    const selected = selectVisible(visibleItems);
+    if (!selected) {
+      clearVisibleItem();
+      return;
+    }
+
+    scrollCtx.push(getMeta(selected.item, selected), getText?.(selected.item, selected) ?? '');
+  }, [active, clearVisibleItem, getMeta, getText, scrollCtx, selectVisible]);
+
+  const onScroll = useCallback(
+    (event: AskableScrollEvent) => {
+      const nativeEvent = event?.nativeEvent ?? {};
+      viewportRef.current = {
+        offsetY: getNumber(nativeEvent.contentOffset?.y),
+        height: Math.max(getNumber(nativeEvent.layoutMeasurement?.height), 0),
+      };
+      syncVisibleItem();
+    },
+    [syncVisibleItem]
+  );
+
+  const measureItem = useCallback(
+    (key: string, item: Item, layout: AskableScrollLayout) => {
+      measuredItemsRef.current.set(key, { key, item, layout });
+      syncVisibleItem();
+    },
+    [syncVisibleItem]
+  );
+
+  const unmeasureItem = useCallback(
+    (key: string) => {
+      measuredItemsRef.current.delete(key);
+      syncVisibleItem();
+    },
+    [syncVisibleItem]
+  );
+
+  const createOnItemLayout = useCallback(
+    (key: string, item: Item) => (event: { nativeEvent?: { layout?: AskableScrollLayout } }) => {
+      measureItem(key, item, event?.nativeEvent?.layout ?? {});
+    },
+    [measureItem]
+  );
+
+  useEffect(() => {
+    if (!active && clearOnBlur) {
+      scrollCtx.clear();
+    }
+  }, [active, clearOnBlur, scrollCtx]);
+
+  useEffect(() => {
+    return () => {
+      measuredItemsRef.current.clear();
+      if (!ctx) {
+        scrollCtx.destroy();
+      }
+    };
+  }, [ctx, scrollCtx]);
+
+  return {
+    ctx: scrollCtx,
+    onScroll,
+    measureItem,
+    unmeasureItem,
+    clearVisibleItem,
+    createOnItemLayout,
+  };
+}

--- a/site/docs/api/react-native.md
+++ b/site/docs/api/react-native.md
@@ -2,7 +2,7 @@
 
 React Native bindings for askable-ui.
 
-This initial slice focuses on explicit mobile interactions: `useAskable()` provides a context backed by `@askable-ui/core`, `useAskableScreen()` lets you mirror screen focus into that context, `useAskableVisibility()` mirrors viewability updates from mobile lists, and `<Askable />` turns `onPress` / `onLongPress` interactions into prompt-ready focus updates.
+This initial slice focuses on explicit mobile interactions: `useAskable()` provides a context backed by `@askable-ui/core`, `useAskableScreen()` lets you mirror screen focus into that context, `useAskableScrollView()` mirrors raw `ScrollView` measurement into that context, `useAskableVisibility()` mirrors viewability updates from mobile lists, and `<Askable />` turns `onPress` / `onLongPress` interactions into prompt-ready focus updates.
 
 A runnable Expo reference app lives in [`examples/react-native-expo`](https://github.com/askable-ui/askable/tree/main/examples/react-native-expo).
 
@@ -107,6 +107,64 @@ function RevenueScreen() {
 | `clearOnBlur` | `boolean` | Clear the context when the screen becomes inactive. Default: `true` |
 | `name` / `viewport` / `events` | Core options | Forwarded when the hook creates its own context |
 
+## `useAskableScrollView(options)`
+
+Mirrors raw `ScrollView` measurement into the shared `AskableContext` by tracking child layouts and selecting the top visible measured item.
+
+```tsx
+import { Pressable, ScrollView, Text } from 'react-native';
+import { Askable, useAskable, useAskableScrollView } from '@askable-ui/react-native';
+
+const cards = [
+  { id: 'rev', title: 'Revenue', meta: { widget: 'revenue' } },
+  { id: 'pipe', title: 'Pipeline', meta: { widget: 'pipeline' } },
+];
+
+function DashboardFeed() {
+  const { ctx } = useAskable();
+  const { onScroll, createOnItemLayout } = useAskableScrollView({
+    ctx,
+    getMeta: (card) => ({ ...card.meta, visible: true }),
+    getText: (card) => `${card.title} is leading the dashboard scroll view`,
+  });
+
+  return (
+    <ScrollView onScroll={onScroll} scrollEventThrottle={16}>
+      {cards.map((card) => (
+        <Askable key={card.id} ctx={ctx} meta={card.meta} text={card.title}>
+          <Pressable onLayout={createOnItemLayout(card.id, card)}>
+            <Text>{card.title}</Text>
+          </Pressable>
+        </Askable>
+      ))}
+    </ScrollView>
+  );
+}
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `ctx` | `AskableContext` | Reuse an existing context instead of creating a new one |
+| `active` | `boolean` | Whether scroll updates should currently affect focus. Default: `true` |
+| `clearOnBlur` | `boolean` | Clear existing scroll focus when tracking becomes inactive. Default: `true` |
+| `getMeta` | `(item, measured) => Record<string, unknown> \| string` | Maps the visible measured item into askable metadata |
+| `getText` | `(item, measured) => string` | Optional human-readable label stored alongside the metadata |
+| `selectVisible` | `(items) => item \| null` | Override which measured item should win focus. Default: the top-most visible item |
+| `name` / `viewport` / `events` | Core options | Forwarded when the hook creates its own context |
+
+**Returns:**
+
+| Value | Type | Description |
+|---|---|---|
+| `ctx` | `AskableContext` | Context instance used for scroll-driven focus updates |
+| `onScroll` | `(event) => void` | Attach to `ScrollView.onScroll` |
+| `measureItem` | `(key, item, layout) => void` | Manually register/update a child layout |
+| `unmeasureItem` | `(key) => void` | Remove a child layout when it leaves the tree |
+| `clearVisibleItem` | `() => void` | Clear the current scroll-driven focus |
+| `createOnItemLayout` | `(key, item) => onLayoutHandler` | Convenience helper for `onLayout` wiring |
+
 ## `useAskableVisibility(options)`
 
 Mirrors `FlatList` / `SectionList` viewability callbacks into the shared `AskableContext`.
@@ -157,7 +215,8 @@ function DealsList() {
 
 ## Notes
 
-- This adapter currently covers press-driven interactions, lightweight screen-awareness, and list viewability callbacks.
+- This adapter currently covers press-driven interactions, lightweight screen-awareness, raw `ScrollView` measurement, and list viewability callbacks.
 - `useAskableScreen()` is designed to pair with React Navigation's `useIsFocused()` or a similar focus signal.
-- `useAskableVisibility()` is ideal for `FlatList` / `SectionList`; raw `ScrollView` measurement is still follow-up work.
+- `useAskableScrollView()` is a good fit for custom dashboard layouts built with `ScrollView`.
+- `useAskableVisibility()` is ideal for `FlatList` / `SectionList`.
 - Existing child `onPress` / `onLongPress` handlers are preserved and still run.


### PR DESCRIPTION
## Summary
- add a `useAskableScrollView()` hook for raw ScrollView measurement-driven visibility tracking
- cover top-visible selection and viewport clearing with React Native adapter tests
- document and demo the raw ScrollView flow in the package docs, site docs, and Expo example

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] `cd examples/react-native-expo && npm run typecheck`

Closes #125
