### PR TITLE
Fix release publishing reruns

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -82,38 +82,30 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish @askable-ui/core
+      - name: Publish packages
         env:
           DIST_TAG: ${{ steps.dist-tag.outputs.tag }}
-        run: npm publish --access public --provenance --tag "$DIST_TAG"
-        working-directory: packages/core
+        run: |
+          publish_package() {
+            local package_dir="$1"
+            local package_name
+            local package_version
 
-      - name: Publish @askable-ui/react
-        env:
-          DIST_TAG: ${{ steps.dist-tag.outputs.tag }}
-        run: npm publish --access public --provenance --tag "$DIST_TAG"
-        working-directory: packages/react
+            package_name=$(node -p "require('./${package_dir}/package.json').name")
+            package_version=$(node -p "require('./${package_dir}/package.json').version")
 
-      - name: Publish @askable-ui/vue
-        env:
-          DIST_TAG: ${{ steps.dist-tag.outputs.tag }}
-        run: npm publish --access public --provenance --tag "$DIST_TAG"
-        working-directory: packages/vue
+            if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+              echo "${package_name}@${package_version} is already published; skipping."
+              return
+            fi
 
-      - name: Publish @askable-ui/svelte
-        env:
-          DIST_TAG: ${{ steps.dist-tag.outputs.tag }}
-        run: npm publish --access public --provenance --tag "$DIST_TAG"
-        working-directory: packages/svelte
+            echo "Publishing ${package_name}@${package_version}..."
+            (cd "$package_dir" && npm publish --access public --provenance --tag "$DIST_TAG")
+          }
 
-      - name: Publish @askable-ui/react-native
-        env:
-          DIST_TAG: ${{ steps.dist-tag.outputs.tag }}
-        run: npm publish --access public --provenance --tag "$DIST_TAG"
-        working-directory: packages/react-native
-
-      - name: Publish create-askable-app
-        env:
-          DIST_TAG: ${{ steps.dist-tag.outputs.tag }}
-        run: npm publish --provenance --tag "$DIST_TAG"
-        working-directory: packages/create-askable-app
+          publish_package packages/core
+          publish_package packages/react
+          publish_package packages/vue
+          publish_package packages/svelte
+          publish_package packages/react-native
+          publish_package packages/create-askable-app

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -4,7 +4,7 @@
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {
-    "create-askable-app": "./bin/create-askable-app.js"
+    "create-askable-app": "bin/create-askable-app.js"
   },
   "files": [
     "bin",
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/create-askable-app"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- makes the npm release workflow idempotent by skipping package versions that already exist on npm
- keeps publishing from each package directory so reruns target the intended workspace package
- normalizes the create-askable-app package metadata that npm warned about during publish

## Why
The 0.6.2 release published the scoped packages successfully, then failed at create-askable-app because that package is not yet available or permitted on npm. This lets a manual rerun skip the already-published scoped packages and retry only missing packages after npm access is fixed.

## Validation
- npm ci
- npm run build
- npm test
- npm publish --dry-run from packages/create-askable-app
