### PR TITLE
fix(react): align AskableInspector with shared contexts

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -74,6 +74,28 @@ Renders any element (default: `div`) with a `data-askable` attribute. The `meta`
 - `as` — HTML tag to render (default: `"div"`)
 - All other props are forwarded to the underlying element
 
+### `AskableInspector(props?)`
+
+Declarative React wrapper around the core inspector.
+
+```tsx
+import { AskableInspector } from '@askable-ui/react';
+
+<AskableInspector events={['click']} />
+```
+
+Pass the same `events`, `name`, `viewport`, or `ctx` that your React app uses for `useAskable()` when the inspector should follow the same context.
+
+```tsx
+function DevInspector() {
+  useAskable({ events: ['click'] });
+
+  return process.env.NODE_ENV === 'development'
+    ? <AskableInspector events={['click']} position="bottom-left" />
+    : null;
+}
+```
+
 ### `useAskable(options?)`
 
 Returns reactive focus state from the shared global `AskableContext`.

--- a/packages/react/src/AskableInspector.tsx
+++ b/packages/react/src/AskableInspector.tsx
@@ -1,24 +1,44 @@
 import { useEffect } from 'react';
 import { createAskableInspector } from '@askable-ui/core';
-import type { AskableInspectorOptions } from '@askable-ui/core';
+import type { AskableContext, AskableEvent, AskableInspectorOptions } from '@askable-ui/core';
 import { useAskable } from './useAskable.js';
 
-export type AskableInspectorProps = AskableInspectorOptions;
+export type AskableInspectorProps = AskableInspectorOptions & {
+  /** Reuse an existing AskableContext for the inspector. */
+  ctx?: AskableContext;
+  /** Optional shared context name to match sibling useAskable() consumers. */
+  name?: string;
+  /** Optional event config to match sibling useAskable() consumers. */
+  events?: AskableEvent[];
+  /** Optional viewport flag to match sibling useAskable() consumers. */
+  viewport?: boolean;
+};
 
 /**
  * Declarative inspector panel. Renders nothing visible — mounts the
  * floating dev panel via createAskableInspector and cleans up on unmount.
  *
+ * Pass `ctx`, `name`, `events`, or `viewport` when the inspector should
+ * follow the same React-managed context configuration as sibling
+ * `useAskable()` consumers.
+ *
  * @example
- * {process.env.NODE_ENV === 'development' && <AskableInspector />}
+ * {process.env.NODE_ENV === 'development' && <AskableInspector events={['click']} />}
  */
-export function AskableInspector(props: AskableInspectorProps) {
-  const { ctx } = useAskable();
+export function AskableInspector({
+  ctx: providedCtx,
+  name,
+  events,
+  viewport,
+  ...inspectorOptions
+}: AskableInspectorProps) {
+  const { ctx } = useAskable({ ctx: providedCtx, name, events, viewport });
+  const promptOptionsKey = JSON.stringify(inspectorOptions.promptOptions ?? null);
 
   useEffect(() => {
-    const handle = createAskableInspector(ctx, props);
+    const handle = createAskableInspector(ctx, inspectorOptions);
     return () => handle.destroy();
-  }, [ctx, props.position, props.highlight]);
+  }, [ctx, inspectorOptions.position, inspectorOptions.highlight, promptOptionsKey]);
 
   return null;
 }

--- a/packages/react/src/__tests__/AskableInspector.test.tsx
+++ b/packages/react/src/__tests__/AskableInspector.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { AskableInspector } from '../AskableInspector';
+import { useAskable } from '../useAskable';
+
+function ClickOnlyConsumer() {
+  const { focus } = useAskable({ events: ['click'] });
+  return <span data-testid="click-only-focus">{focus ? JSON.stringify(focus.meta) : 'null'}</span>;
+}
+
+describe('AskableInspector', () => {
+  it('can share click-only event configuration with sibling useAskable consumers', async () => {
+    const view = render(
+      <>
+        <div data-testid="target" data-askable='{"widget":"inspector-click-only"}'>
+          Inspector target
+        </div>
+        <ClickOnlyConsumer />
+        <AskableInspector events={['click']} />
+      </>
+    );
+
+    expect(document.getElementById('askable-inspector')?.textContent).toContain('No element focused');
+    expect(screen.getByTestId('click-only-focus').textContent).toBe('null');
+
+    act(() => {
+      screen.getByTestId('target').dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(document.getElementById('askable-inspector')?.textContent).toContain('No element focused');
+    expect(screen.getByTestId('click-only-focus').textContent).toBe('null');
+
+    act(() => {
+      screen.getByTestId('target').click();
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById('askable-inspector')?.textContent).toContain('inspector-click-only');
+    });
+    expect(screen.getByTestId('click-only-focus').textContent).toContain('inspector-click-only');
+
+    view.unmount();
+  });
+});

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -40,6 +40,41 @@ import { Askable } from '@askable-ui/react';
 | `ref` | `Ref<HTMLElement>` | — | Forwarded to the underlying element |
 | ...rest | | | All other props forwarded to the element |
 
+### `AskableInspector(props?)`
+
+Declarative React wrapper around `createAskableInspector()`.
+
+```tsx
+import { AskableInspector } from '@askable-ui/react';
+
+// Match a click-only shared React context
+<AskableInspector events={['click']} />
+```
+
+**Props:**
+- all core `AskableInspectorOptions` props such as `position`, `highlight`, and `promptOptions`
+- `ctx?: AskableContext` — reuse an explicit context
+- `name?: string` — match a named shared React context
+- `events?: AskableEvent[]` — match a shared React event configuration
+- `viewport?: boolean` — match a shared viewport-aware React context
+
+When you are already using `useAskable({ events: [...] })`, pass the same `events` (or the same `ctx`) to `<AskableInspector />` so the dev panel tracks the same context instead of silently falling back to the default click/hover/focus observer.
+
+```tsx
+function DashboardDevTools() {
+  useAskable({ events: ['click'] });
+
+  return (
+    <>
+      {/* app UI */}
+      {process.env.NODE_ENV === 'development' && (
+        <AskableInspector events={['click']} position="bottom-left" />
+      )}
+    </>
+  );
+}
+```
+
 ---
 
 ## `useAskable(options?)`

--- a/site/docs/guide/inspector.md
+++ b/site/docs/guide/inspector.md
@@ -67,20 +67,13 @@ createAskableInspector(ctx, {
 ```tsx
 // components/DevInspector.tsx
 'use client';
-import { useEffect } from 'react';
-import { createAskableInspector } from '@askable-ui/core';
-import { useAskable } from '@askable-ui/react';
+import { AskableInspector, useAskable } from '@askable-ui/react';
 
 export function DevInspector() {
-  const { ctx } = useAskable();
+  useAskable({ events: ['click'] });
 
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') return;
-    const inspector = createAskableInspector(ctx, { position: 'bottom-left' });
-    return () => inspector.destroy();
-  }, [ctx]);
-
-  return null;
+  if (process.env.NODE_ENV !== 'development') return null;
+  return <AskableInspector events={['click']} position="bottom-left" />;
 }
 ```
 
@@ -95,6 +88,20 @@ export default function Layout({ children }) {
       {process.env.NODE_ENV === 'development' && <DevInspector />}
     </>
   );
+}
+```
+
+If your React app uses a custom `ctx`, `name`, `events`, or `viewport` setting, pass the same values to `<AskableInspector />` so the panel follows the same context instead of falling back to the default click/hover/focus observer.
+
+```tsx
+const ctx = createAskableContext();
+ctx.observe(document, { events: ['click'] });
+
+function DevInspector() {
+  useAskable({ ctx });
+  return process.env.NODE_ENV === 'development'
+    ? <AskableInspector ctx={ctx} />
+    : null;
 }
 ```
 


### PR DESCRIPTION
## Summary
- let React `<AskableInspector />` reuse the same `ctx`, `name`, `events`, or `viewport` configuration as sibling `useAskable()` consumers
- add a regression test covering click-only shared-context inspector behavior
- document the correct React inspector wiring for custom event configurations

## Testing
- `zsh -lc 'cd ~/projects/askable && npm run build && npm test && cd site/docs && npm run build'`

Closes #192
