### PR TITLE
feat(core): add streaming context subscriptions

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -236,6 +236,28 @@ ctx.clear();
 // → focus is null, 'clear' event fires
 ```
 
+#### `subscribe(callback, options?): () => void`
+
+Subscribe to serialized context updates for streaming LLM integrations. The callback receives the latest `ctx.toContext()` string plus the current `AskableFocus | null`. Returns an unsubscribe function.
+
+```ts
+const unsubscribe = ctx.subscribe((context, focus) => {
+  streamTransport.send({
+    type: 'ui-context',
+    context,
+    focusedMeta: focus?.meta ?? null,
+  });
+}, {
+  history: 3,
+  debounce: 75,
+});
+
+// later
+unsubscribe();
+```
+
+Use `debounce` to coalesce rapid focus changes while a response is streaming.
+
 #### `select(element: HTMLElement): void`
 
 Programmatically set focus to any element, as if the user had interacted with it. Useful for "Ask AI" buttons that explicitly set context before opening a chat.

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -49,6 +49,7 @@ class MockIntersectionObserver {
 
 afterEach(() => {
   MockIntersectionObserver.instances = [];
+  vi.useRealTimers();
 });
 
 describe('createAskableContext', () => {
@@ -84,8 +85,86 @@ describe('createAskableContext', () => {
     expect(typeof (ctx as any).serializeFocus).toBe('function');
     expect(typeof (ctx as any).getVisibleElements).toBe('function');
     expect(typeof (ctx as any).toViewportContext).toBe('function');
+    expect(typeof ctx.subscribe).toBe('function');
     expect(typeof ctx.destroy).toBe('function');
     ctx.destroy();
+  });
+
+  it('subscribes to serialized context updates for focus and clear events', () => {
+    const first = makeEl({ widget: 'table' }, 'Table');
+    const second = makeEl({ widget: 'chart' }, 'Chart');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    const onContext = vi.fn();
+    const unsubscribe = ctx.subscribe(onContext, { history: 1, currentLabel: 'Now' });
+
+    first.click();
+    second.click();
+    ctx.clear();
+
+    expect(onContext).toHaveBeenCalledTimes(3);
+    expect(onContext.mock.calls[0][0]).toContain('Now: User is focused on: — widget: table — value "Table"');
+    expect(onContext.mock.calls[0][1]?.meta).toEqual({ widget: 'table' });
+    expect(onContext.mock.calls[1][0]).toContain('Recent interactions:');
+    expect(onContext.mock.calls[1][1]?.meta).toEqual({ widget: 'chart' });
+    expect(onContext.mock.calls[2][0]).toContain('Now: No UI element is currently focused.');
+    expect(onContext.mock.calls[2][1]).toBeNull();
+
+    unsubscribe();
+    ctx.destroy();
+    cleanup(first);
+    cleanup(second);
+  });
+
+  it('debounces subscribed context updates', () => {
+    vi.useFakeTimers();
+
+    const first = makeEl({ widget: 'table' }, 'Table');
+    const second = makeEl({ widget: 'chart' }, 'Chart');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    const onContext = vi.fn();
+    ctx.subscribe(onContext, { debounce: 50 });
+
+    first.click();
+    second.click();
+
+    expect(onContext).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(49);
+    expect(onContext).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onContext).toHaveBeenCalledTimes(1);
+    expect(onContext.mock.calls[0][0]).toContain('widget: chart');
+    expect(onContext.mock.calls[0][1]?.meta).toEqual({ widget: 'chart' });
+
+    ctx.destroy();
+    cleanup(first);
+    cleanup(second);
+  });
+
+  it('stops subscribed context updates after unsubscribe', () => {
+    const first = makeEl({ widget: 'table' }, 'Table');
+    const second = makeEl({ widget: 'chart' }, 'Chart');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    const onContext = vi.fn();
+    const unsubscribe = ctx.subscribe(onContext);
+
+    first.click();
+    expect(onContext).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    second.click();
+    expect(onContext).toHaveBeenCalledTimes(1);
+
+    ctx.destroy();
+    cleanup(first);
+    cleanup(second);
   });
 
   it('getFocus() returns null before any interaction', () => {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -4,6 +4,7 @@ import type {
   AskableContext,
   AskableContextOptions,
   AskableContextOutputOptions,
+  AskableContextSubscriber,
   AskableEventHandler,
   AskableEventName,
   AskableFocus,
@@ -14,6 +15,7 @@ import type {
   AskablePushOptions,
   AskableSerializedFocus,
   AskableSerializedFocusSegment,
+  AskableSubscribeOptions,
 } from './types.js';
 
 const PRESETS: Record<AskablePromptPreset, AskablePromptContextOptions> = {
@@ -36,6 +38,7 @@ export class AskableContextImpl implements AskableContext {
   private textExtractor: ((el: HTMLElement) => string) | undefined;
   private sanitizeMetaFn: ((meta: Record<string, unknown>) => Record<string, unknown>) | undefined;
   private sanitizeTextFn: ((text: string) => string) | undefined;
+  private subscriptions = new Set<() => void>();
 
   constructor(options?: AskableContextOptions) {
     this.textExtractor = options?.textExtractor;
@@ -315,8 +318,60 @@ export class AskableContextImpl implements AskableContext {
     return this.applyTokenBudget(output, resolved.maxTokens);
   }
 
+  subscribe(callback: AskableContextSubscriber, options?: AskableSubscribeOptions): () => void {
+    const { debounce = 0, ...contextOptions } = options ?? {};
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let active = true;
+
+    const emitContext = () => {
+      if (!active) return;
+      const focus = this.currentFocus;
+      const scopedFocus = this.matchesScope(focus, contextOptions.scope) ? focus : null;
+      callback(this.toContext(contextOptions), scopedFocus);
+    };
+
+    const schedule = () => {
+      if (!active) return;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (debounce > 0) {
+        timer = setTimeout(() => {
+          timer = null;
+          emitContext();
+        }, debounce);
+        return;
+      }
+      emitContext();
+    };
+
+    const onFocus = () => schedule();
+    const onClear = () => schedule();
+
+    this.on('focus', onFocus);
+    this.on('clear', onClear);
+
+    const unsubscribe = () => {
+      if (!active) return;
+      active = false;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      this.off('focus', onFocus);
+      this.off('clear', onClear);
+      this.subscriptions.delete(unsubscribe);
+    };
+
+    this.subscriptions.add(unsubscribe);
+    return unsubscribe;
+  }
+
   destroy(): void {
     this.unobserve();
+    this.subscriptions.forEach((unsubscribe) => unsubscribe());
+    this.subscriptions.clear();
     this.emitter.clear();
     this.currentFocus = null;
     this.history = [];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export type {
   AskableContext,
   AskableContextOptions,
   AskableContextOutputOptions,
+  AskableContextSubscriber,
+  AskableSubscribeOptions,
   AskableEvent,
   AskableEventHandler,
   AskableEventMap,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -134,6 +134,17 @@ export interface AskablePromptContextOptions {
 /**
  * Options for creating an AskableContext.
  */
+export interface AskableSubscribeOptions extends AskableContextOutputOptions {
+  /**
+   * Debounce delay in ms applied to subscription callbacks.
+   * Useful when streaming LLM responses should not be updated on every rapid focus change.
+   * Defaults to 0 (no debounce).
+   */
+  debounce?: number;
+}
+
+export type AskableContextSubscriber = (context: string, focus: AskableFocus | null) => void;
+
 export interface AskableContextOptions {
   /**
    * Optional name for reusing a shared context instance across the same page/runtime.
@@ -239,6 +250,8 @@ export interface AskableContext {
   toViewportContext(options?: AskablePromptContextOptions): string;
   /** Combined current focus + history in a single prompt-ready string */
   toContext(options?: AskableContextOutputOptions): string;
+  /** Subscribe to serialized context updates for streaming/chat integrations. Returns an unsubscribe function. */
+  subscribe(callback: AskableContextSubscriber, options?: AskableSubscribeOptions): () => void;
   /** Clean up all listeners and observers */
   destroy(): void;
 }

--- a/site/docs/examples/ai-sdk.md
+++ b/site/docs/examples/ai-sdk.md
@@ -132,6 +132,62 @@ const { messages, input, handleSubmit } = useChat({
 
 :::
 
+### Streaming updates during generation
+
+When a response is already streaming, you can keep the server-side session fresh by subscribing to Askable context changes and posting debounced updates tied to the active chat request.
+
+```tsx
+'use client';
+import { useEffect, useMemo, useRef } from 'react';
+import { useChat } from 'ai/react';
+import { useAskable } from '@askable-ui/react';
+
+export function StreamingChat() {
+  const { ctx, promptContext } = useAskable();
+  const requestIdRef = useRef<string | null>(null);
+
+  const chatBody = useMemo(() => ({
+    requestId: crypto.randomUUID(),
+    uiContext: promptContext,
+    historyContext: ctx.toHistoryContext(5),
+  }), [ctx, promptContext]);
+
+  const { status, ...chat } = useChat({
+    api: '/api/chat',
+    body: chatBody,
+    onResponse() {
+      requestIdRef.current = chatBody.requestId;
+    },
+    onFinish() {
+      requestIdRef.current = null;
+    },
+  });
+
+  useEffect(() => {
+    if (status !== 'streaming') return;
+
+    return ctx.subscribe(async (context) => {
+      if (!requestIdRef.current) return;
+      await fetch('/api/chat/context', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requestId: requestIdRef.current,
+          context,
+        }),
+      });
+    }, {
+      history: 5,
+      debounce: 100,
+    });
+  }, [ctx, status]);
+
+  return <ChatUI {...chat} />;
+}
+```
+
+On the server, store these incremental updates by `requestId` and let your streaming route read the latest Askable context between model/tool steps.
+
 ## Anthropic SDK
 
 ```ts

--- a/site/docs/examples/copilotkit.md
+++ b/site/docs/examples/copilotkit.md
@@ -139,3 +139,37 @@ export function MetricCard({ data, onOpenChat }) {
 | **Explicit** (`ctx.select()` on button click) | Chat opens on demand; user should control when context is captured |
 
 Both patterns can coexist — use passive observation for the general context and `select()` for specific "Ask AI about this" flows.
+
+## Streaming updates during long-running agent responses
+
+If a Copilot action can continue while the user clicks elsewhere, subscribe to Askable context and feed a debounced combined context string into `useCopilotReadable`.
+
+```tsx
+'use client';
+import { useEffect, useState } from 'react';
+import { useAskable } from '@askable-ui/react';
+import { useCopilotReadable } from '@copilotkit/react-core';
+
+export function LiveCopilotContext() {
+  const { ctx } = useAskable();
+  const [liveContext, setLiveContext] = useState(() => ctx.toContext({ history: 3 }));
+
+  useEffect(() => {
+    return ctx.subscribe((context) => {
+      setLiveContext(context);
+    }, {
+      history: 3,
+      debounce: 100,
+    });
+  }, [ctx]);
+
+  useCopilotReadable({
+    description: 'Current and recent Askable UI context',
+    value: liveContext,
+  });
+
+  return null;
+}
+```
+
+This keeps CopilotKit aligned with the latest user focus without flooding it on every micro-movement.


### PR DESCRIPTION
## Summary
- add `ctx.subscribe()` for push-style serialized context updates during streaming responses
- support debounced subscriptions and return an unsubscribe cleanup function
- document streaming patterns for Vercel AI SDK and CopilotKit

Closes #120

## Testing
- npm test --workspace @askable-ui/core -- --run src/__tests__/context.test.ts
- npm run build
- npm test
- cd site/docs && npm run build