### PR TITLE
feat: add versioned docs publishing support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,12 +34,9 @@ jobs:
         with:
           node-version: 20
 
-      - name: Build VitePress docs
-        run: npm install && npm run build
+      - name: Build versioned VitePress docs
+        run: npm ci && npm run build:versioned
         working-directory: site/docs
-
-      - name: Copy docs into www
-        run: cp -r site/docs/.vitepress/dist site/www/docs
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ packages/*/dist/
 site/docs/node_modules
 site/docs/.vitepress/dist
 site/docs/.vitepress/cache
+site/www/docs
 
 # Playwright
 /playwright-report/

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -1,7 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitepress'
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const docsRoot = resolve(__dirname, '..')
+const versions = JSON.parse(readFileSync(resolve(docsRoot, 'versions.json'), 'utf8')) as {
+  current: { label: string; slug: string }
+  archived: Array<{ label: string; slug: string }>
+}
+const docsBase = process.env.ASKABLE_DOCS_BASE ?? '/docs/'
+const docsOrigin = process.env.ASKABLE_DOCS_SITE_ORIGIN ?? 'https://askable-ui.com'
+const currentVersion = versions.current
+const archivedVersions = versions.archived ?? []
+const latestDocsUrl = `${docsOrigin}/docs/`
+const versionedDocsUrl = (slug: string) => `${docsOrigin}/docs/${slug}/`
+const versionItems = [
+  { text: `Latest docs (${currentVersion.label})`, link: latestDocsUrl },
+  { text: `${currentVersion.label} docs`, link: versionedDocsUrl(currentVersion.slug) },
+  ...archivedVersions.map((version) => ({ text: version.label, link: versionedDocsUrl(version.slug) })),
+  { text: 'Migration guides', link: '/guide/migrations' },
+  { text: 'Changelog', link: 'https://github.com/askable-ui/askable/releases' },
+  { text: 'npm', link: 'https://www.npmjs.com/package/@askable-ui/core' },
+]
+
 export default defineConfig({
-  base: '/docs/',
+  base: docsBase,
   title: 'askable-ui',
   description: 'UI context your LLM can actually use. Annotate elements with data-askable and feed structured focus context into any AI assistant.',
   head: [
@@ -16,11 +40,8 @@ export default defineConfig({
       { text: 'API Reference', link: '/api/core', activeMatch: '/api/' },
       { text: 'Examples', link: '/examples/dashboard', activeMatch: '/examples/' },
       {
-        text: 'v0.5.0',
-        items: [
-          { text: 'Changelog', link: 'https://github.com/askable-ui/askable/releases' },
-          { text: 'npm', link: 'https://www.npmjs.com/package/@askable-ui/core' },
-        ],
+        text: currentVersion.label,
+        items: versionItems,
       },
     ],
 
@@ -50,6 +71,7 @@ export default defineConfig({
             { text: 'Focus & History', link: '/guide/focus-history' },
             { text: 'Ask AI Buttons (select())', link: '/guide/select' },
             { text: 'Prompt Serialization', link: '/guide/serialization' },
+            { text: 'Migration Guides', link: '/guide/migrations' },
             { text: 'SSR Safety', link: '/guide/ssr' },
             { text: 'Browser Support', link: '/guide/browser-support' },
           ],
@@ -84,6 +106,7 @@ export default defineConfig({
           text: 'Types',
           items: [
             { text: 'Type Reference', link: '/api/types' },
+            { text: 'Docs Versioning', link: '/api/versioning' },
           ],
         },
       ],

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -1,0 +1,27 @@
+# Docs Versioning
+
+askable-ui supports two kinds of docs URLs:
+
+- `/docs/` — latest stable docs
+- `/docs/<version>/` — frozen version-specific docs snapshots
+
+## Current version
+
+- Latest stable: `v0.5.0`
+- Versioned current docs URL: `/docs/v0.5.0/`
+
+## Archived versions
+
+No archived major versions yet.
+
+The current release is also published at `/docs/v0.5.0/` so version-specific links work before the first breaking release.
+
+## Breaking release workflow
+
+For a breaking release:
+
+1. snapshot the current docs with `npm run snapshot:current`
+2. move that version into `archived` in `versions.json`
+3. update `current` to the new major version
+4. update docs content for the new release
+5. publish with `npm run build:versioned`

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -3,6 +3,8 @@
 ## Pick your framework
 
 > Current npm release: **v0.5.0**.
+>
+> Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 
 ::: code-group
 

--- a/site/docs/guide/migrations.md
+++ b/site/docs/guide/migrations.md
@@ -1,0 +1,21 @@
+# Migration Guides
+
+This page collects migration guidance for breaking Askable releases.
+
+## Current policy
+
+- **Patch/minor releases** update the live docs only.
+- **Breaking/major releases** preserve the previous major docs under a versioned URL.
+- The latest stable docs remain available at `/docs/`.
+
+## Available migrations
+
+There are no published major-version migrations yet.
+
+When Askable ships a breaking release, add:
+
+- a release summary
+- key API/behavior changes
+- upgrade steps
+- before/after examples
+- links to the archived docs for the previous major

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -38,6 +38,8 @@ features:
 ---
 
 > Current npm release: **v0.5.0**.
+>
+> Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
 ## Quick look
 

--- a/site/docs/package.json
+++ b/site/docs/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build",
+    "build:versioned": "node ./scripts/build-versioned-docs.mjs",
+    "snapshot:current": "node ./scripts/snapshot-current-docs.mjs",
     "preview": "vitepress preview"
   },
   "devDependencies": {

--- a/site/docs/scripts/build-versioned-docs.mjs
+++ b/site/docs/scripts/build-versioned-docs.mjs
@@ -1,0 +1,56 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const docsRoot = resolve(__dirname, '..');
+const repoRoot = resolve(docsRoot, '..', '..');
+const versionsPath = join(docsRoot, 'versions.json');
+const outputRoot = join(repoRoot, 'site', 'www', 'docs');
+const distRoot = join(docsRoot, '.vitepress', 'dist');
+
+const versions = JSON.parse(readFileSync(versionsPath, 'utf8'));
+const current = versions.current;
+const archived = versions.archived ?? [];
+
+function runBuild(base) {
+  rmSync(distRoot, { recursive: true, force: true });
+  const result = spawnSync('npm', ['run', 'build'], {
+    cwd: docsRoot,
+    env: {
+      ...process.env,
+      ASKABLE_DOCS_BASE: base,
+    },
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function copyDir(from, to) {
+  rmSync(to, { recursive: true, force: true });
+  mkdirSync(dirname(to), { recursive: true });
+  cpSync(from, to, { recursive: true });
+}
+
+rmSync(outputRoot, { recursive: true, force: true });
+mkdirSync(outputRoot, { recursive: true });
+
+runBuild('/docs/');
+copyDir(distRoot, outputRoot);
+
+const currentVersionOutput = join(outputRoot, current.slug);
+runBuild(`/docs/${current.slug}/`);
+copyDir(distRoot, currentVersionOutput);
+
+for (const version of archived) {
+  const snapshotRoot = join(docsRoot, 'versions', version.slug);
+  if (!existsSync(snapshotRoot)) {
+    throw new Error(`Missing archived docs snapshot: ${snapshotRoot}`);
+  }
+  copyDir(snapshotRoot, join(outputRoot, version.slug));
+}
+
+writeFileSync(join(outputRoot, 'versions.json'), JSON.stringify(versions, null, 2) + '\n');

--- a/site/docs/scripts/snapshot-current-docs.mjs
+++ b/site/docs/scripts/snapshot-current-docs.mjs
@@ -1,0 +1,30 @@
+import { cpSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const docsRoot = resolve(__dirname, '..');
+const distRoot = join(docsRoot, '.vitepress', 'dist');
+const versions = JSON.parse(readFileSync(join(docsRoot, 'versions.json'), 'utf8'));
+const slug = process.argv[2] ?? versions.current.slug;
+const snapshotRoot = join(docsRoot, 'versions', slug);
+
+rmSync(distRoot, { recursive: true, force: true });
+const result = spawnSync('npm', ['run', 'build'], {
+  cwd: docsRoot,
+  env: {
+    ...process.env,
+    ASKABLE_DOCS_BASE: `/docs/${slug}/`,
+  },
+  stdio: 'inherit',
+});
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+rmSync(snapshotRoot, { recursive: true, force: true });
+mkdirSync(dirname(snapshotRoot), { recursive: true });
+cpSync(distRoot, snapshotRoot, { recursive: true });
+console.log(`Snapshot written to ${snapshotRoot}`);

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,0 +1,7 @@
+{
+  "current": {
+    "label": "v0.5.0",
+    "slug": "v0.5.0"
+  },
+  "archived": []
+}

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -1,0 +1,41 @@
+# Versioned docs snapshots
+
+This directory stores frozen **built** docs snapshots for archived major versions.
+
+The current release (`v0.5.0`) is built on every deploy and published to both:
+
+- `/docs/` (latest stable)
+- `/docs/v0.5.0/` (version-specific URL)
+
+## How it works
+
+- `site/docs/versions.json` declares the current docs version and any archived versions.
+- `npm run build:versioned` builds:
+  - latest docs at `/docs/`
+  - the current version at `/docs/<current-version>/`
+  - any archived snapshots listed in `versions.json`
+- archived versions are served from this directory and are **not rebuilt from source** during normal deploys
+
+## When cutting a breaking release
+
+Before changing the current docs to the new major version:
+
+```bash
+cd site/docs
+npm ci
+npm run snapshot:current
+```
+
+That captures the current docs as a frozen snapshot under `site/docs/versions/<current-version>/`.
+
+Then:
+1. update `versions.json`
+2. move the previous current version into `archived`
+3. set the new `current` version
+4. update docs content for the new major version
+5. deploy with `npm run build:versioned`
+
+## Policy
+
+- patch/minor releases: update live docs only
+- breaking/major releases: preserve the previous major docs as a snapshot


### PR DESCRIPTION
## Summary
- add versioned docs metadata, build scripts, and a release snapshot workflow for breaking releases
- publish the current docs to both `/docs/` and `/docs/v0.5.0/`
- replace the hardcoded docs version label with a version switcher sourced from `versions.json`
- add docs pages for versioning and migration guidance, and wire them into navigation
- update the Pages workflow to build and publish versioned docs output

## Testing
- built the docs site successfully with the versioned docs build flow
- ran the full monorepo build and test suite successfully

Closes #187
