### PR TITLE
fix(react): preserve hover-only shared contexts

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -82,12 +82,16 @@ Returns reactive focus state from the shared global `AskableContext`.
 const { focus, promptContext, ctx } = useAskable();
 
 // Restrict which interactions trigger a context update
-const { focus, promptContext } = useAskable({ events: ['click'] });
-const { focus, promptContext } = useAskable({ events: ['click', 'focus'] });
+const { focus: clickFocus } = useAskable({ events: ['click'] });
+const { focus: hoverFocus } = useAskable({ events: ['hover'] });
+const { focus: focusOnly } = useAskable({ events: ['focus'] });
 ```
 
 **Options:**
+- `name?: string` — optional shared context name for region-specific context reuse
+- `viewport?: boolean` — enable viewport-aware context tracking for this hook's context
 - `events?: AskableEvent[]` — trigger events: `'click'`, `'hover'`, `'focus'`. Defaults to all three.
+- `ctx?: AskableContext` — provide a custom context instead of the shared singleton
 
 **Returns:**
 - `focus: AskableFocus | null` — current focus state
@@ -100,7 +104,19 @@ const { focus, promptContext } = useAskable({ events: ['click', 'focus'] });
   - `ctx.toPromptContext(options?)` — full serialization options (format, maxTokens, excludeKeys, …)
   - `ctx.serializeFocus(options?)` — structured `AskableSerializedFocus` object
 
-The hook manages a shared singleton context per `events` configuration. Multiple `useAskable()` consumers with the same `events` reuse one observer lifecycle, while differing `events` configurations get isolated shared contexts of their own. Each shared context is automatically destroyed when its last consumer unmounts.
+The hook manages a shared singleton context per `name + events + viewport` configuration. Multiple `useAskable()` consumers with the same shared configuration reuse one observer lifecycle, while differing configurations get isolated shared contexts of their own. Each shared context is automatically destroyed when its last consumer unmounts.
+
+If you need isolation, create your own context and pass it through `ctx`:
+
+```tsx
+const panelCtx = createAskableContext();
+panelCtx.observe(panelEl, { events: ['hover'] });
+
+function AnalyticsPanelChat() {
+  const { promptContext } = useAskable({ ctx: panelCtx });
+  return <textarea defaultValue={promptContext} />;
+}
+```
 
 
 ### SSR note

--- a/packages/react/src/__tests__/useAskable.test.tsx
+++ b/packages/react/src/__tests__/useAskable.test.tsx
@@ -369,6 +369,88 @@ describe('useAskable', () => {
 
     clickView.unmount();
   });
+
+  it('updates shared hook-managed focus on hover-only events', async () => {
+    function HoverConsumer({ inspector = false }: { inspector?: boolean }) {
+      const { focus } = useAskable({ events: ['hover'], inspector });
+      return <span data-testid="hover-focus">{focus ? JSON.stringify(focus.meta) : 'null'}</span>;
+    }
+
+    const view = render(
+      <>
+        <div data-testid="hover-target" data-askable='{"widget":"hover-only"}'>
+          Hover only
+        </div>
+        <HoverConsumer />
+      </>
+    );
+    await flushMicrotasks();
+
+    act(() => {
+      screen.getByTestId('hover-target').dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hover-focus').textContent).toContain('hover-only');
+    });
+
+    view.unmount();
+  });
+
+  it('updates shared hook-managed focus on focus-only events', async () => {
+    function FocusConsumer() {
+      const { focus } = useAskable({ events: ['focus'] });
+      return <span data-testid="focus-only-state">{focus ? JSON.stringify(focus.meta) : 'null'}</span>;
+    }
+
+    const view = render(
+      <>
+        <button data-testid="focus-only-target" data-askable='{"widget":"focus-only"}'>
+          Focus only
+        </button>
+        <FocusConsumer />
+      </>
+    );
+    await flushMicrotasks();
+
+    act(() => {
+      screen.getByTestId('focus-only-target').focus();
+      fireEvent.focus(screen.getByTestId('focus-only-target'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('focus-only-state').textContent).toContain('focus-only');
+    });
+
+    view.unmount();
+  });
+
+  it('keeps hover-only shared contexts working when inspector mode is enabled', async () => {
+    function HoverConsumer() {
+      const { focus } = useAskable({ events: ['hover'], inspector: true });
+      return <span data-testid="hover-focus-inspector">{focus ? JSON.stringify(focus.meta) : 'null'}</span>;
+    }
+
+    const view = render(
+      <>
+        <div data-testid="hover-target-inspector" data-askable='{"widget":"hover-inspector"}'>
+          Hover inspector
+        </div>
+        <HoverConsumer />
+      </>
+    );
+    await flushMicrotasks();
+
+    act(() => {
+      screen.getByTestId('hover-target-inspector').dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hover-focus-inspector').textContent).toContain('hover-inspector');
+    });
+
+    view.unmount();
+  });
 });
 
 function ScopedView({

--- a/packages/react/src/useAskable.ts
+++ b/packages/react/src/useAskable.ts
@@ -8,7 +8,7 @@ const globalRefCountByEvents = new Map<string, number>();
 
 function normalizeEvents(events?: AskableEvent[]): AskableEvent[] {
   const configured = events ?? DEFAULT_EVENTS;
-  return DEFAULT_EVENTS.filter((event, index) => configured.includes(event) && configured.indexOf(event) === index);
+  return DEFAULT_EVENTS.filter((event) => configured.includes(event));
 }
 
 function getEventsKey(events?: AskableEvent[]): string {

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -72,13 +72,53 @@ const { focus, promptContext, ctx } = useAskable();
 **Examples:**
 
 ```ts
-// Restrict trigger events
+// Click-only activation
 const { focus } = useAskable({ events: ['click'] });
 
-// Scoped context (multiple independent AI surfaces)
+// Hover-only activation
+const { focus: hoverFocus } = useAskable({ events: ['hover'] });
+
+// Focus-only activation
+const { focus: focusOnly } = useAskable({ events: ['focus'] });
+
+// Named shared context for one surface
+const { focus: chartFocus } = useAskable({
+  name: 'chart',
+  events: ['click', 'hover'],
+});
+
+// Custom context (multiple independent AI surfaces)
 import { createAskableContext } from '@askable-ui/core';
 const myCtx = createAskableContext();
-myCtx.observe(panelEl);
+myCtx.observe(panelEl, { events: ['hover'] });
 
-const { focus } = useAskable({ ctx: myCtx });
+const { focus: panelFocus } = useAskable({ ctx: myCtx });
+```
+
+### Shared vs custom contexts
+
+`useAskable()` has three common modes in React:
+
+- **Default shared context** — `useAskable()` with no `ctx` or `name` reuses one shared document observer for the same `events` + `viewport` configuration.
+- **Named shared context** — `useAskable({ name: 'chart' })` reuses a separate shared context for one UI region or surface.
+- **Custom context** — `useAskable({ ctx })` attaches to an explicitly created `AskableContext` that you observe/configure yourself.
+
+Use a shared context when multiple components on the same page should agree on the same focus/history. Provide a custom `ctx` when you need isolation, a custom root element, or different lifecycle control.
+
+```tsx
+function SharedChatInput() {
+  const { promptContext } = useAskable({ events: ['hover'] });
+  return <textarea defaultValue={promptContext} />;
+}
+
+function PrivatePanel({ panelEl }: { panelEl: HTMLElement }) {
+  const ctx = useMemo(() => {
+    const next = createAskableContext();
+    next.observe(panelEl, { events: ['click'] });
+    return next;
+  }, [panelEl]);
+
+  const { promptContext } = useAskable({ ctx });
+  return <textarea defaultValue={promptContext} />;
+}
 ```


### PR DESCRIPTION
## Summary
- fix React shared-context event normalization so hover-only and focus-only `useAskable()` configs retain their requested events
- add React regression coverage for hover-only and focus-only shared contexts, including `inspector: true`
- expand the React README/docs with concrete shared vs custom context examples and hover/focus event configuration snippets

## Testing
- `zsh -lc 'cd ~/projects/askable && npm test --workspace @askable-ui/react -- --run src/__tests__/useAskable.test.tsx && npm run build && npm test'`
- `zsh -lc 'cd ~/projects/askable/site/docs && npm run build'`

Closes #194
