### PR TITLE
feat(examples): deploy analytics dashboard example via Vercel

### DIFF
--- a/.github/workflows/deploy_analytics_dashboard_react.yml
+++ b/.github/workflows/deploy_analytics_dashboard_react.yml
@@ -1,0 +1,174 @@
+name: deploy / analytics-dashboard-react
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/analytics-dashboard-react/**"
+      - ".github/workflows/deploy_analytics_dashboard_react.yml"
+  push:
+    branches: [main]
+    paths:
+      - "examples/analytics-dashboard-react/**"
+      - ".github/workflows/deploy_analytics_dashboard_react.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: analytics-dashboard-react-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vercel-config:
+    runs-on: ubuntu-latest
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - name: Check Vercel secrets
+        id: check
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID_ANALYTICS_DASHBOARD_REACT: ${{ secrets.VERCEL_PROJECT_ID_ANALYTICS_DASHBOARD_REACT }}
+        run: |
+          missing=0
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID_ANALYTICS_DASHBOARD_REACT; do
+            if [ -z "${!name}" ]; then
+              echo "::notice title=Missing Vercel secret::$name is not configured"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -eq 0 ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-preview:
+    name: deploy preview
+    needs: vercel-config
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.vercel-config.outputs.configured == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/analytics-dashboard-react
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ANALYTICS_DASHBOARD_REACT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: examples/analytics-dashboard-react/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate app build
+        run: npm run build
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel preview environment
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel preview output
+        run: vercel build --token="$VERCEL_TOKEN"
+
+      - name: Deploy preview to Vercel
+        id: deploy
+        run: |
+          url="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "$url"
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        with:
+          script: |
+            const marker = '<!-- analytics-dashboard-react-preview -->';
+            const body = [
+              marker,
+              '## Analytics dashboard Vercel preview',
+              `- Preview URL: ${process.env.PREVIEW_URL}`,
+              `- Commit: \`${context.payload.pull_request.head.sha.slice(0, 7)}\``,
+              '',
+              'This preview is deployed by `.github/workflows/deploy_analytics_dashboard_react.yml`.',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find((comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  deploy-production:
+    name: deploy production
+    needs: vercel-config
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.vercel-config.outputs.configured == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/analytics-dashboard-react
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ANALYTICS_DASHBOARD_REACT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: examples/analytics-dashboard-react/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate app build
+        run: npm run build
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel production environment
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel production output
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy production to Vercel
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/examples/analytics-dashboard-react/README.md
+++ b/examples/analytics-dashboard-react/README.md
@@ -1,0 +1,51 @@
+# Analytics dashboard React example
+
+A runnable Next.js dashboard example showing how Askable can annotate complex product surfaces like metrics grids, charts, tables, and sidebars.
+
+## Local development
+
+```bash
+npm ci
+npm run dev
+```
+
+To verify the production build locally:
+
+```bash
+npm run build
+npm run start
+```
+
+## Vercel deployment
+
+This example is deployed by GitHub Actions through `.github/workflows/deploy_analytics_dashboard_react.yml`.
+
+### What the workflow does
+
+- Pull requests touching `examples/analytics-dashboard-react/**` create a **Vercel preview deployment**.
+- The workflow posts the preview URL back onto the pull request.
+- Pushes to `main` that modify this example deploy the same app to the **production Vercel project**.
+- Forked pull requests do **not** get preview deployments because GitHub does not expose repository secrets to forked PR workflows.
+
+### Required GitHub secrets
+
+Configure these repository secrets before relying on the workflow:
+
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID_ANALYTICS_DASHBOARD_REACT`
+
+### Required Vercel project setup
+
+Create a dedicated Vercel project for this example and configure it with:
+
+- **Root Directory:** `examples/analytics-dashboard-react`
+- **Framework Preset:** Next.js
+- **Automatic Git deployments:** disabled
+
+The workflow uses the Vercel CLI (`vercel pull`, `vercel build`, `vercel deploy --prebuilt`) so deploys stay CI-controlled and deterministic.
+
+### Notes
+
+- The example currently depends on the published `@askable-ui/react` package version from npm.
+- If you need Vercel previews to validate unpublished Askable package changes as well, pair this workflow with preview-package wiring in a follow-up change.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys `examples/analytics-dashboard-react` to Vercel
- post same-repo PR preview URLs back onto the pull request and deploy production on `main`
- document the required GitHub secrets and Vercel project setup in the example README

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy_analytics_dashboard_react.yml"); puts "workflow yaml ok"'`
- `cd examples/analytics-dashboard-react && npm run build`
- `git diff --check`

## Notes
- preview deploys intentionally only run for same-repo PRs because forked PR workflows do not receive repository secrets
- this workflow expects repository secrets `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID_ANALYTICS_DASHBOARD_REACT`
- closes #197
