### PR TITLE
revert: drop CopilotKit positioning docs changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">askable-ui</h1>
 
 <p align="center">
-  <strong>Give your AI copilot eyes.</strong><br />
-  askable-ui is the UI context layer that works on top of CopilotKit, Vercel AI SDK, OpenAI, and other LLM stacks.
+  <strong>Two lines of code to give your LLM eyes.</strong><br />
+  One attribute. Zero prompt engineering. It knows exactly what the user sees.
 </p>
 
 <p align="center">
@@ -67,16 +67,6 @@ function Dashboard({ kpi }) {
 
 That's it. `promptContext` updates automatically as the user interacts. Pass it to any LLM.
 
-### Recommended starting point: CopilotKit + Askable
-
-If you want the fastest path to a production UI copilot, start with **CopilotKit for chat/actions** and **Askable for UI context**.
-
-- **Askable** gives the agent eyes via `promptContext`, `ctx.toHistoryContext()`, and `ctx.select()`
-- **CopilotKit** gives the agent hands via chat UI, runtime orchestration, and actions
-- Together they cover the full loop: what the user is looking at, plus what the agent can do about it
-
-See the full guide: [CopilotKit integration](https://askable-ui.com/docs/guide/copilotkit)
-
 ---
 
 ## Why
@@ -128,9 +118,7 @@ const result = await streamText({
 
 ## Works with
 
-**Recommended path** — CopilotKit + Askable for UI copilots that need both actions and live UI awareness
-
-**Other LLM SDKs** — Vercel AI SDK · OpenAI · Anthropic · LangChain · any SDK that accepts strings or structured context
+**LLM SDKs** — OpenAI · Anthropic · Vercel AI SDK · CopilotKit · LangChain · any SDK
 
 **Frameworks** — React · Vue 3 · Svelte · Vanilla JS · Next.js · Nuxt · SvelteKit
 
@@ -258,14 +246,6 @@ ctx.on('focus', () => {
 
 ---
 
-## Community
-
-- **GitHub Discussions:** [Share use cases, questions, and integration ideas](https://github.com/askable-ui/askable/discussions)
-- **Issues:** [Report bugs or request features](https://github.com/askable-ui/askable/issues)
-- **Contributing:** [PRs welcome](./CONTRIBUTING.md)
-
----
-
 ## Documentation
 
 **[askable-ui.com/docs](https://askable-ui.com/docs/)**
@@ -273,9 +253,9 @@ ctx.on('focus', () => {
 | Guide | |
 |---|---|
 | [Getting started](https://askable-ui.com/docs/guide/getting-started) | Install, observe, inject |
-| [CopilotKit integration](https://askable-ui.com/docs/guide/copilotkit) | Recommended path for full UI copilots |
 | [Annotating elements](https://askable-ui.com/docs/guide/annotating) | `data-askable`, nesting, priority |
 | [React](https://askable-ui.com/docs/guide/react) · [Vue](https://askable-ui.com/docs/guide/vue) · [Svelte](https://askable-ui.com/docs/guide/svelte) | Framework guides |
+| [CopilotKit integration](https://askable-ui.com/docs/guide/copilotkit) | Context-in-input pattern |
 | [API reference](https://askable-ui.com/docs/api/core) | Full type docs |
 
 ---

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -3,16 +3,13 @@ layout: home
 
 hero:
   name: "askable-ui"
-  text: "Give your AI copilot eyes"
-  tagline: Askable is the UI context layer that works on top of CopilotKit, Vercel AI SDK, and other LLM stacks. Annotate meaningful elements once, then send the user's real focus to your model.
+  text: "UI context your LLM can actually use"
+  tagline: Annotate any DOM element with data-askable and instantly turn what the user is looking at into structured, prompt-ready context.
   image:
     src: /avatar.png
     alt: askable-ui
   actions:
     - theme: brand
-      text: Start with CopilotKit
-      link: /guide/copilotkit
-    - theme: alt
       text: Get Started
       link: /guide/getting-started
     - theme: alt
@@ -40,10 +37,10 @@ features:
 
   - icon: 🔌
     title: Works with any LLM
-    details: Start with CopilotKit when you want chat UI and actions, or drop Askable into Vercel AI SDK, OpenAI, Anthropic, and other model pipelines. Askable stays the context layer either way.
+    details: toPromptContext() returns a plain string — drop it into OpenAI, Anthropic, Vercel AI SDK, CopilotKit, or any LLM pipeline. No vendor lock-in.
 ---
 
-> Current npm release: **v0.6.0**.
+> Current npm release: **v0.5.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -61,15 +58,6 @@ features:
     Your browser does not support the video tag.
   </video>
 </div>
-
-## Recommended path
-
-For the fastest route to a production UI copilot:
-
-- use **Askable** for UI context (`promptContext`, `ctx.toHistoryContext()`, `ctx.select()`)
-- use **CopilotKit** for chat UI, actions, and runtime orchestration
-
-Start here: [CopilotKit integration guide](/guide/copilotkit)
 
 ## Quick look
 


### PR DESCRIPTION
## Summary
- revert the README and docs homepage positioning changes from #217
- keep the earlier streaming context subscription work from #216 intact
- return the docs copy to the previous wording

## Testing
- npm run build
- npm test
- cd site/docs && npm run build