### PR TITLE
feat: add scoped context filtering

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,7 +16,7 @@ npm install @askable-ui/core
   Complete Purchase
 </button>
 
-<input data-askable='{"field":"email","required":true}' placeholder="Email address" />
+<input data-askable='{"field":"email","required":true}' data-askable-scope="form-helper" placeholder="Email address" />
 ```
 
 ```ts
@@ -35,6 +35,7 @@ ctx.on('focus', (focus) => {
 
 // Get the current focus as an LLM prompt string
 const prompt = ctx.toPromptContext();
+const formPrompt = ctx.toPromptContext({ scope: 'form-helper' });
 // e.g. "User is focused on: — action: submit, form: checkout — value "Complete Purchase""
 
 // Clean up when done

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -187,6 +187,50 @@ describe('createAskableContext', () => {
     cleanup(el);
   });
 
+  it('captures scope from data-askable-scope and filters prompt/history output by scope', () => {
+    const analytics = makeEl({ metric: 'revenue' }, 'Revenue Chart');
+    analytics.setAttribute('data-askable-scope', 'analytics');
+    const form = makeEl({ field: 'email' }, 'Email input');
+    form.setAttribute('data-askable-scope', 'form-helper');
+    const unscoped = makeEl({ widget: 'global-help' }, 'Help tip');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    analytics.click();
+    form.click();
+    unscoped.click();
+
+    expect(ctx.getHistory().map((focus) => focus.scope)).toEqual([undefined, 'form-helper', 'analytics']);
+    expect(ctx.toPromptContext({ scope: 'analytics' })).toContain('global-help');
+    expect(ctx.toPromptContext({ scope: 'form-helper' })).toContain('global-help');
+    expect(ctx.toHistoryContext(3, { scope: 'analytics' })).toContain('metric: revenue');
+    expect(ctx.toHistoryContext(3, { scope: 'analytics' })).not.toContain('field: email');
+    expect(ctx.toHistoryContext(3, { scope: 'form-helper' })).toContain('field: email');
+    expect(ctx.toHistoryContext(3, { scope: 'form-helper' })).not.toContain('metric: revenue');
+
+    ctx.destroy();
+    cleanup(analytics);
+    cleanup(form);
+    cleanup(unscoped);
+  });
+
+  it('filters pushed focus/history by scope while keeping unscoped entries visible everywhere', () => {
+    const ctx = createAskableContext();
+
+    ctx.push({ metric: 'revenue' }, 'Revenue card', { scope: 'analytics' });
+    ctx.push({ field: 'email' }, 'Email field', { scope: 'form-helper' });
+    ctx.push({ widget: 'global-help' }, 'Help tip');
+
+    expect(ctx.toPromptContext({ scope: 'analytics' })).toContain('global-help');
+    expect(ctx.toPromptContext({ scope: 'form-helper' })).toContain('global-help');
+    expect(ctx.toHistoryContext(3, { scope: 'analytics' })).toContain('metric: revenue');
+    expect(ctx.toHistoryContext(3, { scope: 'analytics' })).not.toContain('field: email');
+    expect(ctx.toHistoryContext(3, { scope: 'form-helper' })).toContain('field: email');
+    expect(ctx.toHistoryContext(3, { scope: 'form-helper' })).not.toContain('metric: revenue');
+
+    ctx.destroy();
+  });
+
   it('serializeFocus() respects excludeKeys and keyOrder', () => {
     const el = makeEl({ z: 1, metric: 'churn', secret: 'x', value: '4.2%' }, 'Churn Rate');
     const ctx = createAskableContext();

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -10,6 +10,7 @@ import type {
   AskableObserveOptions,
   AskablePromptContextOptions,
   AskablePromptPreset,
+  AskablePushOptions,
   AskableSerializedFocus,
 } from './types.js';
 
@@ -64,6 +65,17 @@ export class AskableContextImpl implements AskableContext {
       : focus.meta;
     const text = this.sanitizeTextFn ? this.sanitizeTextFn(focus.text) : focus.text;
     return { ...focus, meta, text };
+  }
+
+  private matchesScope(focus: AskableFocus | null, scope?: string): focus is AskableFocus {
+    if (!focus) return false;
+    if (!scope) return true;
+    return focus.scope === undefined || focus.scope === scope;
+  }
+
+  private filterByScope(focuses: AskableFocus[], scope?: string): AskableFocus[] {
+    if (!scope) return focuses;
+    return focuses.filter((focus) => this.matchesScope(focus, scope));
   }
 
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void {
@@ -134,7 +146,7 @@ export class AskableContextImpl implements AskableContext {
     this.emitter.emit('focus', focus);
   }
 
-  push(meta: Record<string, unknown> | string, text?: string): void {
+  push(meta: Record<string, unknown> | string, text?: string, options?: AskablePushOptions): void {
     const sanitizedMeta = this.sanitizeMetaFn && typeof meta !== 'string'
       ? this.sanitizeMetaFn(meta) : meta;
     const sanitizedText = this.sanitizeTextFn && text
@@ -142,6 +154,7 @@ export class AskableContextImpl implements AskableContext {
     const focus: AskableFocus = {
       source: 'push',
       meta: sanitizedMeta,
+      ...(options?.scope ? { scope: options.scope } : {}),
       text: sanitizedText,
       timestamp: Date.now(),
     };
@@ -159,19 +172,21 @@ export class AskableContextImpl implements AskableContext {
   }
 
   serializeFocus(options?: AskablePromptContextOptions): AskableSerializedFocus | null {
-    if (!this.currentFocus) return null;
-    return this.serializeFocusFrom(this.currentFocus, this.resolveOptions(options));
+    const resolved = this.resolveOptions(options);
+    if (!this.matchesScope(this.currentFocus, resolved.scope)) return null;
+    return this.serializeFocusFrom(this.currentFocus, resolved);
   }
 
   toPromptContext(options?: AskablePromptContextOptions): string {
     const resolved = this.resolveOptions(options);
-    const output = this.buildPromptString(this.currentFocus, resolved);
+    const focus = this.matchesScope(this.currentFocus, resolved.scope) ? this.currentFocus : null;
+    const output = this.buildPromptString(focus, resolved);
     return this.applyTokenBudget(output, resolved.maxTokens);
   }
 
   toHistoryContext(limit?: number, options?: AskablePromptContextOptions): string {
     const resolved = this.resolveOptions(options);
-    const history = this.getHistory(limit);
+    const history = this.filterByScope(this.getHistory(limit), resolved.scope);
     if (history.length === 0) return 'No interaction history.';
     const lines = history.map((focus, i) => `[${i + 1}] ${this.buildPromptString(focus, resolved)}`);
     const output = lines.join('\n');
@@ -180,7 +195,7 @@ export class AskableContextImpl implements AskableContext {
 
   toViewportContext(options?: AskablePromptContextOptions): string {
     const resolved = this.resolveOptions(options);
-    const visible = this.getVisibleElements();
+    const visible = this.filterByScope(this.getVisibleElements(), resolved.scope);
     if (visible.length === 0) return resolved.format === 'json' ? '[]' : 'No annotated UI elements are currently visible.';
     if (resolved.format === 'json') {
       return JSON.stringify(visible.map((focus) => this.serializeFocusFrom(focus, resolved)));
@@ -193,13 +208,14 @@ export class AskableContextImpl implements AskableContext {
     const { history: historyCount = 0, currentLabel = 'Current', historyLabel = 'Recent interactions', ...promptOptions } = options ?? {};
     const resolved = this.resolveOptions(promptOptions);
 
-    const currentLine = `${currentLabel}: ${this.buildPromptString(this.currentFocus, resolved)}`;
+    const currentFocus = this.matchesScope(this.currentFocus, resolved.scope) ? this.currentFocus : null;
+    const currentLine = `${currentLabel}: ${this.buildPromptString(currentFocus, resolved)}`;
 
     if (historyCount <= 0) {
       return this.applyTokenBudget(currentLine, resolved.maxTokens);
     }
 
-    const historyEntries = this.getHistory(historyCount);
+    const historyEntries = this.filterByScope(this.getHistory(historyCount), resolved.scope);
     if (historyEntries.length === 0) {
       return this.applyTokenBudget(currentLine, resolved.maxTokens);
     }
@@ -283,6 +299,7 @@ export class AskableContextImpl implements AskableContext {
 
     return {
       meta,
+      ...(focus.scope ? { scope: focus.scope } : {}),
       ...(text ? { text } : {}),
       timestamp: focus.timestamp,
     };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export type {
   AskablePromptContextOptions,
   AskablePromptFormat,
   AskablePromptPreset,
+  AskablePushOptions,
   AskableSerializedFocus,
   AskableTargetStrategy,
 } from './types.js';

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -65,9 +65,11 @@ export function buildFocus(
   const text = textOverride !== null
     ? textOverride
     : textExtractor ? textExtractor(el) : extractText(el);
+  const scope = el.getAttribute('data-askable-scope')?.trim() || undefined;
   return {
     source: 'dom',
     meta: resolveMeta(el, raw, metaCache),
+    ...(scope ? { scope } : {}),
     text,
     element: el,
     timestamp: Date.now(),
@@ -75,7 +77,7 @@ export function buildFocus(
 }
 
 const ALL_EVENTS: AskableEvent[] = ['click', 'hover', 'focus'];
-const OBSERVED_ATTRIBUTES = ['data-askable', 'data-askable-text', 'data-askable-priority'] as const;
+const OBSERVED_ATTRIBUTES = ['data-askable', 'data-askable-text', 'data-askable-priority', 'data-askable-scope'] as const;
 
 export class Observer {
   private root: HTMLElement | Document | null = null;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,8 @@ export interface AskableFocus {
   source: AskableFocusSource;
   /** Parsed data-askable attribute (JSON object or raw string) */
   meta: Record<string, unknown> | string;
+  /** Optional category used to filter context for different agents/copilots. */
+  scope?: string;
   /** Trimmed textContent of the element */
   text: string;
   /** The DOM element (undefined when set via push()) */
@@ -84,6 +86,8 @@ export interface AskablePromptContextOptions {
    * - `json`    → `{ format: 'json', includeText: true }`
    */
   preset?: AskablePromptPreset;
+  /** Optional scope/category filter. Unscoped entries are included in every scoped view. */
+  scope?: string;
   /** Output format. Defaults to natural language. */
   format?: AskablePromptFormat;
   /** Include extracted text in serialized output. Defaults to true. */
@@ -162,8 +166,14 @@ export interface AskableContextOptions {
 
 export interface AskableSerializedFocus {
   meta: Record<string, unknown> | string;
+  scope?: string;
   text?: string;
   timestamp: number;
+}
+
+export interface AskablePushOptions {
+  /** Optional category used to filter context for different agents/copilots. */
+  scope?: string;
 }
 
 export interface AskableContextOutputOptions extends AskablePromptContextOptions {
@@ -193,7 +203,7 @@ export interface AskableContext {
   /** Programmatically select an element — use for explicit "Ask AI" buttons */
   select(element: HTMLElement): void;
   /** Set focus from data alone — no DOM element required. Ideal for virtualizing table libraries. */
-  push(meta: Record<string, unknown> | string, text?: string): void;
+  push(meta: Record<string, unknown> | string, text?: string, options?: AskablePushOptions): void;
   /** Reset the current focus to null and emit a 'clear' event */
   clear(): void;
   /** Serialize current focus to structured prompt-ready data */

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -21,7 +21,7 @@ export function RevenueCard() {
   const { ctx, promptContext } = useAskable();
 
   return (
-    <Askable ctx={ctx} meta={{ widget: 'revenue' }} text="Revenue card">
+    <Askable ctx={ctx} meta={{ widget: 'revenue' }} scope="analytics" text="Revenue card">
       <Pressable>
         <Text>Revenue</Text>
       </Pressable>
@@ -29,6 +29,8 @@ export function RevenueCard() {
   );
 }
 ```
+
+`scope` is optional and lets you later read filtered context with `ctx.toPromptContext({ scope: 'analytics' })` or `ctx.toHistoryContext(5, { scope: 'analytics' })`.
 
 ## Screen awareness
 

--- a/packages/react-native/src/Askable.tsx
+++ b/packages/react-native/src/Askable.tsx
@@ -5,17 +5,18 @@ import type { AskableContext } from '@askable-ui/core';
 export interface AskableProps {
   ctx: AskableContext;
   meta: Record<string, unknown> | string;
+  scope?: string;
   text?: string;
   children: ReactElement<{ onPress?: () => void; onLongPress?: () => void }>;
 }
 
-export function Askable({ ctx, meta, text = '', children }: AskableProps) {
+export function Askable({ ctx, meta, scope, text = '', children }: AskableProps) {
   const child = React.Children.only(children);
   const originalOnPress = child.props.onPress;
   const originalOnLongPress = child.props.onLongPress;
 
   const focus = () => {
-    ctx.push(meta, text);
+    ctx.push(meta, text, scope ? { scope } : undefined);
   };
 
   return React.cloneElement(child, {

--- a/packages/react-native/src/__tests__/Askable.test.tsx
+++ b/packages/react-native/src/__tests__/Askable.test.tsx
@@ -51,4 +51,28 @@ describe('Askable (React Native)', () => {
 
     ctx.destroy();
   });
+
+  it('pushes scoped focus when scope is provided', () => {
+    const ctx = createAskableContext();
+    const tree = TestRenderer.create(
+      <Askable ctx={ctx} meta={{ widget: 'revenue' }} text="Revenue card" scope="analytics">
+        {React.createElement('Pressable', { testID: 'pressable' })}
+      </Askable>
+    );
+
+    const pressable = tree.root.findByProps({ testID: 'pressable' });
+
+    act(() => {
+      pressable.props.onPress();
+    });
+
+    expect(ctx.getFocus()).toMatchObject({
+      meta: { widget: 'revenue' },
+      text: 'Revenue card',
+      scope: 'analytics',
+      source: 'push',
+    });
+
+    ctx.destroy();
+  });
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -59,6 +59,10 @@ Renders any element (default: `div`) with a `data-askable` attribute. The `meta`
   <ChurnChart />
 </Askable>
 
+<Askable meta={{ widget: 'revenue-chart' }} scope="analytics">
+  <RevenueChart />
+</Askable>
+
 <Askable meta="main navigation" as="nav">
   <NavLinks />
 </Askable>
@@ -66,6 +70,7 @@ Renders any element (default: `div`) with a `data-askable` attribute. The `meta`
 
 **Props:**
 - `meta` — structured metadata attached to the element (`Record<string, unknown> | string`)
+- `scope` — optional category written to `data-askable-scope` for scoped prompt/history queries
 - `as` — HTML tag to render (default: `"div"`)
 - All other props are forwarded to the underlying element
 

--- a/packages/react/src/Askable.tsx
+++ b/packages/react/src/Askable.tsx
@@ -4,17 +4,23 @@ type AnyTag = keyof React.JSX.IntrinsicElements;
 
 type AskableProps<T extends AnyTag = 'div'> = {
   meta: Record<string, unknown> | string;
+  scope?: string;
   as?: T;
   children?: React.ReactNode;
 } & Omit<React.JSX.IntrinsicElements[T], 'children'>;
 
 export function Askable<T extends AnyTag = 'div'>({
   meta,
+  scope,
   as,
   children,
   ...props
 }: AskableProps<T>) {
   const Tag = (as ?? 'div') as string;
   const dataAskable = typeof meta === 'string' ? meta : JSON.stringify(meta);
-  return React.createElement(Tag, { 'data-askable': dataAskable, ...props }, children);
+  return React.createElement(
+    Tag,
+    { 'data-askable': dataAskable, ...(scope ? { 'data-askable-scope': scope } : {}), ...props },
+    children
+  );
 }

--- a/packages/react/src/__tests__/Askable.test.tsx
+++ b/packages/react/src/__tests__/Askable.test.tsx
@@ -52,4 +52,12 @@ describe('Askable', () => {
     expect(el.className).toBe('panel');
     expect(el.getAttribute('data-testid')).toBe('fwd');
   });
+
+  it('sets data-askable-scope when scope is provided', () => {
+    const { container } = render(
+      <Askable meta={{ widget: 'revenue' }} scope="analytics">Revenue Chart</Askable>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute('data-askable-scope')).toBe('analytics');
+  });
 });

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -47,6 +47,8 @@ npm install @askable-ui/svelte @askable-ui/core
 
 Renders any element (default: `div`) with a `data-askable` attribute. Accepts a `<slot />`.
 
+- `scope` is optional and writes `data-askable-scope` for scoped prompt/history queries.
+
 ### `createAskableStore(options?)`
 
 Returns Svelte stores backed by a core `AskableContext`.

--- a/packages/svelte/src/Askable.svelte
+++ b/packages/svelte/src/Askable.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   export let meta: Record<string, unknown> | string;
+  export let scope: string | undefined = undefined;
   export let as: string = 'div';
 
   $: dataAskable = typeof meta === 'string' ? meta : JSON.stringify(meta);
 </script>
 
-<svelte:element this={as} data-askable={dataAskable} {...$$restProps}>
+<svelte:element this={as} data-askable={dataAskable} data-askable-scope={scope} {...$$restProps}>
   <slot />
 </svelte:element>

--- a/packages/svelte/src/__tests__/component.test.ts
+++ b/packages/svelte/src/__tests__/component.test.ts
@@ -36,4 +36,10 @@ describe('Askable (Svelte)', () => {
     const { getByText } = render(AskableWithContent);
     expect(getByText('Revenue Chart')).toBeInTheDocument();
   });
+
+  it('sets data-askable-scope when scope is provided', () => {
+    const { container } = render(Askable, { props: { meta: { widget: 'revenue' }, scope: 'analytics' } });
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.getAttribute('data-askable-scope')).toBe('analytics');
+  });
 });

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -42,6 +42,8 @@ async function ask(question: string) {
 
 Renders any element (default: `div`) with a `data-askable` attribute.
 
+- `scope` is optional and writes `data-askable-scope` for scoped prompt/history queries.
+
 ### `useAskable(options?)`
 
 Returns reactive focus state from the shared context for the requested `events` configuration.

--- a/packages/vue/src/Askable.ts
+++ b/packages/vue/src/Askable.ts
@@ -12,12 +12,20 @@ export const Askable = defineComponent({
       type: String,
       default: 'div',
     },
+    scope: {
+      type: String,
+      default: undefined,
+    },
   },
   setup(props, { slots, attrs }) {
     return () => {
       const dataAskable =
         typeof props.meta === 'string' ? props.meta : JSON.stringify(props.meta);
-      return h(props.as, { 'data-askable': dataAskable, ...attrs }, slots.default?.());
+      return h(
+        props.as,
+        { 'data-askable': dataAskable, ...(props.scope ? { 'data-askable-scope': props.scope } : {}), ...attrs },
+        slots.default?.()
+      );
     };
   },
 });

--- a/packages/vue/src/__tests__/Askable.test.ts
+++ b/packages/vue/src/__tests__/Askable.test.ts
@@ -55,4 +55,9 @@ describe('Askable (Vue)', () => {
     expect(wrapper.attributes('class')).toBe('panel');
     expect(wrapper.attributes('data-testid')).toBe('fwd');
   });
+
+  it('sets data-askable-scope when scope is provided', () => {
+    const wrapper = track(mount(Askable, { props: { meta: { widget: 'revenue' }, scope: 'analytics' } }));
+    expect(wrapper.attributes('data-askable-scope')).toBe('analytics');
+  });
 });

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -49,6 +49,7 @@ const viewportCtx = createAskableContext({ viewport: true });
 | Attribute | Value | Description |
 |---|---|---|
 | `data-askable` | JSON object or string | Marks an element as askable. Value becomes `AskableFocus.meta`. |
+| `data-askable-scope` | string | Optional category filter. Scoped queries like `ctx.toPromptContext({ scope: 'analytics' })` include matching scoped entries plus unscoped ones. |
 | `data-askable-priority` | integer | Override the default innermost-wins rule in `'deepest'` strategy. Higher values win. |
 | `data-askable-text` | string | Override the text captured from this element. Empty string `""` suppresses text entirely. Takes priority over `textExtractor`. |
 
@@ -222,6 +223,7 @@ ctx.toPromptContext({ maxTokens: 50 });
 // Truncates to ~200 chars and appends [truncated] if needed
 
 ctx.toPromptContext({ excludeKeys: ['_id'], keyOrder: ['metric', 'value'] });
+ctx.toPromptContext({ scope: 'analytics' });
 ```
 
 **Returns:** `string` — `'No UI element is currently focused.'` (or `'null'` for JSON format) when nothing is focused.
@@ -238,6 +240,7 @@ ctx.toHistoryContext();
 
 ctx.toHistoryContext(5);
 ctx.toHistoryContext(5, { excludeKeys: ['_id'], maxTokens: 200 });
+ctx.toHistoryContext(5, { scope: 'analytics' });
 ```
 
 **Returns:** `string` — `'No interaction history.'` when history is empty.

--- a/site/docs/api/react-native.md
+++ b/site/docs/api/react-native.md
@@ -41,6 +41,7 @@ function RevenueCard() {
 |---|---|---|
 | `ctx` | `AskableContext` | Context instance that receives focus updates |
 | `meta` | `Record<string, unknown> \| string` | Metadata pushed into the context on press |
+| `scope` | `string` | Optional category stored with press-driven focus for scoped prompt/history queries |
 | `text` | `string` | Optional human-readable label stored alongside `meta` |
 | `children` | `ReactElement` | A single child that accepts `onPress` / `onLongPress` props |
 

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -21,6 +21,10 @@ import { Askable } from '@askable-ui/react';
   <RevenueChart />
 </Askable>
 
+<Askable meta={{ metric: 'revenue' }} scope="analytics">
+  <RevenueChart />
+</Askable>
+
 <Askable meta="main navigation" as="nav">
   <NavLinks />
 </Askable>
@@ -31,6 +35,7 @@ import { Askable } from '@askable-ui/react';
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `meta` | `Record<string, unknown> \| string` | — | Value for `data-askable` attribute |
+| `scope` | `string` | — | Optional category written to `data-askable-scope` for scoped prompt/history queries |
 | `as` | `keyof JSX.IntrinsicElements` | `"div"` | HTML element to render |
 | `ref` | `Ref<HTMLElement>` | — | Forwarded to the underlying element |
 | ...rest | | | All other props forwarded to the element |

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -23,6 +23,10 @@ Renders a wrapper element with `data-askable` managed reactively.
   <RevenueChart />
 </Askable>
 
+<Askable meta={{ metric: 'revenue' }} scope="analytics">
+  <RevenueChart />
+</Askable>
+
 <Askable meta="main navigation" as="nav">
   <NavLinks />
 </Askable>
@@ -33,6 +37,7 @@ Renders a wrapper element with `data-askable` managed reactively.
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `meta` | `Record<string, unknown> \| string` | — | Value for `data-askable` attribute |
+| `scope` | `string` | — | Optional category written to `data-askable-scope` for scoped prompt/history queries |
 | `as` | `string` | `"div"` | HTML element to render |
 
 ---

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -85,6 +85,8 @@ interface AskableFocus {
   source: AskableFocusSource;
   /** Parsed data-askable value. JSON → object; plain string → string. */
   meta: Record<string, unknown> | string;
+  /** Optional category used to filter context for different agents/copilots. */
+  scope?: string;
   /** Trimmed textContent of the element. */
   text: string;
   /** The DOM element. Undefined when set via push(). */
@@ -103,6 +105,7 @@ The shape returned by `serializeFocus()`. Similar to `AskableFocus` but without 
 ```ts
 interface AskableSerializedFocus {
   meta: Record<string, unknown> | string;
+  scope?: string;
   text?: string;
   timestamp: number;
 }
@@ -133,6 +136,7 @@ Options accepted by `toPromptContext()`, `toHistoryContext()`, and `serializeFoc
 ```ts
 interface AskablePromptContextOptions {
   preset?: AskablePromptPreset;    // Named shorthand. Individual options override it.
+  scope?: string;                  // Optional category filter. Unscoped entries are included everywhere.
   format?: AskablePromptFormat;    // 'natural' | 'json'. Default: 'natural'
   includeText?: boolean;           // Include element text. Default: true
   maxTextLength?: number;          // Truncate text to N chars

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -19,6 +19,10 @@ Renders a wrapper element with `data-askable` managed reactively from `:meta`.
   <RevenueChart />
 </Askable>
 
+<Askable :meta="{ metric: 'revenue' }" scope="analytics">
+  <RevenueChart />
+</Askable>
+
 <Askable meta="main navigation" as="nav">
   <NavLinks />
 </Askable>
@@ -29,6 +33,7 @@ Renders a wrapper element with `data-askable` managed reactively from `:meta`.
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `meta` | `Record<string, unknown> \| string` | — | Value for `data-askable` attribute |
+| `scope` | `string` | — | Optional category written to `data-askable-scope` for scoped prompt/history queries |
 | `as` | `string` | `"div"` | HTML element to render |
 
 ---


### PR DESCRIPTION
## Summary
- add scope-aware filtering to core prompt/history serialization while keeping unscoped entries visible everywhere
- support `scope` / `data-askable-scope` across React, Vue, Svelte, and React Native Askable components
- document scoped context usage across package READMEs and site API docs

## Test plan
- [x] `npm run build`
- [x] `npm test`

Closes #119
