### PR TITLE
chore(release): bump version to 6.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,6 @@
 npm install @askable-ui/react
 ```
 
-Want a runnable Askable + CopilotKit starter app instead?
-
-```bash
-npx create-askable-app my-app
-cd my-app
-npm install
-npm run dev
-```
-
 ```tsx
 import { Askable, useAskable } from '@askable-ui/react';
 
@@ -75,6 +66,16 @@ function Dashboard({ kpi }) {
 ```
 
 That's it. `promptContext` updates automatically as the user interacts. Pass it to any LLM.
+
+Need a runnable starter app with Askable and CopilotKit?
+
+```bash
+npx create-askable-app my-app
+cd my-app
+npm install
+npm run dev
+```
+
 
 ---
 

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^6.1.0",
+    "@askable-ui/react": "^6.1.1",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^6.1.0",
-    "@askable-ui/react-native": "^6.1.0",
+    "@askable-ui/core": "^6.1.1",
+    "@askable-ui/react-native": "^6.1.1",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.6.2",
     "expo": "^55.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "workspaces": [
         "packages/*"
       ],
@@ -4195,7 +4195,7 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -4204,7 +4204,7 @@
       }
     },
     "packages/create-askable-app": {
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4212,10 +4212,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^6.1.0"
+        "@askable-ui/core": "^6.1.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4235,10 +4235,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^6.1.0"
+        "@askable-ui/core": "^6.1.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -4340,10 +4340,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^6.1.0"
+        "@askable-ui/core": "^6.1.1"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -4459,10 +4459,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^6.1.0"
+        "@askable-ui/core": "^6.1.1"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-askable-app",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '6.1.0';
+const ASKABLE_VERSION = '6.1.1';
 const COPILOTKIT_VERSION = '1.56.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^6.1.0"
+    "@askable-ui/core": "^6.1.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^6.1.0"
+    "@askable-ui/core": "^6.1.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^6.1.0"
+    "@askable-ui/core": "^6.1.1"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^6.1.0"
+    "@askable-ui/core": "^6.1.1"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v6.1.0`
-- Versioned current docs URL: `/docs/v6.1.0/`
+- Latest stable: `v6.1.1`
+- Versioned current docs URL: `/docs/v6.1.1/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v6.1.0/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v6.1.1/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v6.1.0**.
+> Current npm release: **v6.1.1**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,6 +1,6 @@
-# What’s New in v6.1.0
+# What’s New in v6.1.1
 
-askable-ui v6.1.0 rolls up the most recent improvements across the core library, React bindings, and docs.
+askable-ui v6.1.1 rolls up the most recent improvements across the core library, React bindings, and docs.
 
 ## Highlights
 
@@ -81,7 +81,7 @@ If you are integrating Askable into an AI copilot, start here:
 
 ## Version note
 
-The current published docs track **v6.1.0** at both:
+The current published docs track **v6.1.1** at both:
 
 - `/docs/`
-- `/docs/v6.1.0/`
+- `/docs/v6.1.1/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string — drop it into OpenAI, Anthropic, Vercel AI SDK, CopilotKit, or any LLM pipeline. No vendor lock-in.
 ---
 
-> Current npm release: **v6.1.0**.
+> Current npm release: **v6.1.1**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,7 +59,7 @@ features:
   </video>
 </div>
 
-## Latest in v6.1.0
+## Latest in v6.1.1
 
 - `ctx.subscribe(callback, options?)` for debounced streaming context updates in `@askable-ui/core`
 - per-component React activation overrides with `events={['hover']}`, `events={['click']}`, or `events="manual"`
@@ -67,7 +67,7 @@ features:
 
 Start here:
 
-- [What’s New in v6.1.0](/guide/whats-new)
+- [What’s New in v6.1.1](/guide/whats-new)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)
 

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v6.1.0",
-    "slug": "v6.1.0"
+    "label": "v6.1.1",
+    "slug": "v6.1.1"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v6.1.0`) is built on every deploy and published to both:
+The current release (`v6.1.1`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v6.1.0/` (version-specific URL)
+- `/docs/v6.1.1/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- bump the monorepo packages to v6.1.1
- update `create-askable-app` scaffolding and example dependency ranges to match the new release
- refresh docs/version references and move the starter-app callout lower in the README so installation stays first

## Testing
- Example version consistency script passed
- Workspace builds passed across all packages
- Workspace test suites passed across all packages
- Versioned docs build passed
