### PR TITLE
fix(expo): override xmldom to patched version

### DIFF
--- a/examples/react-native-expo/package-lock.json
+++ b/examples/react-native-expo/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@askable-ui/example-react-native-expo",
       "version": "0.0.0",
       "dependencies": {
-        "@askable-ui/core": "^0.5.0",
-        "@askable-ui/react-native": "^0.5.0",
+        "@askable-ui/core": "^6.1.0",
+        "@askable-ui/react-native": "^6.1.0",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.6.2",
         "expo": "^55.0.15",
@@ -25,18 +25,18 @@
       }
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.5.0.tgz",
-      "integrity": "sha512-H4KY+syMIA19Ak5nn6qf+GWDzjELyycQut2QXJiOWpoxIWyv53PZY8t17nFEax/8V+l5e6wPYHEp/lpOegQVCg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-lJgS+UIxUgjGPObWOQERQXLUyYIivwt2Ryo5Z7luMKbar0CBwBr05nDJ+AN+f0ahCuUKMDlYd9k7TnuYPqkjcg==",
       "license": "MIT"
     },
     "node_modules/@askable-ui/react-native": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.5.0.tgz",
-      "integrity": "sha512-miFXiJQwVLqUT7bleIOLhb88CynZqKCtm+8obEgyUCbQGuVbLTfnihKzCK0q80FnBnD4Cg5aANwAbowW4ESVWw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-6.1.0.tgz",
+      "integrity": "sha512-KqWY1qWFx8vR7lgrg+9kq1b4V3PW9/e46vdbXh5w8WScP4Wg54mNZm3KgPRSQY/t5TCv6Ujqks5LqqR2JD0rDQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.5.0"
+        "@askable-ui/core": "^6.1.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0"
@@ -2543,9 +2543,9 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "@types/react": "^19.1.1",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "@xmldom/xmldom": "^0.8.13"
   }
 }


### PR DESCRIPTION
## Summary
- add an npm override in the Expo example to force `@xmldom/xmldom` to a patched release
- regenerate the Expo example lockfile so transitive consumers resolve `@xmldom/xmldom@0.8.13`
- remove the high-severity `xmldom` advisories from `examples/react-native-expo`

## Testing
- `cd examples/react-native-expo && npm audit --json`
- `cd examples/react-native-expo && npm run typecheck`

## Notes
- The remaining Expo example audit findings are moderate-severity issues in the Expo dependency chain; the `xmldom` high-severity findings are cleared by this change.
