### PR TITLE
chore: bump to v6.1.0 and refresh docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.6.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.6.0",
+      "version": "6.1.0",
       "workspaces": [
         "packages/*"
       ],
@@ -4191,7 +4191,7 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.6.0",
+      "version": "6.1.0",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -4201,10 +4201,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.6.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.0"
+        "@askable-ui/core": "^6.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4224,10 +4224,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.6.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.0"
+        "@askable-ui/core": "^6.1.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -4329,10 +4329,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.6.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.0"
+        "@askable-ui/core": "^6.1.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -4448,10 +4448,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.6.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.0"
+        "@askable-ui/core": "^6.1.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.6.0",
+  "version": "6.1.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.6.0",
+  "version": "6.1.0",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.6.0",
+  "version": "6.1.0",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.0"
+    "@askable-ui/core": "^6.1.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.6.0",
+  "version": "6.1.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.0"
+    "@askable-ui/core": "^6.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.6.0",
+  "version": "6.1.0",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.0"
+    "@askable-ui/core": "^6.1.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.6.0",
+  "version": "6.1.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.0"
+    "@askable-ui/core": "^6.1.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
           text: 'Introduction',
           items: [
             { text: 'What is askable-ui?', link: '/guide/' },
+            { text: 'What’s New in v6.1.0', link: '/guide/whats-new' },
             { text: 'Getting Started', link: '/guide/getting-started' },
             { text: 'How It Works', link: '/guide/how-it-works' },
           ],
@@ -87,6 +88,12 @@ export default defineConfig({
           text: 'Tooling',
           items: [
             { text: 'Inspector / Dev Panel', link: '/guide/inspector' },
+          ],
+        },
+        {
+          text: 'Writing',
+          items: [
+            { text: 'Medium article draft', link: '/guide/medium-article-your-ai-copilot-still-cant-see-your-ui' },
           ],
         },
       ],

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.5.0`
-- Versioned current docs URL: `/docs/v0.5.0/`
+- Latest stable: `v6.1.0`
+- Versioned current docs URL: `/docs/v6.1.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.5.0/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v6.1.0/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.5.0**.
+> Current npm release: **v6.1.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/medium-article-your-ai-copilot-still-cant-see-your-ui.md
+++ b/site/docs/guide/medium-article-your-ai-copilot-still-cant-see-your-ui.md
@@ -1,0 +1,186 @@
+# Your AI Copilot Still Can’t See Your UI
+
+Most AI copilots fail in product interfaces for a boring reason: the model usually has no idea what the user is actually looking at.
+
+It sees the chat.
+It sees the prompt.
+It may even have tool access.
+
+But when the user asks:
+
+- “Why is this dropping?”
+- “What does this number mean?”
+- “Can you help me with this form?”
+
+…the assistant often has to guess what **this** means.
+
+That is the gap askable-ui is built to close.
+
+askable-ui gives AI copilots a lightweight UI context layer. Instead of scraping the page or shipping massive DOM payloads to the model, you annotate meaningful elements with structured metadata and let the library track what the user is focused on right now.
+
+## The problem with in-app AI
+
+Inside dashboards, forms, CRMs, admin panels, and internal tools, the frontend already knows a lot:
+
+- which KPI card the user clicked
+- which table row is selected
+- which chart the user hovered
+- which form field they are stuck on
+
+But that context usually never reaches the model in a reliable way.
+
+So we end up with assistants that are technically integrated into the app, but still feel disconnected from it.
+
+Users have to restate what they see. Context gets lost between turns. Responses stay generic even when the data is right there on the page.
+
+That is not really a model-quality problem.
+
+It is a context plumbing problem.
+
+## Why the obvious solutions fall short
+
+### Send the whole DOM
+
+This is noisy, expensive, brittle, and often low-signal.
+A model does not need the entire page to explain a single revenue widget.
+
+### Use screenshots everywhere
+
+Vision can help, but it is not the default answer for every product UI.
+In many apps, the semantic meaning is already present in code.
+You do not need the model to infer from pixels what your React props already know.
+
+### Hand-build prompt strings in every feature
+
+This works for a few components, then slowly turns into prompt glue spread across the frontend.
+
+## The askable-ui approach
+
+The core idea is simple:
+
+1. annotate meaningful elements
+2. observe focus, click, hover, or explicit selection
+3. serialize that context for the AI boundary
+
+In React:
+
+```tsx
+import { Askable, useAskable } from '@askable-ui/react';
+
+function Dashboard({ kpi }) {
+  const { promptContext } = useAskable();
+
+  return (
+    <Askable meta={{ metric: kpi.name, value: kpi.value, delta: kpi.delta }}>
+      <KPICard data={kpi} />
+    </Askable>
+  );
+}
+```
+
+Now the app can produce prompt-ready context like:
+
+> User is focused on: metric: revenue, value: $128,400, delta: +12%
+
+That string can go straight into OpenAI, Anthropic, Vercel AI SDK, CopilotKit, or any other LLM stack.
+
+The point is not the framework.
+The point is that the model gets the same semantic context your UI already had.
+
+## A better mental model for AI products
+
+askable-ui is not trying to replace your LLM SDK or your agent runtime.
+
+It fits underneath them.
+
+- Askable gives the system **eyes**
+- CopilotKit can provide **chat UI, actions, and runtime orchestration**
+- Vercel AI SDK can handle **streaming and model wiring**
+- OpenAI or Anthropic can handle **generation**
+
+That separation matters.
+It keeps the UI-context problem small, explicit, and reusable.
+
+## Why annotation beats scraping
+
+One of the strongest parts of this approach is that the same data that renders the UI can also power the AI context.
+
+```tsx
+<Askable meta={{ metric: 'revenue', value: '$2.3M', delta: '+12%', period: 'Q3' }}>
+  <RevenueChart data={data} />
+</Askable>
+```
+
+That gives you:
+
+- smaller prompts
+- clearer semantics
+- less accidental noise
+- more predictable AI behavior
+
+Instead of forcing the model to reverse-engineer your interface, you let the product tell it what matters.
+
+## Context should not freeze when the model starts talking
+
+A subtle failure mode in AI UX is stale context during streaming.
+
+The user clicks one thing, a response starts streaming, then they move to another element before the model finishes.
+The assistant keeps talking about old context because the context snapshot was taken only once at request start.
+
+That is why recent askable-ui updates added streaming context subscriptions:
+
+```ts
+const unsubscribe = ctx.subscribe((context, focus) => {
+  transport.send({ context, focus });
+}, {
+  history: 5,
+  debounce: 100,
+});
+```
+
+This makes it easier to keep long-running AI responses aligned with live UI behavior.
+
+## Good AI UX is not just better models
+
+A lot of product teams are chasing smarter models when the bigger opportunity is better boundaries around the model:
+
+- better context
+- better grounding
+- better timing
+- better visibility into what the system knows
+- better user control over what gets sent
+
+That is where askable-ui fits.
+
+It gives product teams a clean interface for one very specific but very important thing:
+
+**what is the user looking at right now?**
+
+## The simplest takeaway
+
+Your app already knows what the user is looking at.
+Your model usually does not.
+
+askable-ui is the layer that closes that gap.
+
+And once you feel the difference in a real product, it is hard to go back.
+
+## Try it
+
+```bash
+npm install @askable-ui/react
+```
+
+```tsx
+<Askable meta={{ metric: 'revenue', value: '$128,400', delta: '+12%' }}>
+  <RevenueCard />
+</Askable>
+```
+
+```tsx
+const { promptContext } = useAskable();
+```
+
+Then pass `promptContext` into your model boundary.
+
+That is enough to make an AI assistant feel much more grounded in the actual product experience.

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,0 +1,87 @@
+# What’s New in v6.1.0
+
+askable-ui v6.1.0 rolls up the most recent improvements across the core library, React bindings, and docs.
+
+## Highlights
+
+### Streaming context subscriptions
+
+You can now subscribe to serialized Askable context updates directly from `@askable-ui/core`:
+
+```ts
+const unsubscribe = ctx.subscribe((context, focus) => {
+  streamTransport.send({ context, focus });
+}, {
+  history: 5,
+  debounce: 100,
+});
+```
+
+This is especially useful for AI experiences that keep streaming while the user continues interacting with the UI.
+
+Use it when you want to:
+
+- keep Vercel AI SDK sessions aligned with live UI focus
+- update CopilotKit readable context during long-running agent responses
+- debounce rapid UI changes before forwarding them to your model/runtime
+
+Related docs:
+
+- [AI SDK integration](/examples/ai-sdk)
+- [CopilotKit example](/examples/copilotkit)
+- [@askable-ui/core API](/api/core)
+
+### Per-component activation rules in React
+
+React components can now override activation behavior per component with the `events` prop on `<Askable>`.
+
+```tsx
+<Askable meta={{ widget: 'revenue' }} events={['hover']}>
+  <RevenueCard />
+</Askable>
+
+<Askable meta={{ widget: 'account-row' }} events={['click']}>
+  <AccountRow />
+</Askable>
+
+<Askable meta={{ widget: 'details-panel' }} events="manual">
+  <Panel />
+</Askable>
+```
+
+This makes mixed interaction patterns easier inside a single page or shared context:
+
+- hover-only summary cards
+- click-only rows in dense tables
+- fully manual "Ask AI about this" flows driven by `ctx.select()`
+
+Related docs:
+
+- [React API](/api/react)
+- [Ask AI button example](/examples/ask-ai-button)
+
+### Better shared-context guidance
+
+The recent docs updates also clarify how shared contexts behave across React, Vue, and the inspector tooling.
+
+That includes guidance for:
+
+- named shared contexts
+- private vs shared contexts
+- matching inspector configuration to custom event/view settings
+- preserving hover-only and focus-only behavior in shared setups
+
+## Recommended next step
+
+If you are integrating Askable into an AI copilot, start here:
+
+1. [Getting Started](/guide/getting-started)
+2. [CopilotKit integration guide](/guide/copilotkit)
+3. [AI SDK integration patterns](/examples/ai-sdk)
+
+## Version note
+
+The current published docs track **v6.1.0** at both:
+
+- `/docs/`
+- `/docs/v6.1.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string — drop it into OpenAI, Anthropic, Vercel AI SDK, CopilotKit, or any LLM pipeline. No vendor lock-in.
 ---
 
-> Current npm release: **v0.5.0**.
+> Current npm release: **v6.1.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -58,6 +58,18 @@ features:
     Your browser does not support the video tag.
   </video>
 </div>
+
+## Latest in v6.1.0
+
+- `ctx.subscribe(callback, options?)` for debounced streaming context updates in `@askable-ui/core`
+- per-component React activation overrides with `events={['hover']}`, `events={['click']}`, or `events="manual"`
+- refreshed docs coverage for streaming AI SDK flows, CopilotKit, shared contexts, and inspector alignment
+
+Start here:
+
+- [What’s New in v6.1.0](/guide/whats-new)
+- [AI SDK integration patterns](/examples/ai-sdk)
+- [CopilotKit guide](/guide/copilotkit)
 
 ## Quick look
 

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.6.0",
-    "slug": "v0.6.0"
+    "label": "v6.1.0",
+    "slug": "v6.1.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.6.0`) is built on every deploy and published to both:
+The current release (`v6.1.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.6.0/` (version-specific URL)
+- `/docs/v6.1.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- bump the monorepo package versions to 6.1.0 and update internal workspace dependency ranges
- refresh docs version metadata and add a v6.1.0 updates page
- add a polished Medium article draft to the docs

## Testing
- npm run build
- npm test
- cd site/docs && npm run build