### PR TITLE
docs: surface live preview links across repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@
   <a href="#works-with">Works with</a> &nbsp;·&nbsp;
   <a href="#features">Features</a> &nbsp;·&nbsp;
   <a href="#packages">Packages</a> &nbsp;·&nbsp;
-  <a href="https://askable-ui.com/docs/">Docs</a>
+  <a href="https://askable-ui.com/docs/">Docs</a> &nbsp;·&nbsp;
+  <a href="https://askable-mu.vercel.app/">Live Demo</a>
 </p>
 
 <p align="center">
@@ -233,6 +234,13 @@ ctx.on('focus', () => {
 ```
 
 </details>
+
+---
+
+## Live links
+
+- **Docs:** [askable-ui.com/docs](https://askable-ui.com/docs/)
+- **Analytics dashboard demo:** [askable-mu.vercel.app](https://askable-mu.vercel.app/)
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,5 +2,5 @@
 
 This directory contains runnable or in-progress example apps for Askable.
 
-- `analytics-dashboard-react/` — runnable Vercel/shadcn-inspired analytics dashboard example with Askable-integrated panels and Ask AI actions
+- `analytics-dashboard-react/` — runnable Vercel/shadcn-inspired analytics dashboard example with Askable-integrated panels and Ask AI actions ([live preview](https://askable-mu.vercel.app/))
 - `react-native-expo/` — runnable Expo example showing screen-aware, visibility-aware, and press-aware mobile context capture

--- a/examples/analytics-dashboard-react/README.md
+++ b/examples/analytics-dashboard-react/README.md
@@ -2,6 +2,9 @@
 
 A runnable Next.js dashboard example showing how Askable can annotate complex product surfaces like metrics grids, charts, tables, and sidebars.
 
+- **Stable live URL:** [askable-mu.vercel.app](https://askable-mu.vercel.app/)
+- **Pull request previews:** surfaced automatically by Vercel on GitHub PRs for this project
+
 ## Local development
 
 ```bash

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -13,6 +13,9 @@ hero:
       text: Get Started
       link: /guide/getting-started
     - theme: alt
+      text: Live Demo
+      link: https://askable-mu.vercel.app/
+    - theme: alt
       text: API Reference
       link: /api/core
     - theme: alt


### PR DESCRIPTION
## Summary
- add the live analytics dashboard preview URL to the root README and examples index
- expose the live demo on the docs homepage alongside getting started and API links
- document the stable live URL directly in the analytics dashboard example README

## Validation
- `cd examples/analytics-dashboard-react && npm run build`
- `cd site/docs && npm ci && npm run build`
- `git diff --check`
