### PR TITLE
feat(react): support per-component activation rules

### DIFF
--- a/packages/core/src/__tests__/observer.test.ts
+++ b/packages/core/src/__tests__/observer.test.ts
@@ -606,5 +606,58 @@ describe('Observer', () => {
 
       obs.unobserve();
     });
+
+    it('respects per-element manual activation overrides', () => {
+      const el = attach(makeEl({ id: 'manual-only' }, 'Manual only'));
+      el.setAttribute('data-askable-events', 'manual');
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document);
+
+      el.click();
+      el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      el.focus();
+
+      expect(onFocus).not.toHaveBeenCalled();
+
+      obs.unobserve();
+    });
+
+    it('respects per-element hover-only activation overrides', () => {
+      const el = attach(makeEl({ id: 'hover-only-override' }, 'Hover only override'));
+      el.setAttribute('data-askable-events', 'hover');
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document);
+
+      el.click();
+      expect(onFocus).not.toHaveBeenCalled();
+
+      el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      expect(onFocus).toHaveBeenCalledOnce();
+      expect(onFocus.mock.calls[0][0].meta).toEqual({ id: 'hover-only-override' });
+
+      obs.unobserve();
+    });
+
+    it('respects per-element click-only activation overrides', () => {
+      const el = attach(makeEl({ id: 'click-only-override' }, 'Click only override'));
+      el.setAttribute('data-askable-events', 'click');
+
+      const onFocus = vi.fn();
+      const obs = new Observer(onFocus);
+      obs.observe(document);
+
+      el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      expect(onFocus).not.toHaveBeenCalled();
+
+      el.click();
+      expect(onFocus).toHaveBeenCalledOnce();
+      expect(onFocus.mock.calls[0][0].meta).toEqual({ id: 'click-only-override' });
+
+      obs.unobserve();
+    });
   });
 });

--- a/packages/core/src/observer.ts
+++ b/packages/core/src/observer.ts
@@ -160,7 +160,32 @@ export function buildFocus(
 }
 
 const ALL_EVENTS: AskableEvent[] = ['click', 'hover', 'focus'];
-const OBSERVED_ATTRIBUTES = ['data-askable', 'data-askable-text', 'data-askable-priority', 'data-askable-scope', 'data-askable-parent'] as const;
+const OBSERVED_ATTRIBUTES = ['data-askable', 'data-askable-text', 'data-askable-priority', 'data-askable-scope', 'data-askable-parent', 'data-askable-events'] as const;
+
+type AskableElementEventOverride = AskableEvent[] | 'manual' | null;
+
+function parseElementEventOverride(el: HTMLElement): AskableElementEventOverride {
+  const raw = el.getAttribute('data-askable-events');
+  if (raw === null) return null;
+
+  const normalized = raw.trim();
+  if (!normalized) return null;
+  if (normalized === 'manual') return 'manual';
+
+  const values = normalized
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value): value is AskableEvent => ALL_EVENTS.includes(value as AskableEvent));
+
+  return values.length > 0 ? ALL_EVENTS.filter((event) => values.includes(event)) : null;
+}
+
+function resolveInteractionEvent(eventType: string, activeEvents: AskableEvent[]): AskableEvent | null {
+  if (eventType === 'focus' && activeEvents.includes('focus')) return 'focus';
+  if (isHoverInteraction(eventType, activeEvents)) return 'hover';
+  if (eventType === 'click' && activeEvents.includes('click')) return 'click';
+  return null;
+}
 
 export class Observer {
   private root: HTMLElement | Document | null = null;
@@ -289,7 +314,14 @@ export class Observer {
       }
     }
 
-    const isHover = isHoverInteraction(event.type, this.activeEvents);
+    const interactionEvent = resolveInteractionEvent(event.type, this.activeEvents);
+    if (!interactionEvent) return;
+
+    const elementEventOverride = parseElementEventOverride(el);
+    if (elementEventOverride === 'manual') return;
+    if (elementEventOverride && !elementEventOverride.includes(interactionEvent)) return;
+
+    const isHover = interactionEvent === 'hover';
 
     if (isHover && this.hoverDebounce > 0) {
       if (this.hoverTimer !== null) clearTimeout(this.hoverTimer);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -63,6 +63,10 @@ Renders any element (default: `div`) with a `data-askable` attribute. The `meta`
   <RevenueChart />
 </Askable>
 
+<Askable meta={{ widget: 'pipeline-chart' }} events={['hover']}>
+  <PipelineChart />
+</Askable>
+
 <Askable meta="main navigation" as="nav">
   <NavLinks />
 </Askable>
@@ -71,8 +75,37 @@ Renders any element (default: `div`) with a `data-askable` attribute. The `meta`
 **Props:**
 - `meta` — structured metadata attached to the element (`Record<string, unknown> | string`)
 - `scope` — optional category written to `data-askable-scope` for scoped prompt/history queries
+- `events` — optional per-component activation override (`AskableEvent[] | 'manual'`)
 - `as` — HTML tag to render (default: `"div"`)
 - All other props are forwarded to the underlying element
+
+Use `events` when one annotated component should be hover-only, click-only, or fully manual within the same page/context.
+
+```tsx
+function MixedDashboard() {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const { ctx } = useAskable();
+
+  return (
+    <>
+      <Askable meta={{ widget: 'pipeline' }} events={['hover']}>
+        <PipelineCard />
+      </Askable>
+
+      <Askable meta={{ widget: 'revenue' }} events={['click']}>
+        <RevenueCard />
+      </Askable>
+
+      <Askable ref={cardRef} meta={{ widget: 'account-summary' }} events="manual">
+        <AccountSummary />
+        <button onClick={() => cardRef.current && ctx.select(cardRef.current)}>
+          Ask AI
+        </button>
+      </Askable>
+    </>
+  );
+}
+```
 
 ### `AskableInspector(props?)`
 

--- a/packages/react/src/Askable.tsx
+++ b/packages/react/src/Askable.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import type { AskableEvent } from '@askable-ui/core';
 
 type AnyTag = keyof React.JSX.IntrinsicElements;
+type AskableActivation = AskableEvent[] | 'manual';
 
 type AskableProps<T extends AnyTag = 'div'> = {
   meta: Record<string, unknown> | string;
   scope?: string;
+  events?: AskableActivation;
   as?: T;
   children?: React.ReactNode;
 } & Omit<React.JSX.IntrinsicElements[T], 'children'>;
@@ -12,15 +15,22 @@ type AskableProps<T extends AnyTag = 'div'> = {
 export function Askable<T extends AnyTag = 'div'>({
   meta,
   scope,
+  events,
   as,
   children,
   ...props
 }: AskableProps<T>) {
   const Tag = (as ?? 'div') as string;
   const dataAskable = typeof meta === 'string' ? meta : JSON.stringify(meta);
+  const dataAskableEvents = Array.isArray(events) ? events.join(',') : events;
   return React.createElement(
     Tag,
-    { 'data-askable': dataAskable, ...(scope ? { 'data-askable-scope': scope } : {}), ...props },
+    {
+      'data-askable': dataAskable,
+      ...(scope ? { 'data-askable-scope': scope } : {}),
+      ...(dataAskableEvents ? { 'data-askable-events': dataAskableEvents } : {}),
+      ...props,
+    },
     children
   );
 }

--- a/packages/react/src/__tests__/Askable.test.tsx
+++ b/packages/react/src/__tests__/Askable.test.tsx
@@ -61,6 +61,22 @@ describe('Askable', () => {
     expect(el.getAttribute('data-askable-scope')).toBe('analytics');
   });
 
+  it('sets data-askable-events when component-level activation events are provided', () => {
+    const { container } = render(
+      <Askable meta={{ widget: 'revenue' }} events={['hover', 'focus']}>Revenue Chart</Askable>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute('data-askable-events')).toBe('hover,focus');
+  });
+
+  it('supports a manual activation mode for explicit button-driven flows', () => {
+    const { container } = render(
+      <Askable meta={{ widget: 'revenue' }} events="manual">Revenue Chart</Askable>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute('data-askable-events')).toBe('manual');
+  });
+
   it('supports nested Askable wrappers that form a DOM hierarchy', () => {
     const { container } = render(
       <Askable meta={{ view: 'dashboard' }}>

--- a/packages/react/src/__tests__/useAskable.test.tsx
+++ b/packages/react/src/__tests__/useAskable.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { useEffect } from 'react';
 import { createAskableContext } from '@askable-ui/core';
 import type { AskableContext } from '@askable-ui/core';
+import { Askable } from '../Askable';
 import { useAskable } from '../useAskable';
 
 function Consumer({
@@ -368,6 +369,78 @@ describe('useAskable', () => {
     });
 
     clickView.unmount();
+  });
+
+  it('supports per-component activation overrides within one shared context', async () => {
+    function MixedActivationConsumer() {
+      const { focus, ctx } = useAskable();
+      return (
+        <>
+          <span data-testid="mixed-focus">{focus ? JSON.stringify(focus.meta) : 'null'}</span>
+          <button
+            data-testid="manual-trigger"
+            onClick={() => {
+              const el = document.querySelector('[data-testid="manual-card"]') as HTMLElement | null;
+              if (el) ctx.select(el);
+            }}
+          >
+            Ask AI
+          </button>
+        </>
+      );
+    }
+
+    const view = render(
+      <>
+        <Askable meta={{ widget: 'hover-card' }} events={['hover']} data-testid="hover-card">
+          Hover card
+        </Askable>
+        <Askable meta={{ widget: 'click-card' }} events={['click']} data-testid="click-card">
+          Click card
+        </Askable>
+        <Askable meta={{ widget: 'manual-card' }} events="manual" data-testid="manual-card">
+          Manual card
+        </Askable>
+        <MixedActivationConsumer />
+      </>
+    );
+    await flushMicrotasks();
+
+    act(() => {
+      screen.getByTestId('hover-card').dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mixed-focus').textContent).toContain('hover-card');
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('hover-card'));
+    });
+    expect(screen.getByTestId('mixed-focus').textContent).toContain('hover-card');
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('click-card'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mixed-focus').textContent).toContain('click-card');
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('manual-card'));
+    });
+    expect(screen.getByTestId('mixed-focus').textContent).toContain('click-card');
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('manual-trigger'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mixed-focus').textContent).toContain('manual-card');
+    });
+
+    view.unmount();
   });
 
   it('updates shared hook-managed focus on hover-only events', async () => {

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -25,6 +25,14 @@ import { Askable } from '@askable-ui/react';
   <RevenueChart />
 </Askable>
 
+<Askable meta={{ metric: 'pipeline' }} events={['hover']}>
+  <PipelineChart />
+</Askable>
+
+<Askable meta={{ metric: 'revenue' }} events="manual">
+  <RevenueCard />
+</Askable>
+
 <Askable meta="main navigation" as="nav">
   <NavLinks />
 </Askable>
@@ -36,9 +44,38 @@ import { Askable } from '@askable-ui/react';
 |---|---|---|---|
 | `meta` | `Record<string, unknown> \| string` | — | Value for `data-askable` attribute |
 | `scope` | `string` | — | Optional category written to `data-askable-scope` for scoped prompt/history queries |
+| `events` | `AskableEvent[] \| 'manual'` | — | Optional per-component activation override. Use a subset like `['hover']`/`['click']` to narrow passive activation or `'manual'` to disable passive activation entirely |
 | `as` | `keyof JSX.IntrinsicElements` | `"div"` | HTML element to render |
 | `ref` | `Ref<HTMLElement>` | — | Forwarded to the underlying element |
 | ...rest | | | All other props forwarded to the element |
+
+Use `events` on `<Askable>` when one component should behave differently from the surrounding shared context. Typical patterns are hover-only cards, click-only cards, or fully manual cards that are activated through `ctx.select()`.
+
+```tsx
+function MixedDashboard() {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const { ctx } = useAskable();
+
+  return (
+    <>
+      <Askable meta={{ widget: 'pipeline' }} events={['hover']}>
+        <PipelineCard />
+      </Askable>
+
+      <Askable meta={{ widget: 'revenue' }} events={['click']}>
+        <RevenueCard />
+      </Askable>
+
+      <Askable ref={cardRef} meta={{ widget: 'account-summary' }} events="manual">
+        <AccountSummary />
+        <button onClick={() => cardRef.current && ctx.select(cardRef.current)}>
+          Ask AI
+        </button>
+      </Askable>
+    </>
+  );
+}
+```
 
 ### `AskableInspector(props?)`
 


### PR DESCRIPTION
## Summary
- add per-component activation overrides on React `<Askable>` via `events`
- support hover-only, click-only, and `manual` activation modes within one shared context
- document mixed activation patterns and explicit `ctx.select()` usage for manual cards

## Testing
- `npm run build`
- `npm test`
- `cd site/docs && npm run build`

Closes #190
