### PR TITLE
Publish starter under askable-ui scope

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -94,7 +94,7 @@ jobs:
             package_name=$(node -p "require('./${package_dir}/package.json').name")
             package_version=$(node -p "require('./${package_dir}/package.json').version")
 
-            if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+            if npm pack "${package_name}@${package_version}" --dry-run --json >/dev/null 2>&1; then
               echo "${package_name}@${package_version} is already published; skipping."
               return
             fi

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ That's it. `promptContext` updates automatically as the user interacts. Pass it 
 Need a runnable starter app with Askable and CopilotKit?
 
 ```bash
-npx create-askable-app my-app
+npm create @askable-ui/app my-app
 cd my-app
 npm install
 npm run dev
@@ -160,7 +160,7 @@ askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it
 | [`@askable-ui/react-native`](https://www.npmjs.com/package/@askable-ui/react-native) | [![npm](https://img.shields.io/npm/v/@askable-ui/react-native?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/react-native) | React Native (initial press-driven adapter) |
 | [`@askable-ui/vue`](https://www.npmjs.com/package/@askable-ui/vue) | [![npm](https://img.shields.io/npm/v/@askable-ui/vue?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/vue) | Vue 3 |
 | [`@askable-ui/svelte`](https://www.npmjs.com/package/@askable-ui/svelte) | [![npm](https://img.shields.io/npm/v/@askable-ui/svelte?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/svelte) | Svelte 4 & 5 |
-| [`create-askable-app`](https://www.npmjs.com/package/create-askable-app) | npm package | React + Vite + CopilotKit starter scaffold |
+| [`@askable-ui/create-app`](https://www.npmjs.com/package/@askable-ui/create-app) | npm package | React + Vite + CopilotKit starter scaffold |
 
 <details>
 <summary><strong>Framework quick starts</strong></summary>

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,6 @@
 
 This directory contains runnable or in-progress example apps for Askable.
 
-- `../packages/create-askable-app/` — starter scaffold that generates a React + Vite + CopilotKit Askable app via `npx create-askable-app my-app`
+- `../packages/create-askable-app/` — starter scaffold that generates a React + Vite + CopilotKit Askable app via `npm create @askable-ui/app my-app`
 - `analytics-dashboard-react/` — runnable Vercel/shadcn-inspired analytics dashboard example with Askable-integrated panels and Ask AI actions ([live preview](https://askable-mu.vercel.app/))
 - `react-native-expo/` — runnable Expo example showing screen-aware, visibility-aware, and press-aware mobile context capture

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.6.2",
+    "@askable-ui/react": "^0.6.3",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.2",
-    "@askable-ui/react-native": "^0.6.2",
+    "@askable-ui/core": "^0.6.3",
+    "@askable-ui/react-native": "^0.6.3",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "workspaces": [
         "packages/*"
       ],
@@ -84,6 +84,10 @@
     },
     "node_modules/@askable-ui/core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@askable-ui/create-app": {
+      "resolved": "packages/create-askable-app",
       "link": true
     },
     "node_modules/@askable-ui/react": {
@@ -1805,10 +1809,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/create-askable-app": {
-      "resolved": "packages/create-askable-app",
-      "link": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4185,7 +4185,7 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -4194,7 +4194,8 @@
       }
     },
     "packages/create-askable-app": {
-      "version": "0.6.2",
+      "name": "@askable-ui/create-app",
+      "version": "0.6.3",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4202,10 +4203,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.2"
+        "@askable-ui/core": "^0.6.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4225,10 +4226,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.2"
+        "@askable-ui/core": "^0.6.3"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -4343,10 +4344,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.2"
+        "@askable-ui/core": "^0.6.3"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -4462,10 +4463,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.2"
+        "@askable-ui/core": "^0.6.3"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-askable-app/README.md
+++ b/packages/create-askable-app/README.md
@@ -1,11 +1,11 @@
-# create-askable-app
+# @askable-ui/create-app
 
 Scaffold a runnable **React + Vite + CopilotKit + askable-ui** starter app.
 
 ## Usage
 
 ```bash
-npx create-askable-app my-app
+npm create @askable-ui/app my-app
 cd my-app
 npm install
 npm run dev

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "create-askable-app",
-  "version": "0.6.2",
+  "name": "@askable-ui/create-app",
+  "version": "0.6.3",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.6.2';
+const ASKABLE_VERSION = '0.6.3';
 const COPILOTKIT_VERSION = '1.56.2';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -56,7 +56,7 @@ export async function runCli(args) {
   const [projectArg] = args;
 
   if (!projectArg || projectArg === '--help' || projectArg === '-h') {
-    console.log(`create-askable-app\n\nUsage:\n  npx create-askable-app my-app\n`);
+    console.log(`create-askable-app\n\nUsage:\n  npm create @askable-ui/app my-app\n`);
     return;
   }
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.2"
+    "@askable-ui/core": "^0.6.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.2"
+    "@askable-ui/core": "^0.6.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.2"
+    "@askable-ui/core": "^0.6.3"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.2"
+    "@askable-ui/core": "^0.6.3"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.6.2`
-- Versioned current docs URL: `/docs/v0.6.2/`
+- Latest stable: `v0.6.3`
+- Versioned current docs URL: `/docs/v0.6.3/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.6.2/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.6.3/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.6.2**.
+> Current npm release: **v0.6.3**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 
@@ -11,7 +11,7 @@
 If you want a runnable Askable + CopilotKit example instead of wiring everything by hand, start here:
 
 ```bash
-npx create-askable-app my-app
+npm create @askable-ui/app my-app
 cd my-app
 npm install
 npm run dev

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,6 +1,6 @@
-# What’s New in v0.6.2
+# What’s New in v0.6.3
 
-askable-ui v0.6.2 rolls up the most recent improvements across the core library, React bindings, and docs.
+askable-ui v0.6.3 rolls up the most recent improvements across the core library, React bindings, and docs.
 
 ## Highlights
 
@@ -81,7 +81,7 @@ If you are integrating Askable into an AI copilot, start here:
 
 ## Version note
 
-The current published docs track **v0.6.2** at both:
+The current published docs track **v0.6.3** at both:
 
 - `/docs/`
-- `/docs/v0.6.2/`
+- `/docs/v0.6.3/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string — drop it into OpenAI, Anthropic, Vercel AI SDK, CopilotKit, or any LLM pipeline. No vendor lock-in.
 ---
 
-> Current npm release: **v0.6.2**.
+> Current npm release: **v0.6.3**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,7 +59,7 @@ features:
   </video>
 </div>
 
-## Latest in v0.6.2
+## Latest in v0.6.3
 
 - `ctx.subscribe(callback, options?)` for debounced streaming context updates in `@askable-ui/core`
 - per-component React activation overrides with `events={['hover']}`, `events={['click']}`, or `events="manual"`
@@ -67,7 +67,7 @@ features:
 
 Start here:
 
-- [What’s New in v0.6.2](/guide/whats-new)
+- [What’s New in v0.6.3](/guide/whats-new)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)
 

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.6.2",
-    "slug": "v0.6.2"
+    "label": "v0.6.3",
+    "slug": "v0.6.3"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.6.2`) is built on every deploy and published to both:
+The current release (`v0.6.3`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.6.2/` (version-specific URL)
+- `/docs/v0.6.3/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- renames the starter package to @askable-ui/create-app under the askable-ui npm scope
- documents the scoped starter command as npm create @askable-ui/app my-app
- bumps packages and docs to 0.6.3 so the scoped package release is consistent
- makes release rerun detection use npm pack --dry-run, which works for newly published scoped packages where npm view can lag

## NPM state
- unpublished the unscoped create-askable-app@0.6.2 package
- published @askable-ui/create-app@0.6.3
- verified npm create @askable-ui/app -- --help runs successfully

## Validation
- npm ci
- npm run build
- npm test
- npm audit --json
- npm publish --dry-run --access public from packages/create-askable-app
