### PR TITLE
docs: add library-specific inspector examples

### DIFF
--- a/site/docs/api/react-native.md
+++ b/site/docs/api/react-native.md
@@ -89,6 +89,27 @@ const { focus, promptContext, ctx } = useAskable();
 | `promptContext` | `string` | Natural-language context string for your LLM prompt |
 | `ctx` | `AskableContext` | Full context instance for `push()`, `clear()`, `toHistoryContext()`, etc. |
 
+### Inspector
+
+React Native does **not** use the floating browser overlay inspector. `createAskableInspector()` is DOM-based, so it is only relevant on web targets.
+
+For React Native development, the equivalent debugging pattern is to inspect `focus`, `promptContext`, and `ctx.toHistoryContext()` directly in your own debug UI or logs:
+
+```tsx
+function AskableDebugPanel() {
+  const { focus, promptContext } = useAskable();
+
+  return __DEV__ ? (
+    <View>
+      <Text>{focus ? JSON.stringify(focus.meta) : 'No focus yet'}</Text>
+      <Text>{promptContext}</Text>
+    </View>
+  ) : null;
+}
+```
+
+If you share a custom `ctx` across a screen, read from that same `ctx` in your debug panel so the mobile debugging surface reflects the same Askable context as your press/visibility helpers.
+
 ### Shared vs private/custom contexts
 
 React Native differs from the web adapters: `useAskable()` creates a **private** context per hook call unless you provide `ctx`.

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -86,6 +86,35 @@ $: console.log($promptContext);
 const store = createAskableStore({ events: ['click'] });
 ```
 
+### Inspector
+
+Svelte can mount the inspector through `createAskableStore({ inspector: ... })`.
+
+```ts
+import { createAskableStore } from '@askable-ui/svelte';
+
+const askable = createAskableStore({
+  events: ['click'],
+  inspector: {
+    position: 'bottom-left',
+  },
+});
+```
+
+Because `createAskableStore()` creates a private context by default, the inspector automatically follows that store's context. If you want multiple components or stores to share one inspector/context, pass the same explicit `ctx` to each store:
+
+```ts
+import { createAskableContext } from '@askable-ui/core';
+
+const sharedCtx = createAskableContext();
+sharedCtx.observe(document, { events: ['hover'] });
+
+const chartStore = createAskableStore({ ctx: sharedCtx, inspector: true });
+const chatStore = createAskableStore({ ctx: sharedCtx });
+```
+
+Remember to call `destroy()` so the inspector panel is removed when the component/store is torn down.
+
 ### Shared vs private/custom contexts
 
 Svelte differs from the React/Vue adapters: `createAskableStore()` creates a **private** `AskableContext` per store by default.

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -78,6 +78,35 @@ const { focus } = useAskable({ events: ['click'] });
 // {{ promptContext }} in template
 ```
 
+### Inspector
+
+Vue can mount the inspector through `useAskable({ inspector: ... })` so the panel follows the same composable-managed context.
+
+```ts
+const { focus } = useAskable({
+  events: ['click'],
+  inspector: {
+    position: 'bottom-left',
+  },
+});
+```
+
+Use this in development only. If you need a custom context, create it yourself and pass `ctx`:
+
+```ts
+import { createAskableContext } from '@askable-ui/core';
+
+const panelCtx = createAskableContext();
+panelCtx.observe(panelEl, { events: ['hover'] });
+
+const askable = useAskable({
+  ctx: panelCtx,
+  inspector: true,
+});
+```
+
+When combining custom `events` with the inspector, prefer `useAskable({ inspector: true, events: [...] })` so the dev panel and your Vue UI share the same context.
+
 ### Shared vs private/custom contexts
 
 Vue mirrors the React adapter's context model:


### PR DESCRIPTION
## Summary
- add library-specific inspector guidance to the Vue, Svelte, and React Native API pages
- document the recommended development-only inspector entrypoint for each adapter
- clarify that React Native does not use the floating DOM inspector and should use app-local debug UI instead

## Testing
- `zsh -lc 'cd ~/projects/askable && npm run build && npm test && cd site/docs && npm run build'`

Closes #193
