### PR TITLE
docs: explain shared and private context usage

### DIFF
--- a/site/docs/api/react-native.md
+++ b/site/docs/api/react-native.md
@@ -89,6 +89,46 @@ const { focus, promptContext, ctx } = useAskable();
 | `promptContext` | `string` | Natural-language context string for your LLM prompt |
 | `ctx` | `AskableContext` | Full context instance for `push()`, `clear()`, `toHistoryContext()`, etc. |
 
+### Shared vs private/custom contexts
+
+React Native differs from the web adapters: `useAskable()` creates a **private** context per hook call unless you provide `ctx`.
+
+- **Private default** — each `useAskable()` call gets its own `AskableContext`.
+- **Custom shared context** — create one context and pass it to `useAskable({ ctx })`, `<Askable ctx={ctx} />`, `useAskableScreen({ ctx })`, `useAskableScrollView({ ctx })`, and `useAskableVisibility({ ctx })` when one screen or app surface should share focus/history.
+- **Multiple isolated surfaces** — create separate contexts when different tabs/screens/chats should not affect each other.
+
+```tsx
+import { createAskableContext } from '@askable-ui/core';
+import { Askable, useAskable, useAskableScreen } from '@askable-ui/react-native';
+
+// Shared screen-level context
+const screenCtx = createAskableContext();
+
+function RevenueScreen() {
+  const askable = useAskable({ ctx: screenCtx });
+
+  useAskableScreen({
+    ctx: screenCtx,
+    meta: { screen: 'RevenueScreen' },
+    text: 'Revenue screen',
+  });
+
+  return (
+    <Askable ctx={screenCtx} meta={{ widget: 'revenue' }} text="Revenue card">
+      <Pressable>{/* ... */}</Pressable>
+    </Askable>
+  );
+}
+
+// Separate private context for another surface
+function SupportChatScreen() {
+  const support = useAskable();
+  return null;
+}
+```
+
+Use the private default for isolated screens. Provide `ctx` explicitly when multiple React Native helpers/components should cooperate on one Askable context.
+
 ## `useAskableScreen(options)`
 
 Pushes screen-level context into the shared `AskableContext` while a screen is active.

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -85,3 +85,31 @@ $: console.log($promptContext);
 // Click-only
 const store = createAskableStore({ events: ['click'] });
 ```
+
+### Shared vs private/custom contexts
+
+Svelte differs from the React/Vue adapters: `createAskableStore()` creates a **private** `AskableContext` per store by default.
+
+- **Private default** — every `createAskableStore()` call creates its own context and observer lifecycle.
+- **Custom provided context** — pass `ctx` when multiple components/stores should share one context.
+- **Per-surface isolation** — create separate stores or separate explicit contexts when different panels should not share focus/history.
+
+That means if two components both call `createAskableStore()` with no `ctx`, they will not automatically share focus.
+
+```ts
+import { createAskableContext } from '@askable-ui/core';
+import { createAskableStore } from '@askable-ui/svelte';
+
+// Private stores: isolated from each other
+const left = createAskableStore({ events: ['click'] });
+const right = createAskableStore({ events: ['click'] });
+
+// Shared explicit context across stores/components
+const sharedCtx = createAskableContext();
+sharedCtx.observe(document, { events: ['hover'] });
+
+const chartStore = createAskableStore({ ctx: sharedCtx });
+const chatStore = createAskableStore({ ctx: sharedCtx });
+```
+
+Use the private default for isolated widgets. Pass a shared `ctx` when multiple Svelte components need to agree on one Askable focus/history stream.

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -77,3 +77,34 @@ const { focus } = useAskable({ events: ['click'] });
 // promptContext.value in <script setup>
 // {{ promptContext }} in template
 ```
+
+### Shared vs private/custom contexts
+
+Vue mirrors the React adapter's context model:
+
+- **Default shared context** — `useAskable()` reuses one shared document observer for the same `events` + `viewport` configuration.
+- **Named shared context** — `useAskable({ name: 'chart' })` reuses a separate shared context for one region or AI surface.
+- **Private auto-created context** — passing context-creation options like `maxHistory`, `sanitizeMeta`, `sanitizeText`, or `textExtractor` without `name` or `ctx` creates a private context for that composable instance.
+- **Custom provided context** — `useAskable({ ctx })` attaches to an explicitly created `AskableContext` that you observe/configure yourself.
+
+Use the shared mode when multiple Vue components should agree on the same focus/history. Use a private or provided context when one panel needs isolation or a custom root.
+
+```ts
+// Shared chart/chat pair
+const chart = useAskable({ name: 'chart', events: ['hover'] });
+const chat = useAskable({ name: 'chart', events: ['hover'] });
+
+// Private composable instance with sanitization
+const privateAskable = useAskable({
+  sanitizeText: (text) => text.trim(),
+  maxHistory: 10,
+});
+
+// Explicit provided context
+import { createAskableContext } from '@askable-ui/core';
+
+const panelCtx = createAskableContext();
+panelCtx.observe(panelEl, { events: ['click'] });
+
+const panel = useAskable({ ctx: panelCtx });
+```


### PR DESCRIPTION
## Summary
- explain shared vs private/custom context behavior across the Vue, Svelte, and React Native API pages
- add copy-pasteable examples for shared named contexts, private auto-created contexts, and explicitly provided `ctx` usage
- clarify that Svelte and React Native differ from the web adapters by defaulting to private contexts per store/hook call

## Testing
- `zsh -lc 'cd ~/projects/askable && npm run build && npm test && cd site/docs && npm run build'`

Closes #195
