### PR TITLE
feat: add hierarchical askable context trees

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -231,6 +231,119 @@ describe('createAskableContext', () => {
     ctx.destroy();
   });
 
+  it('includes ancestor chains from nested [data-askable] elements in prompt output', () => {
+    const dashboard = makeEl({ view: 'dashboard' }, 'Dashboard');
+    const finance = makeEl({ tab: 'finance' }, 'Finance');
+    const revenue = makeEl({ metric: 'revenue', value: '$2.3M' }, 'Revenue card');
+    dashboard.appendChild(finance);
+    finance.appendChild(revenue);
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    revenue.click();
+
+    expect(ctx.toPromptContext()).toContain('view: dashboard > tab: finance > metric: revenue, value: $2.3M');
+    expect(ctx.toHistoryContext(1)).toContain('view: dashboard > tab: finance > metric: revenue, value: $2.3M');
+
+    ctx.destroy();
+    dashboard.remove();
+  });
+
+  it('supports explicit data-askable-parent links and hierarchy depth limits', () => {
+    const dashboard = makeEl({ view: 'dashboard' }, 'Dashboard');
+    dashboard.id = 'dashboard-root';
+    const finance = makeEl({ tab: 'finance' }, 'Finance');
+    finance.id = 'finance-tab';
+    finance.setAttribute('data-askable-parent', '#dashboard-root');
+    const revenue = makeEl({ metric: 'revenue', value: '$2.3M' }, 'Revenue card');
+    revenue.setAttribute('data-askable-parent', '#finance-tab');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    revenue.click();
+
+    expect(ctx.toPromptContext()).toContain('view: dashboard > tab: finance > metric: revenue, value: $2.3M');
+    expect(ctx.toPromptContext({ hierarchyDepth: 1 })).toContain('tab: finance > metric: revenue, value: $2.3M');
+    expect(ctx.toPromptContext({ hierarchyDepth: 1 })).not.toContain('view: dashboard >');
+    expect((ctx as any).serializeFocus({ hierarchyDepth: 1 })).toEqual({
+      meta: { metric: 'revenue', value: '$2.3M' },
+      ancestors: [
+        { meta: { tab: 'finance' }, text: 'Finance' },
+      ],
+      text: 'Revenue card',
+      timestamp: expect.any(Number),
+    });
+
+    ctx.destroy();
+    dashboard.remove();
+    finance.remove();
+    revenue.remove();
+  });
+
+  it('serializes DOM hierarchy in JSON output and respects scope filtering for ancestors', () => {
+    const dashboard = makeEl({ view: 'dashboard' }, 'Dashboard');
+    dashboard.setAttribute('data-askable-scope', 'analytics');
+    const finance = makeEl({ tab: 'finance' }, 'Finance');
+    finance.setAttribute('data-askable-scope', 'analytics');
+    const revenue = makeEl({ metric: 'revenue', value: '$2.3M' }, 'Revenue card');
+    revenue.setAttribute('data-askable-scope', 'analytics');
+    dashboard.appendChild(finance);
+    finance.appendChild(revenue);
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    revenue.click();
+
+    expect((ctx as any).serializeFocus()).toEqual({
+      meta: { metric: 'revenue', value: '$2.3M' },
+      scope: 'analytics',
+      ancestors: [
+        { meta: { view: 'dashboard' }, scope: 'analytics', text: 'DashboardFinanceRevenue card' },
+        { meta: { tab: 'finance' }, scope: 'analytics', text: 'FinanceRevenue card' },
+      ],
+      text: 'Revenue card',
+      timestamp: expect.any(Number),
+    });
+    expect(JSON.parse(ctx.toPromptContext({ format: 'json', hierarchyDepth: 1 }))).toEqual({
+      meta: { metric: 'revenue', value: '$2.3M' },
+      scope: 'analytics',
+      ancestors: [
+        { meta: { tab: 'finance' }, scope: 'analytics', text: 'FinanceRevenue card' },
+      ],
+      text: 'Revenue card',
+      timestamp: expect.any(Number),
+    });
+
+    ctx.destroy();
+    dashboard.remove();
+  });
+
+  it('serializes pushed ancestor chains and applies hierarchy depth limits', () => {
+    const ctx = createAskableContext();
+
+    ctx.push({ metric: 'revenue', value: '$2.3M' }, 'Revenue card', {
+      scope: 'analytics',
+      ancestors: [
+        { meta: { view: 'dashboard' }, scope: 'analytics', text: 'Dashboard' },
+        { meta: { tab: 'finance' }, scope: 'analytics', text: 'Finance' },
+      ],
+    });
+
+    expect(ctx.toPromptContext()).toContain('view: dashboard > tab: finance > metric: revenue, value: $2.3M');
+    expect(ctx.toPromptContext({ hierarchyDepth: 1 })).toContain('tab: finance > metric: revenue, value: $2.3M');
+    expect((ctx as any).serializeFocus({ hierarchyDepth: 1 })).toEqual({
+      meta: { metric: 'revenue', value: '$2.3M' },
+      scope: 'analytics',
+      ancestors: [
+        { meta: { tab: 'finance' }, scope: 'analytics', text: 'Finance' },
+      ],
+      text: 'Revenue card',
+      timestamp: expect.any(Number),
+    });
+
+    ctx.destroy();
+  });
+
   it('serializeFocus() respects excludeKeys and keyOrder', () => {
     const el = makeEl({ z: 1, metric: 'churn', secret: 'x', value: '4.2%' }, 'Churn Rate');
     const ctx = createAskableContext();

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -7,11 +7,13 @@ import type {
   AskableEventHandler,
   AskableEventName,
   AskableFocus,
+  AskableFocusSegment,
   AskableObserveOptions,
   AskablePromptContextOptions,
   AskablePromptPreset,
   AskablePushOptions,
   AskableSerializedFocus,
+  AskableSerializedFocusSegment,
 } from './types.js';
 
 const PRESETS: Record<AskablePromptPreset, AskablePromptContextOptions> = {
@@ -64,7 +66,14 @@ export class AskableContextImpl implements AskableContext {
       ? this.sanitizeMetaFn(focus.meta)
       : focus.meta;
     const text = this.sanitizeTextFn ? this.sanitizeTextFn(focus.text) : focus.text;
-    return { ...focus, meta, text };
+    const ancestors = focus.ancestors?.map((segment) => ({
+      ...segment,
+      meta: this.sanitizeMetaFn && typeof segment.meta !== 'string'
+        ? this.sanitizeMetaFn(segment.meta)
+        : segment.meta,
+      text: this.sanitizeTextFn ? this.sanitizeTextFn(segment.text) : segment.text,
+    }));
+    return { ...focus, meta, ...(ancestors?.length ? { ancestors } : {}), text };
   }
 
   private matchesScope(focus: AskableFocus | null, scope?: string): focus is AskableFocus {
@@ -76,6 +85,85 @@ export class AskableContextImpl implements AskableContext {
   private filterByScope(focuses: AskableFocus[], scope?: string): AskableFocus[] {
     if (!scope) return focuses;
     return focuses.filter((focus) => this.matchesScope(focus, scope));
+  }
+
+  private resolveHierarchyElements(focus: AskableFocus, scope?: string): HTMLElement[] {
+    if (!focus.element) return [];
+
+    const visited = new Set<HTMLElement>([focus.element]);
+    const ancestors: HTMLElement[] = [];
+    let current: HTMLElement | null = focus.element;
+
+    while (current) {
+      const explicitParent = this.resolveExplicitHierarchyParent(current);
+      const parent: HTMLElement | null = explicitParent ?? current.parentElement?.closest('[data-askable]') ?? null;
+      if (!parent || visited.has(parent)) break;
+      visited.add(parent);
+      const parentFocus = buildFocus(parent, this.textExtractor);
+      if (parentFocus && this.matchesScope(parentFocus, scope)) {
+        ancestors.push(parent);
+      }
+      current = parent;
+    }
+
+    return ancestors.reverse();
+  }
+
+  private resolveExplicitHierarchyParent(el: HTMLElement): HTMLElement | null {
+    const selector = el.getAttribute('data-askable-parent')?.trim();
+    if (!selector) return null;
+    const rootNode = el.getRootNode();
+    const queryRoot = typeof (rootNode as ParentNode).querySelector === 'function'
+      ? rootNode as ParentNode
+      : document;
+    const candidate = queryRoot.querySelector(selector);
+    return candidate instanceof HTMLElement && candidate !== el && candidate.hasAttribute('data-askable')
+      ? candidate
+      : null;
+  }
+
+  private limitHierarchyDepth(elements: HTMLElement[], depth?: number): HTMLElement[] {
+    if (depth === undefined) return elements;
+    if (depth <= 0) return [];
+    return elements.slice(-depth);
+  }
+
+  private formatFocusMeta(meta: Record<string, unknown> | string): string {
+    return typeof meta === 'string'
+      ? meta
+      : Object.entries(meta).map(([k, v]) => `${k}: ${String(v)}`).join(', ');
+  }
+
+  private filterAncestorSegments(segments: AskableFocusSegment[] | undefined, scope?: string): AskableFocusSegment[] {
+    if (!segments || segments.length === 0) return [];
+    if (!scope) return segments;
+    return segments.filter((segment) => segment.scope === undefined || segment.scope === scope);
+  }
+
+  private limitAncestorSegments(segments: AskableFocusSegment[] | undefined, depth?: number): AskableFocusSegment[] {
+    if (!segments || segments.length === 0) return [];
+    if (depth === undefined) return segments;
+    if (depth <= 0) return [];
+    return segments.slice(-depth);
+  }
+
+  private serializeFocusSegment(
+    segment: AskableFocusSegment,
+    options?: AskablePromptContextOptions
+  ): AskableSerializedFocusSegment {
+    const resolved = this.resolveOptions(options);
+    const includeText = resolved.includeText ?? true;
+    const maxTextLength = resolved.maxTextLength;
+    const meta = typeof segment.meta === 'string'
+      ? segment.meta
+      : this.normalizeMeta(segment.meta, resolved);
+    const text = includeText ? this.normalizeText(segment.text, maxTextLength) : '';
+
+    return {
+      meta,
+      ...(segment.scope ? { scope: segment.scope } : {}),
+      ...(text ? { text } : {}),
+    };
   }
 
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void {
@@ -155,6 +243,7 @@ export class AskableContextImpl implements AskableContext {
       source: 'push',
       meta: sanitizedMeta,
       ...(options?.scope ? { scope: options.scope } : {}),
+      ...(options?.ancestors?.length ? { ancestors: options.ancestors } : {}),
       text: sanitizedText,
       timestamp: Date.now(),
     };
@@ -274,13 +363,27 @@ export class AskableContextImpl implements AskableContext {
 
     const textLabel = resolved.textLabel ?? 'value';
     const prefix = resolved.prefix ?? 'User is focused on:';
+    const ancestorSegments = focus?.ancestors?.length
+      ? this.limitAncestorSegments(this.filterAncestorSegments(focus.ancestors, resolved.scope), resolved.hierarchyDepth)
+      : focus
+        ? this.limitHierarchyDepth(this.resolveHierarchyElements(focus, resolved.scope), resolved.hierarchyDepth)
+          .map((element) => buildFocus(element, this.textExtractor))
+          .filter((item): item is AskableFocus => Boolean(item))
+          .map((item) => ({
+            meta: typeof item.meta === 'string' ? item.meta : this.normalizeMeta(item.meta, resolved),
+            ...(item.scope ? { scope: item.scope } : {}),
+            ...(item.text ? { text: this.normalizeText(item.text, resolved.maxTextLength) } : {}),
+          }))
+        : [];
+    const hierarchyPrefix = ancestorSegments
+      .map((segment) => this.formatFocusMeta(segment.meta))
+      .join(' > ');
 
-    const metaStr = typeof serialized.meta === 'string'
-      ? serialized.meta
-      : Object.entries(serialized.meta).map(([k, v]) => `${k}: ${String(v)}`).join(', ');
+    const metaStr = this.formatFocusMeta(serialized.meta);
+    const metaWithHierarchy = hierarchyPrefix ? `${hierarchyPrefix} > ${metaStr}` : metaStr;
 
     const parts: string[] = [prefix];
-    if (metaStr) parts.push(metaStr);
+    if (metaWithHierarchy) parts.push(metaWithHierarchy);
     if (serialized.text) parts.push(`${textLabel} "${serialized.text}"`);
 
     return parts.join(' — ');
@@ -294,12 +397,17 @@ export class AskableContextImpl implements AskableContext {
     const meta = typeof focus.meta === 'string'
       ? focus.meta
       : this.normalizeMeta(focus.meta, resolved);
+    const ancestors = this.limitAncestorSegments(
+      this.filterAncestorSegments(focus.ancestors, resolved.scope),
+      resolved.hierarchyDepth,
+    ).map((segment) => this.serializeFocusSegment(segment, resolved));
 
     const text = includeText ? this.normalizeText(focus.text, maxTextLength) : '';
 
     return {
       meta,
       ...(focus.scope ? { scope: focus.scope } : {}),
+      ...(ancestors.length ? { ancestors } : {}),
       ...(text ? { text } : {}),
       timestamp: focus.timestamp,
     };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export type {
   AskableEventMap,
   AskableEventName,
   AskableFocus,
+  AskableFocusSegment,
   AskableFocusSource,
   AskableObserveOptions,
   AskablePromptContextOptions,
@@ -21,6 +22,7 @@ export type {
   AskablePromptPreset,
   AskablePushOptions,
   AskableSerializedFocus,
+  AskableSerializedFocusSegment,
   AskableTargetStrategy,
 } from './types.js';
 

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -1,4 +1,4 @@
-import type { AskableFocus, AskableEvent, AskableTargetStrategy } from './types.js';
+import type { AskableFocus, AskableEvent, AskableFocusSegment, AskableTargetStrategy } from './types.js';
 
 type FocusCallback = (focus: AskableFocus) => void;
 type ObserverLifecycleCallbacks = {
@@ -32,6 +32,19 @@ function extractText(el: HTMLElement): string {
   return (el.textContent ?? '').trim();
 }
 
+function resolveExplicitParent(el: HTMLElement): HTMLElement | null {
+  const selector = el.getAttribute('data-askable-parent')?.trim();
+  if (!selector) return null;
+  const rootNode = el.getRootNode();
+  const queryRoot = typeof (rootNode as ParentNode).querySelector === 'function'
+    ? rootNode as ParentNode
+    : document;
+  const candidate = queryRoot.querySelector(selector);
+  return candidate instanceof HTMLElement && candidate !== el && candidate.hasAttribute('data-askable')
+    ? candidate
+    : null;
+}
+
 type MetaCacheEntry = {
   raw: string;
   parsed: Record<string, unknown> | string;
@@ -52,32 +65,71 @@ function resolveMeta(
   return parsed;
 }
 
-export function buildFocus(
+function buildFocusSegment(
   el: HTMLElement,
   textExtractor?: (el: HTMLElement) => string,
   metaCache?: WeakMap<HTMLElement, MetaCacheEntry>
-): AskableFocus | null {
+): AskableFocusSegment | null {
   const raw = el.getAttribute('data-askable');
   if (raw === null) return null;
-  // data-askable-text overrides both textExtractor and default textContent extraction.
-  // Set to an empty string ("") to suppress text entirely for a single element.
   const textOverride = el.getAttribute('data-askable-text');
   const text = textOverride !== null
     ? textOverride
     : textExtractor ? textExtractor(el) : extractText(el);
   const scope = el.getAttribute('data-askable-scope')?.trim() || undefined;
+
   return {
-    source: 'dom',
     meta: resolveMeta(el, raw, metaCache),
     ...(scope ? { scope } : {}),
     text,
+  };
+}
+
+function resolveAncestorSegments(
+  el: HTMLElement,
+  textExtractor?: (el: HTMLElement) => string,
+  metaCache?: WeakMap<HTMLElement, MetaCacheEntry>
+): AskableFocusSegment[] {
+  const segments: AskableFocusSegment[] = [];
+  const visited = new Set<HTMLElement>([el]);
+  let current: HTMLElement | null = el;
+
+  while (current) {
+    const explicitParent = resolveExplicitParent(current);
+    const parent: HTMLElement | null = explicitParent ?? current.parentElement?.closest('[data-askable]') ?? null;
+    if (!parent || visited.has(parent)) break;
+    visited.add(parent);
+    const segment = buildFocusSegment(parent, textExtractor, metaCache);
+    if (segment) {
+      segments.push(segment);
+    }
+    current = parent;
+  }
+
+  return segments.reverse();
+}
+
+export function buildFocus(
+  el: HTMLElement,
+  textExtractor?: (el: HTMLElement) => string,
+  metaCache?: WeakMap<HTMLElement, MetaCacheEntry>
+): AskableFocus | null {
+  const segment = buildFocusSegment(el, textExtractor, metaCache);
+  if (!segment) return null;
+  const ancestors = resolveAncestorSegments(el, textExtractor, metaCache);
+  return {
+    source: 'dom',
+    meta: segment.meta,
+    ...(segment.scope ? { scope: segment.scope } : {}),
+    ...(ancestors.length > 0 ? { ancestors } : {}),
+    text: segment.text,
     element: el,
     timestamp: Date.now(),
   };
 }
 
 const ALL_EVENTS: AskableEvent[] = ['click', 'hover', 'focus'];
-const OBSERVED_ATTRIBUTES = ['data-askable', 'data-askable-text', 'data-askable-priority', 'data-askable-scope'] as const;
+const OBSERVED_ATTRIBUTES = ['data-askable', 'data-askable-text', 'data-askable-priority', 'data-askable-scope', 'data-askable-parent'] as const;
 
 export class Observer {
   private root: HTMLElement | Document | null = null;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,6 +8,8 @@ export interface AskableFocus {
   meta: Record<string, unknown> | string;
   /** Optional category used to filter context for different agents/copilots. */
   scope?: string;
+  /** Optional ancestor chain from outermost to innermost parent annotation. */
+  ancestors?: AskableFocusSegment[];
   /** Trimmed textContent of the element */
   text: string;
   /** The DOM element (undefined when set via push()) */
@@ -76,6 +78,18 @@ export type AskablePromptFormat = 'natural' | 'json';
  */
 export type AskablePromptPreset = 'compact' | 'verbose' | 'json';
 
+export interface AskableFocusSegment {
+  meta: Record<string, unknown> | string;
+  scope?: string;
+  text: string;
+}
+
+export interface AskableSerializedFocusSegment {
+  meta: Record<string, unknown> | string;
+  scope?: string;
+  text?: string;
+}
+
 export interface AskablePromptContextOptions {
   /**
    * Apply a named preset as the default configuration.
@@ -88,6 +102,8 @@ export interface AskablePromptContextOptions {
   preset?: AskablePromptPreset;
   /** Optional scope/category filter. Unscoped entries are included in every scoped view. */
   scope?: string;
+  /** Number of ancestor levels to include, counting back from the immediate annotated parent. Defaults to the full chain. */
+  hierarchyDepth?: number;
   /** Output format. Defaults to natural language. */
   format?: AskablePromptFormat;
   /** Include extracted text in serialized output. Defaults to true. */
@@ -167,6 +183,7 @@ export interface AskableContextOptions {
 export interface AskableSerializedFocus {
   meta: Record<string, unknown> | string;
   scope?: string;
+  ancestors?: AskableSerializedFocusSegment[];
   text?: string;
   timestamp: number;
 }
@@ -174,6 +191,8 @@ export interface AskableSerializedFocus {
 export interface AskablePushOptions {
   /** Optional category used to filter context for different agents/copilots. */
   scope?: string;
+  /** Optional ancestor chain from outermost to innermost parent annotation. */
+  ancestors?: AskableFocusSegment[];
 }
 
 export interface AskableContextOutputOptions extends AskablePromptContextOptions {

--- a/packages/react-native/src/Askable.tsx
+++ b/packages/react-native/src/Askable.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import type { ReactElement } from 'react';
-import type { AskableContext } from '@askable-ui/core';
+import type { AskableContext, AskableFocusSegment } from '@askable-ui/core';
+
+const AskableHierarchyContext = React.createContext<AskableFocusSegment[]>([]);
 
 export interface AskableProps {
   ctx: AskableContext;
@@ -12,21 +14,38 @@ export interface AskableProps {
 
 export function Askable({ ctx, meta, scope, text = '', children }: AskableProps) {
   const child = React.Children.only(children);
+  const parentAncestors = React.useContext(AskableHierarchyContext);
+  const currentSegment = React.useMemo<AskableFocusSegment>(() => ({
+    meta,
+    ...(scope ? { scope } : {}),
+    text,
+  }), [meta, scope, text]);
+  const nextAncestors = React.useMemo(
+    () => [...parentAncestors, currentSegment],
+    [currentSegment, parentAncestors],
+  );
   const originalOnPress = child.props.onPress;
   const originalOnLongPress = child.props.onLongPress;
 
   const focus = () => {
-    ctx.push(meta, text, scope ? { scope } : undefined);
+    ctx.push(meta, text, {
+      ...(scope ? { scope } : {}),
+      ...(parentAncestors.length ? { ancestors: parentAncestors } : {}),
+    });
   };
 
-  return React.cloneElement(child, {
-    onPress: () => {
-      originalOnPress?.();
-      focus();
-    },
-    onLongPress: () => {
-      originalOnLongPress?.();
-      focus();
-    },
-  });
+  return (
+    <AskableHierarchyContext.Provider value={nextAncestors}>
+      {React.cloneElement(child, {
+        onPress: () => {
+          originalOnPress?.();
+          focus();
+        },
+        onLongPress: () => {
+          originalOnLongPress?.();
+          focus();
+        },
+      })}
+    </AskableHierarchyContext.Provider>
+  );
 }

--- a/packages/react-native/src/__tests__/Askable.test.tsx
+++ b/packages/react-native/src/__tests__/Askable.test.tsx
@@ -75,4 +75,46 @@ describe('Askable (React Native)', () => {
 
     ctx.destroy();
   });
+
+  it('supports nested Askable wrappers by pushing ancestor hierarchy', () => {
+    const ctx = createAskableContext();
+    const tree = TestRenderer.create(
+      <Askable ctx={ctx} meta={{ view: 'dashboard' }} text="Dashboard" scope="analytics">
+        <Askable ctx={ctx} meta={{ tab: 'finance' }} text="Finance" scope="analytics">
+          <Askable ctx={ctx} meta={{ metric: 'revenue' }} text="Revenue card" scope="analytics">
+            {React.createElement('Pressable', { testID: 'pressable' })}
+          </Askable>
+        </Askable>
+      </Askable>
+    );
+
+    const pressable = tree.root.findByProps({ testID: 'pressable' });
+
+    act(() => {
+      pressable.props.onPress();
+    });
+
+    expect(ctx.getFocus()).toMatchObject({
+      meta: { metric: 'revenue' },
+      text: 'Revenue card',
+      scope: 'analytics',
+      ancestors: [
+        { meta: { view: 'dashboard' }, scope: 'analytics', text: 'Dashboard' },
+        { meta: { tab: 'finance' }, scope: 'analytics', text: 'Finance' },
+      ],
+      source: 'push',
+    });
+    expect(ctx.toPromptContext()).toContain('view: dashboard > tab: finance > metric: revenue');
+    expect((ctx as any).serializeFocus({ hierarchyDepth: 1 })).toEqual({
+      meta: { metric: 'revenue' },
+      scope: 'analytics',
+      ancestors: [
+        { meta: { tab: 'finance' }, scope: 'analytics', text: 'Finance' },
+      ],
+      text: 'Revenue card',
+      timestamp: expect.any(Number),
+    });
+
+    ctx.destroy();
+  });
 });

--- a/packages/react/src/__tests__/Askable.test.tsx
+++ b/packages/react/src/__tests__/Askable.test.tsx
@@ -60,4 +60,22 @@ describe('Askable', () => {
     const el = container.firstChild as HTMLElement;
     expect(el.getAttribute('data-askable-scope')).toBe('analytics');
   });
+
+  it('supports nested Askable wrappers that form a DOM hierarchy', () => {
+    const { container } = render(
+      <Askable meta={{ view: 'dashboard' }}>
+        <Askable meta={{ tab: 'finance' }}>
+          <Askable meta={{ metric: 'revenue' }}>Revenue Chart</Askable>
+        </Askable>
+      </Askable>
+    );
+
+    const outer = container.firstChild as HTMLElement;
+    const middle = outer.firstElementChild as HTMLElement;
+    const inner = middle.firstElementChild as HTMLElement;
+
+    expect(outer.getAttribute('data-askable')).toBe(JSON.stringify({ view: 'dashboard' }));
+    expect(middle.getAttribute('data-askable')).toBe(JSON.stringify({ tab: 'finance' }));
+    expect(inner.getAttribute('data-askable')).toBe(JSON.stringify({ metric: 'revenue' }));
+  });
 });

--- a/packages/svelte/src/__tests__/AskableNested.svelte
+++ b/packages/svelte/src/__tests__/AskableNested.svelte
@@ -1,0 +1,9 @@
+<script>
+  import Askable from '../Askable.svelte';
+</script>
+
+<Askable meta={{ view: 'dashboard' }}>
+  <Askable meta={{ tab: 'finance' }}>
+    <Askable meta={{ metric: 'revenue' }}>Revenue Chart</Askable>
+  </Askable>
+</Askable>

--- a/packages/svelte/src/__tests__/component.test.ts
+++ b/packages/svelte/src/__tests__/component.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import Askable from '../Askable.svelte';
 import AskableWithContent from './AskableWithContent.svelte';
+import AskableNested from './AskableNested.svelte';
 
 describe('Askable (Svelte)', () => {
   it('sets data-askable attribute with stringified object meta', () => {
@@ -41,5 +42,15 @@ describe('Askable (Svelte)', () => {
     const { container } = render(Askable, { props: { meta: { widget: 'revenue' }, scope: 'analytics' } });
     const el = container.firstElementChild as HTMLElement;
     expect(el.getAttribute('data-askable-scope')).toBe('analytics');
+  });
+
+  it('supports nested Askable wrappers that form a DOM hierarchy', () => {
+    const { container } = render(AskableNested);
+
+    const nodes = container.querySelectorAll('[data-askable]');
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0].getAttribute('data-askable')).toBe(JSON.stringify({ view: 'dashboard' }));
+    expect(nodes[1].getAttribute('data-askable')).toBe(JSON.stringify({ tab: 'finance' }));
+    expect(nodes[2].getAttribute('data-askable')).toBe(JSON.stringify({ metric: 'revenue' }));
   });
 });

--- a/packages/vue/src/__tests__/Askable.test.ts
+++ b/packages/vue/src/__tests__/Askable.test.ts
@@ -60,4 +60,23 @@ describe('Askable (Vue)', () => {
     const wrapper = track(mount(Askable, { props: { meta: { widget: 'revenue' }, scope: 'analytics' } }));
     expect(wrapper.attributes('data-askable-scope')).toBe('analytics');
   });
+
+  it('supports nested Askable wrappers that form a DOM hierarchy', () => {
+    const wrapper = track(mount({
+      components: { Askable },
+      template: `
+        <Askable :meta="{ view: 'dashboard' }">
+          <Askable :meta="{ tab: 'finance' }">
+            <Askable :meta="{ metric: 'revenue' }">Revenue Chart</Askable>
+          </Askable>
+        </Askable>
+      `,
+    }));
+
+    const nodes = wrapper.findAll('[data-askable]');
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0].attributes('data-askable')).toBe(JSON.stringify({ view: 'dashboard' }));
+    expect(nodes[1].attributes('data-askable')).toBe(JSON.stringify({ tab: 'finance' }));
+    expect(nodes[2].attributes('data-askable')).toBe(JSON.stringify({ metric: 'revenue' }));
+  });
 });

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -50,6 +50,7 @@ const viewportCtx = createAskableContext({ viewport: true });
 |---|---|---|
 | `data-askable` | JSON object or string | Marks an element as askable. Value becomes `AskableFocus.meta`. |
 | `data-askable-scope` | string | Optional category filter. Scoped queries like `ctx.toPromptContext({ scope: 'analytics' })` include matching scoped entries plus unscoped ones. |
+| `data-askable-parent` | CSS selector | Explicit parent annotation to use in hierarchy paths when DOM nesting alone is not enough. |
 | `data-askable-priority` | integer | Override the default innermost-wins rule in `'deepest'` strategy. Higher values win. |
 | `data-askable-text` | string | Override the text captured from this element. Empty string `""` suppresses text entirely. Takes priority over `textExtractor`. |
 
@@ -120,6 +121,7 @@ const focus = ctx.getFocus();
 if (focus) {
   console.log(focus.source);    // 'dom' | 'select' | 'push'
   console.log(focus.meta);      // Record<string, unknown> | string
+  console.log(focus.ancestors); // optional ancestor chain, outermost first
   console.log(focus.text);      // trimmed textContent
   console.log(focus.element);   // HTMLElement | undefined (undefined for push())
   console.log(focus.timestamp); // Unix ms
@@ -177,7 +179,7 @@ ctx.select(el);
 
 ---
 
-### `push(meta, text?)`
+### `push(meta, text?, options?)`
 
 Set focus from data alone — no DOM element required. Fires the `'focus'` event and updates history. The resulting `AskableFocus` has `source: 'push'` and `element: undefined`.
 
@@ -192,6 +194,18 @@ ctx.push('row-label');
 
 // No text
 ctx.push({ chart: 'revenue', period: 'Q3' });
+
+// Explicit hierarchy for non-DOM or synthetic UIs
+ctx.push(
+  { metric: 'revenue', value: '$2.3M' },
+  'Revenue card',
+  {
+    ancestors: [
+      { meta: { view: 'dashboard' }, text: 'Dashboard' },
+      { meta: { tab: 'finance' }, text: 'Finance' },
+    ],
+  },
+);
 ```
 
 Sanitizers (`sanitizeMeta`, `sanitizeText`) apply to `push()` the same way they apply to DOM-sourced focus.
@@ -214,7 +228,10 @@ Serialize the current focus to a prompt-ready string. See [Prompt Serialization]
 
 ```ts
 ctx.toPromptContext();
-// → "User is focused on: — metric: revenue, delta: -12% — value "Revenue""
+// → "User is focused on: — metric: revenue, delta: -12% — value \"Revenue\""
+
+ctx.toPromptContext({ hierarchyDepth: 1 });
+// Limit ancestor depth when hierarchical context is available
 
 ctx.toPromptContext({ format: 'json' });
 // → '{"meta":{"metric":"revenue","delta":"-12%"},"text":"Revenue","timestamp":1712345678}'

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -137,6 +137,7 @@ Options accepted by `toPromptContext()`, `toHistoryContext()`, and `serializeFoc
 interface AskablePromptContextOptions {
   preset?: AskablePromptPreset;    // Named shorthand. Individual options override it.
   scope?: string;                  // Optional category filter. Unscoped entries are included everywhere.
+  hierarchyDepth?: number;         // Limit ancestor levels included in hierarchical context.
   format?: AskablePromptFormat;    // 'natural' | 'json'. Default: 'natural'
   includeText?: boolean;           // Include element text. Default: true
   maxTextLength?: number;          // Truncate text to N chars

--- a/site/docs/guide/annotating.md
+++ b/site/docs/guide/annotating.md
@@ -60,6 +60,35 @@ You can nest `[data-askable]` elements. When a user interacts with a nested elem
 </section>
 ```
 
+When you serialize focus, Askable also preserves that structure in the hierarchy path:
+
+```ts
+ctx.toPromptContext();
+// → "User is focused on: — page: dashboard > widget: revenue-chart — value \"Revenue Chart\""
+```
+
+### Explicit hierarchy links
+
+If DOM nesting alone is not enough, point an element at its logical Askable parent with `data-askable-parent`:
+
+```html
+<section id="dashboard-root" data-askable='{"page":"dashboard"}'></section>
+<div id="finance-tab" data-askable='{"tab":"finance"}' data-askable-parent="#dashboard-root"></div>
+<button
+  data-askable='{"metric":"revenue","value":"$2.3M"}'
+  data-askable-parent="#finance-tab"
+>
+  Revenue card
+</button>
+```
+
+You can also limit how much ancestry is included when serializing:
+
+```ts
+ctx.toPromptContext({ hierarchyDepth: 1 });
+// → "User is focused on: — tab: finance > metric: revenue, value: $2.3M — value \"Revenue card\""
+```
+
 ### Target strategy
 
 The `targetStrategy` option passed to `observe()` controls how the winning element is chosen when nested `[data-askable]` elements are involved:


### PR DESCRIPTION
## Summary
- add hierarchical Askable ancestry for nested DOM annotations and explicit `data-askable-parent` links
- expose ancestor chains in structured serializers and JSON output with `hierarchyDepth` support
- add push-based/programmatic hierarchy support and React Native nested wrapper parity
- document hierarchy attributes/options and expand adapter/core tests

## Testing
- targeted core context tests
- targeted React Native Askable tests
- targeted React Askable tests
- targeted Vue and Svelte Askable tests
- full monorepo build and test suite

Closes #121
Closes #183
Closes #184
