### PR TITLE
docs: add coding-agent adoption templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
   <a href="#features">Features</a> &nbsp;·&nbsp;
   <a href="#packages">Packages</a> &nbsp;·&nbsp;
   <a href="https://askable-ui.com/docs/">Docs</a> &nbsp;·&nbsp;
+  <a href="https://askable-ui.com/docs/guide/agents">Agent Templates</a> &nbsp;·&nbsp;
   <a href="https://askable-mu.vercel.app/">Live Demo</a>
 </p>
 
@@ -135,6 +136,7 @@ askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it
 - **Viewport awareness** — `ctx.getVisibleElements()` / `ctx.toViewportContext()` for on-screen context
 - **Redaction hooks** — strip sensitive fields before data reaches serialization
 - **Inspector panel** — `<AskableInspector />` or `useAskable({ inspector: true })` for a live dev overlay
+- **Agent templates** — reusable `AGENTS.md` guidance and copy-paste prompts for coding-agent-driven adoption
 - **Lightweight core** — zero runtime dependencies
 
 ---

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
           items: [
             { text: 'Third-Party Libraries', link: '/guide/third-party-libraries' },
             { text: 'CopilotKit', link: '/guide/copilotkit' },
+            { text: 'Using Coding Agents', link: '/guide/agents' },
           ],
         },
         {

--- a/site/docs/guide/agents.md
+++ b/site/docs/guide/agents.md
@@ -1,0 +1,199 @@
+# Using askable-ui with coding agents
+
+Many teams integrate libraries by prompting coding agents instead of reading every API page front-to-back. This guide gives you reusable markdown files and prompts you can drop into your own repo so those agents use `askable-ui` well.
+
+## What to copy into your app repo
+
+Recommended starting point:
+
+1. Copy [`templates/AGENTS.askable-ui.md`](https://github.com/askable-ui/askable/blob/main/templates/AGENTS.askable-ui.md)
+2. Save it in the root of your app repo as `AGENTS.md`
+3. Replace the **Product-specific customization** section with your app's own rules
+4. If your team frequently prompts agents directly, also copy useful snippets from [`templates/agent-prompts.askable-ui.md`](https://github.com/askable-ui/askable/blob/main/templates/agent-prompts.askable-ui.md)
+
+That gives Claude/Cursor/Codex-style agents a stable, repo-local source of truth about how to use Askable in your product.
+
+## What the template teaches the agent
+
+The template is designed to help an agent make good decisions about:
+- how to annotate meaningful UI surfaces
+- when to use passive context updates vs explicit `ctx.select()` flows
+- how to wire `promptContext` / `ctx.toContext()` into an AI request
+- when to reuse a shared Askable context vs create an isolated one
+- how to sanitize metadata/text before it reaches the model
+- what common mistakes to avoid
+
+## Recommended repo placement
+
+Use this layout in your app repo:
+
+```text
+your-app/
+├─ AGENTS.md
+├─ src/
+├─ app/
+└─ ...
+```
+
+If your team also keeps reusable internal prompts, you can add something like:
+
+```text
+your-app/
+├─ AGENTS.md
+├─ docs/
+│  └─ ai/
+│     └─ askable-prompts.md
+└─ ...
+```
+
+## How to customize `AGENTS.md`
+
+At minimum, replace the product-specific section with:
+- your primary AI surfaces
+- which flows should use passive context vs explicit Ask AI buttons
+- sensitive fields that must never reach the model
+- metadata conventions you want agents to preserve
+- any domain vocabulary the assistant should prefer
+
+Example customization:
+
+```md
+## Product-specific customization
+
+- primary AI surfaces:
+  - sales dashboard copilot
+  - account page assistant
+- preferred interaction model:
+  - passive context on dashboards
+  - explicit `ctx.select()` for "Ask AI" buttons on account cards
+- never send these fields to the model:
+  - customer_internal_id
+  - stripe_customer_id
+  - auth tokens
+- required metadata conventions:
+  - always include `widget`
+  - include `team` and `dateRange` on analytics panels
+```
+
+## Recommended annotation strategy for agents
+
+Teach agents to prefer:
+
+### Structured metadata
+
+```tsx
+<Askable
+  meta={{
+    widget: 'revenue-chart',
+    metric: 'monthly-recurring-revenue',
+    period: selectedRange,
+  }}
+>
+  <RevenueChart />
+</Askable>
+```
+
+### Curated text for visual widgets
+
+```tsx
+<Askable
+  meta={{ widget: 'pipeline-chart' }}
+  data-askable-text={[
+    'Pipeline overview for the current team.',
+    'Most open value is concentrated in enterprise deals.',
+    'Late-stage opportunities increased from last week.',
+  ].join('\n')}
+>
+  <PipelineChart />
+</Askable>
+```
+
+### Explicit Ask AI button flows when needed
+
+```tsx
+function RevenueCard() {
+  const ref = useRef<HTMLDivElement>(null);
+  const { ctx } = useAskable({ events: ['click'] });
+
+  return (
+    <Askable ref={ref} meta={{ widget: 'revenue-card' }}>
+      <RevenueChart />
+      <button
+        onClick={() => {
+          if (ref.current) ctx.select(ref.current);
+          openAssistant();
+        }}
+      >
+        Ask AI
+      </button>
+    </Askable>
+  );
+}
+```
+
+## Prompt-boundary guidance
+
+A coding agent should keep Askable context close to the actual AI request boundary.
+
+```ts
+const result = await streamText({
+  model,
+  system: [
+    'You are a helpful analytics assistant.',
+    promptContext,
+  ].join('\n\n'),
+  messages,
+});
+```
+
+If current focus alone is not enough, the agent can consider:
+- `ctx.toHistoryContext(n)`
+- `ctx.toContext({ history: n })`
+- `ctx.toViewportContext()` when on-screen context matters
+
+## Noise-control and safety checklist
+
+Your copied `AGENTS.md` should push agents toward:
+- removing internal-only IDs unless truly needed
+- redacting secrets/tokens
+- trimming noisy text
+- avoiding giant serialized objects in `meta`
+- preferring product semantics over implementation details
+
+Example sanitization:
+
+```tsx
+const askable = useAskable({
+  sanitizeMeta: ({ internalId, accessToken, ...safe }) => safe,
+  sanitizeText: (text) => text.replace(/\s+/g, ' ').trim(),
+});
+```
+
+## Common mistakes to warn agents about
+
+Include or preserve warnings like these in your app-level `AGENTS.md`:
+- do not annotate every tiny element by default
+- do not dump raw API payloads into `meta`
+- do not rely only on flattened DOM text for charts/dashboards
+- do not accidentally merge unrelated AI surfaces into one context
+- do not ship inspector/debug tooling in production
+
+## Copy-paste prompts for agents
+
+If you want more guided one-shot prompts, use the examples in:
+- [`templates/agent-prompts.askable-ui.md`](https://github.com/askable-ui/askable/blob/main/templates/agent-prompts.askable-ui.md)
+
+That file includes prompts for:
+- adding Askable to an existing app
+- improving existing annotations
+- wiring context into a chat boundary
+- adding safe sanitization
+- implementing explicit Ask AI button flows
+
+## When to use this guide
+
+Reach for these templates when:
+- onboarding Askable into an existing product with the help of a coding agent
+- handing repo-specific integration rules to Claude/Cursor/Codex
+- standardizing Askable usage across multiple teams or apps
+- reducing repeated prompt-writing for the same integration style

--- a/templates/AGENTS.askable-ui.md
+++ b/templates/AGENTS.askable-ui.md
@@ -1,0 +1,206 @@
+# AGENTS.md template for projects using askable-ui
+
+> Copy this file into the root of your app as `AGENTS.md`, then customize the product-specific sections.
+
+## Project goal
+
+This application uses `askable-ui` to give the app's AI assistant accurate UI context.
+
+When working in this repo:
+- preserve or improve `askable-ui` annotations
+- prefer structured metadata over brittle DOM scraping
+- keep AI context focused on what the user is actually looking at
+- avoid passing noisy, redundant, or sensitive UI data into prompts
+
+## What askable-ui is for
+
+`askable-ui` is the UI-context layer for the app's AI features.
+
+Use it to:
+- annotate meaningful UI elements with structured metadata
+- track what the user is focused on
+- generate prompt-ready context via `promptContext`, `ctx.toPromptContext()`, `ctx.toHistoryContext()`, or `ctx.toContext()`
+- support both passive context updates and explicit "Ask AI" interactions
+
+Do not treat it as:
+- analytics tracking
+- a generic DOM scraping tool
+- a replacement for the app's LLM SDK or chat API
+
+## Preferred integration patterns
+
+### 1. Annotate meaningful UI surfaces
+
+Prefer high-signal metadata:
+
+```tsx
+<Askable
+  meta={{
+    widget: 'revenue-chart',
+    metric: 'monthly-recurring-revenue',
+    period: selectedRange,
+    unit: 'usd',
+  }}
+>
+  <RevenueChart />
+</Askable>
+```
+
+Good metadata usually includes:
+- widget/component identity
+- business meaning
+- active filters/range/segment
+- units or status when relevant
+
+Avoid:
+- huge raw objects
+- internal IDs unless the AI truly needs them
+- duplicate metadata already obvious from other fields
+
+### 2. Prefer `data-askable-text` or curated text for visual widgets
+
+For charts, dashboards, and dense cards, prefer a curated summary instead of trusting flattened DOM text.
+
+```tsx
+<Askable
+  meta={{ widget: 'pipeline-chart', team: activeTeam }}
+  data-askable-text={[
+    'Pipeline overview for the active team.',
+    'Open pipeline is concentrated in enterprise deals.',
+    'Late-stage opportunities increased week over week.',
+  ].join('\n')}
+>
+  <PipelineChart />
+</Askable>
+```
+
+### 3. Use passive context for exploratory UI
+
+Use passive focus updates for dashboards, tables, forms, and pages where the user naturally clicks, focuses, or hovers relevant elements.
+
+```tsx
+const { promptContext } = useAskable({ events: ['click', 'hover'] });
+```
+
+### 4. Use explicit `ctx.select()` for button-driven AI flows
+
+If the app has an explicit "Ask AI" button, make the button pin context intentionally.
+
+```tsx
+function RevenueCard() {
+  const ref = useRef<HTMLDivElement>(null);
+  const { ctx } = useAskable({ events: ['click'] });
+
+  return (
+    <Askable ref={ref} meta={{ widget: 'revenue-card' }}>
+      <RevenueChart />
+      <button
+        onClick={() => {
+          if (ref.current) ctx.select(ref.current);
+          openAssistant();
+        }}
+      >
+        Ask AI
+      </button>
+    </Askable>
+  );
+}
+```
+
+### 5. Reuse shared context intentionally
+
+If multiple components should agree on one AI surface, keep them on the same Askable context.
+
+```tsx
+const chartCtx = useAskable({ name: 'chart-surface', events: ['click', 'hover'] });
+```
+
+If one region should stay isolated from another, use a separate named context or a custom `ctx`.
+
+## AI boundary guidance
+
+When sending requests to the app's LLM backend:
+- include `promptContext` or `ctx.toContext(...)` at the AI boundary
+- keep the integration close to the chat/completion request
+- prefer structured, minimal context over dumping the whole page state
+
+Example:
+
+```ts
+const result = await streamText({
+  model,
+  system: [
+    'You are a helpful product assistant.',
+    promptContext,
+  ].join('\n\n'),
+  messages,
+});
+```
+
+For multi-turn UI-aware interactions, prefer:
+- `ctx.toHistoryContext(n)` when recent focus history matters
+- `ctx.toContext({ history: n })` when combining current + history
+- `ctx.toViewportContext()` only when on-screen context is actually needed
+
+## Sanitization and safety rules
+
+Before exposing metadata/text to the AI:
+- remove secrets, tokens, internal references, and unnecessary IDs
+- redact hidden/internal-only fields
+- keep text concise and human-meaningful
+
+Prefer built-in sanitization hooks when needed:
+
+```tsx
+const askable = useAskable({
+  sanitizeMeta: ({ internalId, accessToken, ...safe }) => safe,
+  sanitizeText: (text) => text.replace(/\s+/g, ' ').trim(),
+});
+```
+
+## Common mistakes to avoid
+
+Do not:
+- annotate every tiny element by default
+- pass giant API payloads into `meta`
+- rely only on raw `textContent` for charts or dashboards
+- mix unrelated AI surfaces into one context accidentally
+- mount inspector/debug tooling in production builds
+- assume the AI needs implementation details when product semantics are enough
+
+## Framework-specific notes
+
+### React
+- use `useAskable()` for shared hook-managed contexts
+- use `<AskableInspector />` or `useAskable({ inspector: true })` only in development
+- if using custom `events`, `name`, or `ctx`, pass the same configuration to the inspector
+
+### Vue
+- use `useAskable()` in `setup`
+- if enabling inspector, prefer `useAskable({ inspector: true, events: [...] })`
+
+### Svelte
+- `createAskableStore()` creates a private context by default
+- share a custom `ctx` explicitly when multiple components must use the same context
+
+### React Native
+- prefer explicit `ctx` sharing across screen helpers/components
+- use app-local debug UI instead of the DOM inspector overlay
+
+## Product-specific customization
+
+Replace this section with app-specific guidance:
+- primary AI surfaces in this app:
+- preferred interaction model (passive vs explicit button):
+- sensitive fields that must never reach the model:
+- required metadata conventions:
+- important business terms the agent should preserve:
+
+## Acceptance criteria for askable-ui-related changes
+
+Any change touching the AI/UI-context flow should:
+- keep or improve annotation quality
+- preserve the intended context-sharing model
+- avoid introducing noisy or sensitive prompt context
+- update docs/examples when the preferred integration pattern changes
+- validate that the assistant still receives the intended context in realistic usage

--- a/templates/agent-prompts.askable-ui.md
+++ b/templates/agent-prompts.askable-ui.md
@@ -1,0 +1,81 @@
+# askable-ui prompts for coding agents
+
+Use these prompts when asking a coding agent to add or improve `askable-ui` integration in an application.
+
+## 1. Add askable-ui to an existing app
+
+```md
+Add `askable-ui` to this app.
+
+Goals:
+- annotate meaningful UI surfaces with structured metadata
+- expose prompt-ready UI context to the existing AI/chat flow
+- avoid noisy or sensitive metadata in prompts
+- prefer curated summaries for charts/dashboards instead of raw DOM text
+
+Implementation rules:
+- use passive Askable focus updates for exploratory UI
+- use explicit `ctx.select()` for any "Ask AI" button flow
+- reuse shared contexts only when multiple components should power the same AI surface
+- create isolated contexts for unrelated panels/agents
+- add sanitization if any internal IDs, tokens, or hidden fields could reach the model
+- add or update docs/comments where the integration pattern would be non-obvious
+
+Deliver:
+- the code changes
+- a short explanation of the chosen annotation strategy
+- any risks or follow-up recommendations
+```
+
+## 2. Improve existing annotations
+
+```md
+Review this app's existing `askable-ui` integration and improve it.
+
+Focus on:
+- low-signal or noisy metadata
+- missing annotations on important surfaces
+- dashboards/charts that should use curated `data-askable-text`
+- accidental context sharing between unrelated panels
+- missing explicit `ctx.select()` usage on button-driven AI flows
+- opportunities to sanitize metadata/text before prompt serialization
+
+For each change, prefer product semantics over implementation detail.
+```
+
+## 3. Wire context into the chat boundary
+
+```md
+Find where this app sends requests to the LLM/chat backend and wire `askable-ui` context into that boundary.
+
+Requirements:
+- keep the context injection close to the actual AI request
+- use the existing Askable context for the relevant UI surface
+- prefer concise prompt context over dumping large state objects
+- preserve current app behavior when no Askable focus is active
+- document the integration point briefly if it would be hard to rediscover later
+```
+
+## 4. Add safe sanitization
+
+```md
+Audit the current `askable-ui` metadata/text for privacy and noise.
+
+Please:
+- identify fields that should not reach the model
+- add `sanitizeMeta`, `sanitizeText`, or a better text extraction strategy where needed
+- keep business-meaningful context intact
+- summarize what was redacted and why
+```
+
+## 5. Add an explicit Ask AI button pattern
+
+```md
+Implement an explicit "Ask AI" button flow for the main annotated card/list items in this app.
+
+Requirements:
+- use `ctx.select()` to pin the relevant Askable element before opening/submitting to the assistant
+- keep the button behavior predictable on desktop and mobile
+- preserve any existing click handlers
+- update docs/examples if the pattern becomes a recommended user flow
+```


### PR DESCRIPTION
## Summary
- add reusable coding-agent adoption templates for teams integrating askable-ui into their own repos
- add a new docs guide explaining where to place `AGENTS.md`, how to customize it, and how to use the copy-paste agent prompts
- link the new guide from the docs sidebar and README

## Testing
- `npm run build`
- `npm test`
- `cd site/docs && npm run build`

Closes #207
