### PR TITLE
docs: update docs version and hierarchy coverage

### DIFF
--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       { text: 'API Reference', link: '/api/core', activeMatch: '/api/' },
       { text: 'Examples', link: '/examples/dashboard', activeMatch: '/examples/' },
       {
-        text: 'v0.4.1',
+        text: 'v0.5.0',
         items: [
           { text: 'Changelog', link: 'https://github.com/askable-ui/askable/releases' },
           { text: 'npm', link: 'https://www.npmjs.com/package/@askable-ui/core' },
@@ -74,6 +74,7 @@ export default defineConfig({
           items: [
             { text: '@askable-ui/core', link: '/api/core' },
             { text: '@askable-ui/react', link: '/api/react' },
+            { text: '@askable-ui/react-native', link: '/api/react-native' },
             { text: '@askable-ui/vue', link: '/api/vue' },
             { text: '@askable-ui/svelte', link: '/api/svelte' },
 

--- a/site/docs/api/react-native.md
+++ b/site/docs/api/react-native.md
@@ -16,7 +16,7 @@ npm install @askable-ui/react-native @askable-ui/core
 
 ## `<Askable>`
 
-Clones a single React Native pressable child and merges focus updates into its `onPress` and `onLongPress` handlers.
+Clones a single React Native pressable child and merges focus updates into its `onPress` and `onLongPress` handlers. Nested `<Askable>` wrappers also contribute ancestor segments, so press-driven mobile flows can serialize the same hierarchy paths as DOM-based web flows.
 
 ```tsx
 import { Pressable, Text } from 'react-native';
@@ -44,6 +44,21 @@ function RevenueCard() {
 | `scope` | `string` | Optional category stored with press-driven focus for scoped prompt/history queries |
 | `text` | `string` | Optional human-readable label stored alongside `meta` |
 | `children` | `ReactElement` | A single child that accepts `onPress` / `onLongPress` props |
+
+```tsx
+<Askable ctx={ctx} meta={{ view: 'dashboard' }} text="Dashboard" scope="analytics">
+  <Askable ctx={ctx} meta={{ tab: 'finance' }} text="Finance" scope="analytics">
+    <Askable ctx={ctx} meta={{ metric: 'revenue' }} text="Revenue card" scope="analytics">
+      <Pressable>
+        <Text>Revenue</Text>
+      </Pressable>
+    </Askable>
+  </Askable>
+</Askable>
+
+ctx.toPromptContext();
+// → "User is focused on: — view: dashboard > tab: finance > metric: revenue — value \"Revenue card\""
+```
 
 ---
 

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -8,11 +8,14 @@ import type {
   AskableContextOptions,
   AskableContextOutputOptions,
   AskableFocus,
+  AskableFocusSegment,
   AskableFocusSource,
   AskableSerializedFocus,
+  AskableSerializedFocusSegment,
   AskablePromptContextOptions,
   AskablePromptFormat,
   AskablePromptPreset,
+  AskablePushOptions,
   AskableEvent,
   AskableObserveOptions,
   AskableEventMap,
@@ -87,12 +90,22 @@ interface AskableFocus {
   meta: Record<string, unknown> | string;
   /** Optional category used to filter context for different agents/copilots. */
   scope?: string;
+  /** Optional ancestor chain, outermost first. */
+  ancestors?: AskableFocusSegment[];
   /** Trimmed textContent of the element. */
   text: string;
   /** The DOM element. Undefined when set via push(). */
   element?: HTMLElement;
   /** Unix timestamp (ms) when focus was set. */
   timestamp: number;
+}
+```
+
+```ts
+interface AskableFocusSegment {
+  meta: Record<string, unknown> | string;
+  scope?: string;
+  text: string;
 }
 ```
 
@@ -106,8 +119,30 @@ The shape returned by `serializeFocus()`. Similar to `AskableFocus` but without 
 interface AskableSerializedFocus {
   meta: Record<string, unknown> | string;
   scope?: string;
+  ancestors?: AskableSerializedFocusSegment[];
   text?: string;
   timestamp: number;
+}
+```
+
+```ts
+interface AskableSerializedFocusSegment {
+  meta: Record<string, unknown> | string;
+  scope?: string;
+  text?: string;
+}
+```
+
+---
+
+## `AskablePushOptions`
+
+Options accepted by `ctx.push(meta, text, options)`.
+
+```ts
+interface AskablePushOptions {
+  scope?: string;
+  ancestors?: AskableFocusSegment[];
 }
 ```
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,6 +2,8 @@
 
 ## Pick your framework
 
+> Current npm release: **v0.5.0**.
+
 ::: code-group
 
 ```bash [React]

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -5,6 +5,9 @@ hero:
   name: "askable-ui"
   text: "UI context your LLM can actually use"
   tagline: Annotate any DOM element with data-askable and instantly turn what the user is looking at into structured, prompt-ready context.
+  image:
+    src: /logo-dark.svg
+    alt: askable-ui
   actions:
     - theme: brand
       text: Get Started
@@ -33,6 +36,8 @@ features:
     title: Works with any LLM
     details: toPromptContext() returns a plain string — drop it into OpenAI, Anthropic, Vercel AI SDK, CopilotKit, or any LLM pipeline. No vendor lock-in.
 ---
+
+> Current npm release: **v0.5.0**.
 
 ## Quick look
 


### PR DESCRIPTION
## Summary
- update the docs site nav from v0.4.1 to the current v0.5.0 release
- add the React Native API page to the docs sidebar and document nested hierarchy behavior there
- expand the type reference with hierarchy-related types and push options
- add visible current-release notes to the docs homepage and getting started page

## Testing
- built the docs site successfully with VitePress from `site/docs`

Fixes docs follow-up from #185.
