### PR TITLE
feat(context): add web context MCP foundation

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -103,9 +103,11 @@ jobs:
             (cd "$package_dir" && npm publish --access public --provenance --tag "$DIST_TAG")
           }
 
+          publish_package packages/context
           publish_package packages/core
           publish_package packages/react
           publish_package packages/vue
           publish_package packages/svelte
           publish_package packages/react-native
+          publish_package packages/mcp
           publish_package packages/create-askable-app

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it
 - **"Ask AI" button** — `ctx.select(element)` pins focus to any element programmatically
 - **Conversation history** — `ctx.toHistoryContext(n)` for multi-turn context
 - **Viewport awareness** — `ctx.getVisibleElements()` / `ctx.toViewportContext()` for on-screen context
+- **Structured web context packets** — `ctx.toContextPacket()` for agent/MCP-ready page context
 - **Redaction hooks** — strip sensitive fields before data reaches serialization
 - **Inspector panel** — `<AskableInspector />` or `useAskable({ inspector: true })` for a live dev overlay
 - **Agent templates** — reusable `AGENTS.md` guidance and copy-paste prompts for coding-agent-driven adoption
@@ -156,10 +157,12 @@ askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it
 | Package | Version | Use when |
 |---|---|---|
 | [`@askable-ui/core`](https://www.npmjs.com/package/@askable-ui/core) | [![npm](https://img.shields.io/npm/v/@askable-ui/core?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/core) | Vanilla JS, custom framework, or as a peer dep |
+| [`@askable-ui/context`](https://www.npmjs.com/package/@askable-ui/context) | npm package | Shared web context packet types, schema, and validators |
 | [`@askable-ui/react`](https://www.npmjs.com/package/@askable-ui/react) | [![npm](https://img.shields.io/npm/v/@askable-ui/react?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/react) | React 18+ |
 | [`@askable-ui/react-native`](https://www.npmjs.com/package/@askable-ui/react-native) | [![npm](https://img.shields.io/npm/v/@askable-ui/react-native?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/react-native) | React Native (initial press-driven adapter) |
 | [`@askable-ui/vue`](https://www.npmjs.com/package/@askable-ui/vue) | [![npm](https://img.shields.io/npm/v/@askable-ui/vue?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/vue) | Vue 3 |
 | [`@askable-ui/svelte`](https://www.npmjs.com/package/@askable-ui/svelte) | [![npm](https://img.shields.io/npm/v/@askable-ui/svelte?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/svelte) | Svelte 4 & 5 |
+| [`@askable-ui/mcp`](https://www.npmjs.com/package/@askable-ui/mcp) | npm package | MCP bridge for exposing web context packets to agents |
 | [`@askable-ui/create-app`](https://www.npmjs.com/package/@askable-ui/create-app) | npm package | React + Vite + CopilotKit starter scaffold |
 
 <details>

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.6.3",
+    "@askable-ui/react": "^0.7.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.3",
-    "@askable-ui/react-native": "^0.6.3",
+    "@askable-ui/core": "^0.7.0",
+    "@askable-ui/react-native": "^0.7.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "workspaces": [
         "packages/*"
       ],
@@ -82,12 +82,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@askable-ui/context": {
+      "resolved": "packages/context",
+      "link": true
+    },
     "node_modules/@askable-ui/core": {
       "resolved": "packages/core",
       "link": true
     },
     "node_modules/@askable-ui/create-app": {
       "resolved": "packages/create-askable-app",
+      "link": true
+    },
+    "node_modules/@askable-ui/mcp": {
+      "resolved": "packages/mcp",
       "link": true
     },
     "node_modules/@askable-ui/react": {
@@ -824,6 +832,18 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -890,6 +910,46 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1649,6 +1709,19 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1660,6 +1733,39 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1732,6 +1838,30 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
@@ -1740,6 +1870,44 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -1803,6 +1971,28 @@
         "proto-list": "~1.2.1"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1810,11 +2000,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1853,6 +2077,23 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -1868,6 +2109,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -1904,6 +2154,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1930,12 +2194,27 @@
         "node": ">=14"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -1950,12 +2229,42 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -1999,6 +2308,12 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -2034,6 +2349,36 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2043,6 +2388,89 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2062,6 +2490,27 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2079,6 +2528,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2092,6 +2559,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -2116,6 +2629,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2129,6 +2687,42 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2139,12 +2733,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -2163,6 +2781,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -2177,7 +2801,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -2194,6 +2817,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-beautify": {
@@ -2328,6 +2960,18 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2637,6 +3281,61 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -2673,6 +3372,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -2690,6 +3395,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/nopt": {
@@ -2712,10 +3426,21 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -2728,6 +3453,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
@@ -2749,11 +3495,19 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2774,6 +3528,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -2801,6 +3565,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -2901,6 +3674,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2909,6 +3695,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -2985,7 +3810,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3026,6 +3850,28 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -3062,11 +3908,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3079,10 +3975,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3121,6 +4088,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -3348,6 +4324,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -3382,6 +4367,37 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
@@ -3404,6 +4420,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vitefu": {
@@ -4010,7 +5044,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4140,6 +5173,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -4164,6 +5203,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "packages/angular": {
       "name": "@askable-ui/angular",
       "version": "0.2.0",
@@ -4183,10 +5240,22 @@
         "@angular/core": ">=16.0.0"
       }
     },
+    "packages/context": {
+      "name": "@askable-ui/context",
+      "version": "0.7.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.2"
+      }
+    },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
+      "dependencies": {
+        "@askable-ui/context": "^0.7.0"
+      },
       "devDependencies": {
         "jsdom": "^29.0.1",
         "typescript": "^6.0.2",
@@ -4195,18 +5264,32 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
       }
     },
-    "packages/react": {
-      "name": "@askable-ui/react",
-      "version": "0.6.3",
+    "packages/mcp": {
+      "name": "@askable-ui/mcp",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.3"
+        "@askable-ui/context": "^0.7.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.2"
+      }
+    },
+    "packages/react": {
+      "name": "@askable-ui/react",
+      "version": "0.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "@askable-ui/core": "^0.7.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4226,10 +5309,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.3"
+        "@askable-ui/core": "^0.7.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -4344,10 +5427,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.3"
+        "@askable-ui/core": "^0.7.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -4463,10 +5546,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.3"
+        "@askable-ui/core": "^0.7.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -1,0 +1,20 @@
+# @askable-ui/context
+
+Typed packet format and schema for sending web context to AI agents.
+
+This package is intentionally small: it defines the versioned packet shape,
+exports a JSON Schema, and includes helpers for constructing and identifying
+packets. Capture runtimes such as `@askable-ui/core`, browser extensions, and
+MCP bridges can all emit the same packet format.
+
+```ts
+import { createWebContextPacket } from '@askable-ui/context';
+
+const packet = createWebContextPacket({
+  capture: { mode: 'element-focus', gesture: 'click' },
+  target: {
+    text: 'Revenue',
+    metadata: { metric: 'revenue', value: '$2.3M' },
+  },
+});
+```

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@askable-ui/core",
+  "name": "@askable-ui/context",
   "version": "0.7.0",
-  "description": "Framework-agnostic context tracker for LLM-aware UIs",
+  "description": "Open web context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -17,30 +17,25 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
-    "directory": "packages/core"
+    "url": "git+https://github.com/askable-ui/askable.git",
+    "directory": "packages/context"
   },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "vitest run",
-    "bench": "node bench/perf.mjs",
-    "bench:ci": "node bench/perf.mjs --budget"
+    "test": "vitest run --passWithNoTests"
   },
   "keywords": [
-    "llm",
+    "ai",
     "context",
-    "ui",
-    "accessibility",
-    "focus"
+    "web",
+    "mcp",
+    "selection",
+    "viewport"
   ],
   "homepage": "https://askable-ui.com",
   "license": "MIT",
-  "dependencies": {
-    "@askable-ui/context": "^0.7.0"
-  },
   "devDependencies": {
-    "jsdom": "^29.0.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"
   }

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -1,0 +1,285 @@
+export const WEB_CONTEXT_PROTOCOL = 'askable.web-context';
+export const WEB_CONTEXT_VERSION = '0.1';
+
+export type WebContextJson =
+  | string
+  | number
+  | boolean
+  | null
+  | WebContextJson[]
+  | { [key: string]: WebContextJson };
+
+export type WebContextRecord = Record<string, unknown>;
+
+export type WebContextCaptureMode =
+  | 'text-selection'
+  | 'element-focus'
+  | 'viewport'
+  | 'full-page'
+  | 'region'
+  | 'lasso'
+  | 'circle'
+  | 'semantic'
+  | 'custom';
+
+export type WebContextGesture =
+  | 'click'
+  | 'hover'
+  | 'focus'
+  | 'keyboard'
+  | 'drag'
+  | 'circle'
+  | 'lasso'
+  | 'programmatic'
+  | 'custom';
+
+export type WebContextProvenanceMethod =
+  | 'app'
+  | 'dom'
+  | 'extension'
+  | 'mcp'
+  | 'manual';
+
+export interface WebContextSource {
+  url?: string;
+  title?: string;
+  app?: string;
+  route?: string;
+  timestamp: string;
+}
+
+export interface WebContextCapture {
+  mode: WebContextCaptureMode;
+  gesture?: WebContextGesture;
+  intent?: string;
+}
+
+export interface WebContextRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface WebContextScreenshot {
+  mimeType: 'image/png' | 'image/jpeg' | 'image/webp';
+  data?: string;
+  url?: string;
+}
+
+export interface WebContextTarget {
+  text?: string;
+  role?: string;
+  label?: string;
+  selector?: string;
+  bounds?: WebContextRect;
+  metadata?: WebContextRecord | string;
+  screenshot?: WebContextScreenshot;
+}
+
+export interface WebContextSurrounding {
+  ancestors?: WebContextTarget[];
+  nearby?: WebContextTarget[];
+  visible?: WebContextTarget[];
+  history?: WebContextTarget[];
+}
+
+export interface WebContextPrivacy {
+  redacted: boolean;
+  consent: 'explicit' | 'implicit' | 'none';
+  omitted?: string[];
+}
+
+export interface WebContextProvenance {
+  producer: string;
+  method: WebContextProvenanceMethod;
+}
+
+export interface WebContextPacket {
+  protocol: typeof WEB_CONTEXT_PROTOCOL;
+  version: typeof WEB_CONTEXT_VERSION;
+  source: WebContextSource;
+  capture: WebContextCapture;
+  target?: WebContextTarget;
+  surrounding?: WebContextSurrounding;
+  privacy: WebContextPrivacy;
+  provenance: WebContextProvenance;
+}
+
+export interface CreateWebContextPacketOptions {
+  source?: Partial<WebContextSource>;
+  capture: WebContextCapture;
+  target?: WebContextTarget;
+  surrounding?: WebContextSurrounding;
+  privacy?: Partial<WebContextPrivacy>;
+  provenance?: Partial<WebContextProvenance>;
+}
+
+export const webContextPacketSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://askable-ui.com/schemas/web-context-packet-0.1.schema.json',
+  title: 'Askable Web Context Packet',
+  type: 'object',
+  required: ['protocol', 'version', 'source', 'capture', 'privacy', 'provenance'],
+  additionalProperties: false,
+  properties: {
+    protocol: { const: WEB_CONTEXT_PROTOCOL },
+    version: { const: WEB_CONTEXT_VERSION },
+    source: {
+      type: 'object',
+      required: ['timestamp'],
+      additionalProperties: false,
+      properties: {
+        url: { type: 'string' },
+        title: { type: 'string' },
+        app: { type: 'string' },
+        route: { type: 'string' },
+        timestamp: { type: 'string' },
+      },
+    },
+    capture: {
+      type: 'object',
+      required: ['mode'],
+      additionalProperties: false,
+      properties: {
+        mode: {
+          enum: [
+            'text-selection',
+            'element-focus',
+            'viewport',
+            'full-page',
+            'region',
+            'lasso',
+            'circle',
+            'semantic',
+            'custom',
+          ],
+        },
+        gesture: {
+          enum: [
+            'click',
+            'hover',
+            'focus',
+            'keyboard',
+            'drag',
+            'circle',
+            'lasso',
+            'programmatic',
+            'custom',
+          ],
+        },
+        intent: { type: 'string' },
+      },
+    },
+    target: { $ref: '#/$defs/target' },
+    surrounding: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        ancestors: { type: 'array', items: { $ref: '#/$defs/target' } },
+        nearby: { type: 'array', items: { $ref: '#/$defs/target' } },
+        visible: { type: 'array', items: { $ref: '#/$defs/target' } },
+        history: { type: 'array', items: { $ref: '#/$defs/target' } },
+      },
+    },
+    privacy: {
+      type: 'object',
+      required: ['redacted', 'consent'],
+      additionalProperties: false,
+      properties: {
+        redacted: { type: 'boolean' },
+        consent: { enum: ['explicit', 'implicit', 'none'] },
+        omitted: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    provenance: {
+      type: 'object',
+      required: ['producer', 'method'],
+      additionalProperties: false,
+      properties: {
+        producer: { type: 'string' },
+        method: { enum: ['app', 'dom', 'extension', 'mcp', 'manual'] },
+      },
+    },
+  },
+  $defs: {
+    rect: {
+      type: 'object',
+      required: ['x', 'y', 'width', 'height'],
+      additionalProperties: false,
+      properties: {
+        x: { type: 'number' },
+        y: { type: 'number' },
+        width: { type: 'number' },
+        height: { type: 'number' },
+      },
+    },
+    screenshot: {
+      type: 'object',
+      required: ['mimeType'],
+      additionalProperties: false,
+      properties: {
+        mimeType: { enum: ['image/png', 'image/jpeg', 'image/webp'] },
+        data: { type: 'string' },
+        url: { type: 'string' },
+      },
+    },
+    target: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        text: { type: 'string' },
+        role: { type: 'string' },
+        label: { type: 'string' },
+        selector: { type: 'string' },
+        bounds: { $ref: '#/$defs/rect' },
+        metadata: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'object', additionalProperties: true },
+          ],
+        },
+        screenshot: { $ref: '#/$defs/screenshot' },
+      },
+    },
+  },
+} as const;
+
+export function createWebContextPacket(options: CreateWebContextPacketOptions): WebContextPacket {
+  return {
+    protocol: WEB_CONTEXT_PROTOCOL,
+    version: WEB_CONTEXT_VERSION,
+    source: {
+      timestamp: new Date().toISOString(),
+      ...options.source,
+    },
+    capture: options.capture,
+    ...(options.target ? { target: options.target } : {}),
+    ...(options.surrounding ? { surrounding: options.surrounding } : {}),
+    privacy: {
+      redacted: false,
+      consent: 'implicit',
+      ...options.privacy,
+    },
+    provenance: {
+      producer: 'askable-ui',
+      method: 'app',
+      ...options.provenance,
+    },
+  };
+}
+
+export function isWebContextPacket(value: unknown): value is WebContextPacket {
+  if (!isRecord(value)) return false;
+  if (value.protocol !== WEB_CONTEXT_PROTOCOL || value.version !== WEB_CONTEXT_VERSION) return false;
+  if (!isRecord(value.source) || typeof value.source.timestamp !== 'string') return false;
+  if (!isRecord(value.capture) || typeof value.capture.mode !== 'string') return false;
+  if (!isRecord(value.privacy) || typeof value.privacy.redacted !== 'boolean') return false;
+  if (!['explicit', 'implicit', 'none'].includes(String(value.privacy.consent))) return false;
+  if (!isRecord(value.provenance) || typeof value.provenance.producer !== 'string') return false;
+  return typeof value.provenance.method === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "directory": "packages/core"
   },
   "scripts": {
+    "prebuild": "npm run build -w @askable-ui/context",
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -244,6 +244,89 @@ describe('createAskableContext', () => {
     cleanup(el);
   });
 
+  it('toContextPacket() returns a structured web context packet for focused UI', () => {
+    const el = makeEl({ metric: 'revenue', value: '$2.3M' }, 'Revenue Chart');
+    el.setAttribute('aria-label', 'Revenue card');
+    const ctx = createAskableContext();
+    ctx.observe(document);
+
+    el.click();
+
+    expect(ctx.toContextPacket({ source: { app: 'analytics' }, history: 1 })).toMatchObject({
+      protocol: 'askable.web-context',
+      version: '0.1',
+      source: {
+        app: 'analytics',
+        timestamp: expect.any(String),
+      },
+      capture: {
+        mode: 'element-focus',
+        gesture: 'focus',
+      },
+      target: {
+        text: 'Revenue Chart',
+        label: 'Revenue card',
+        metadata: { metric: 'revenue', value: '$2.3M' },
+        selector: expect.any(String),
+        bounds: {
+          x: expect.any(Number),
+          y: expect.any(Number),
+          width: expect.any(Number),
+          height: expect.any(Number),
+        },
+      },
+      surrounding: {
+        history: [
+          expect.objectContaining({
+            text: 'Revenue Chart',
+            metadata: { metric: 'revenue', value: '$2.3M' },
+          }),
+        ],
+      },
+      privacy: {
+        redacted: false,
+        consent: 'implicit',
+      },
+      provenance: {
+        producer: '@askable-ui/core',
+        method: 'app',
+      },
+    });
+
+    ctx.destroy();
+    cleanup(el);
+  });
+
+  it('toContextPacket() includes privacy and viewport context when configured', () => {
+    const originalIntersectionObserver = globalThis.IntersectionObserver;
+    globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+    const first = makeEl({ widget: 'table', secret: 'remove' }, 'Table Secret');
+    const ctx = createAskableContext({
+      viewport: true,
+      sanitizeMeta: ({ secret: _secret, ...safe }) => safe,
+      sanitizeText: (text) => text.replace('Secret', '[redacted]'),
+    });
+    ctx.observe(document);
+
+    const observer = MockIntersectionObserver.instances[0];
+    observer.trigger([{ target: first, isIntersecting: true }]);
+    first.click();
+
+    const packet = ctx.toContextPacket({ includeViewport: true });
+    expect(packet.privacy.redacted).toBe(true);
+    expect(packet.target?.metadata).toEqual({ widget: 'table' });
+    expect(packet.target?.text).toBe('Table [redacted]');
+    expect(packet.surrounding?.visible?.[0]).toMatchObject({
+      metadata: { widget: 'table' },
+      text: 'Table [redacted]',
+    });
+
+    ctx.destroy();
+    cleanup(first);
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+  });
+
   it('serializeFocus() respects includeText and maxTextLength', () => {
     const el = makeEl({ metric: 'churn' }, 'ABCDEFGHIJ');
     const ctx = createAskableContext();

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,9 +1,11 @@
+import { createWebContextPacket } from '@askable-ui/context';
 import { Emitter } from './emitter.js';
 import { buildFocus, Observer } from './observer.js';
 import type {
   AskableContext,
   AskableContextOptions,
   AskableContextOutputOptions,
+  AskableContextPacketOptions,
   AskableContextSubscriber,
   AskableEventHandler,
   AskableEventName,
@@ -17,6 +19,14 @@ import type {
   AskableSerializedFocusSegment,
   AskableSubscribeOptions,
 } from './types.js';
+import type {
+  WebContextCaptureMode,
+  WebContextGesture,
+  WebContextPacket,
+  WebContextRect,
+  WebContextSource,
+  WebContextTarget,
+} from '@askable-ui/context';
 
 const PRESETS: Record<AskablePromptPreset, AskablePromptContextOptions> = {
   compact: { includeText: false, format: 'natural' },
@@ -318,6 +328,46 @@ export class AskableContextImpl implements AskableContext {
     return this.applyTokenBudget(output, resolved.maxTokens);
   }
 
+  toContextPacket(options?: AskableContextPacketOptions): WebContextPacket {
+    const resolved = this.resolveOptions(options);
+    const currentFocus = this.matchesScope(this.currentFocus, resolved.scope) ? this.currentFocus : null;
+    const historyCount = options?.history ?? 0;
+    const history = historyCount > 0
+      ? this.filterByScope(this.getHistory(historyCount), resolved.scope).map((focus) => this.focusToTarget(focus, resolved))
+      : [];
+    const visible = options?.includeViewport
+      ? this.filterByScope(this.getVisibleElements(), resolved.scope).map((focus) => this.focusToTarget(focus, resolved))
+      : [];
+    const ancestors = currentFocus ? this.focusAncestorsToTargets(currentFocus, resolved) : [];
+
+    return createWebContextPacket({
+      source: this.resolvePacketSource(options?.source),
+      capture: {
+        mode: options?.mode ?? this.resolveCaptureMode(currentFocus),
+        gesture: options?.gesture ?? this.resolveGesture(currentFocus),
+        ...(options?.intent ? { intent: options.intent } : {}),
+      },
+      ...(currentFocus ? { target: this.focusToTarget(currentFocus, resolved) } : {}),
+      ...((ancestors.length > 0 || history.length > 0 || visible.length > 0) ? {
+        surrounding: {
+          ...(ancestors.length > 0 ? { ancestors } : {}),
+          ...(visible.length > 0 ? { visible } : {}),
+          ...(history.length > 0 ? { history } : {}),
+        },
+      } : {}),
+      privacy: {
+        redacted: Boolean(this.sanitizeMetaFn || this.sanitizeTextFn),
+        consent: 'implicit',
+        ...options?.privacy,
+      },
+      provenance: {
+        producer: '@askable-ui/core',
+        method: currentFocus?.source === 'push' ? 'manual' : 'app',
+        ...options?.provenance,
+      },
+    });
+  }
+
   subscribe(callback: AskableContextSubscriber, options?: AskableSubscribeOptions): () => void {
     const { debounce = 0, ...contextOptions } = options ?? {};
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -398,6 +448,100 @@ export class AskableContextImpl implements AskableContext {
     });
 
     return Object.fromEntries(ordered);
+  }
+
+  private focusToTarget(focus: AskableFocus, options?: AskablePromptContextOptions): WebContextTarget {
+    const serialized = this.serializeFocusFrom(focus, options);
+    const element = focus.element;
+    const target: WebContextTarget = {
+      metadata: serialized.meta,
+      ...(serialized.text ? { text: serialized.text } : {}),
+      ...(focus.scope ? { role: focus.scope } : {}),
+    };
+
+    if (element) {
+      const label = element.getAttribute('aria-label') ?? element.getAttribute('title') ?? undefined;
+      const role = element.getAttribute('role') ?? target.role;
+      const selector = this.buildElementSelector(element);
+      const bounds = this.getElementBounds(element);
+      if (label) target.label = label;
+      if (role) target.role = role;
+      if (selector) target.selector = selector;
+      if (bounds) target.bounds = bounds;
+    }
+
+    return target;
+  }
+
+  private focusAncestorsToTargets(focus: AskableFocus, options?: AskablePromptContextOptions): WebContextTarget[] {
+    const resolved = this.resolveOptions(options);
+    return this.limitAncestorSegments(
+      this.filterAncestorSegments(focus.ancestors, resolved.scope),
+      resolved.hierarchyDepth,
+    ).map((segment) => ({
+      metadata: typeof segment.meta === 'string' ? segment.meta : this.normalizeMeta(segment.meta, resolved),
+      ...(segment.scope ? { role: segment.scope } : {}),
+      ...(resolved.includeText ?? true ? { text: this.normalizeText(segment.text, resolved.maxTextLength) } : {}),
+    }));
+  }
+
+  private resolveCaptureMode(focus: AskableFocus | null): WebContextCaptureMode {
+    if (!focus) return 'full-page';
+    if (focus.source === 'push') return 'semantic';
+    return 'element-focus';
+  }
+
+  private resolveGesture(focus: AskableFocus | null): WebContextGesture | undefined {
+    if (!focus) return undefined;
+    if (focus.source === 'select' || focus.source === 'push') return 'programmatic';
+    return 'focus';
+  }
+
+  private resolvePacketSource(source?: Partial<WebContextSource>): Partial<WebContextSource> {
+    const inferred: Partial<WebContextSource> = {};
+    if (typeof document !== 'undefined') {
+      inferred.title = document.title || undefined;
+    }
+    if (typeof window !== 'undefined') {
+      inferred.url = window.location?.href;
+      inferred.route = window.location?.pathname;
+    }
+    return { ...inferred, ...source };
+  }
+
+  private getElementBounds(element: HTMLElement): WebContextRect | undefined {
+    if (typeof element.getBoundingClientRect !== 'function') return undefined;
+    const rect = element.getBoundingClientRect();
+    return {
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  private buildElementSelector(element: HTMLElement): string | undefined {
+    if (element.id) return `#${this.escapeSelectorIdent(element.id)}`;
+    const askableId = element.getAttribute('data-askable-id')?.trim();
+    if (askableId) return `[data-askable-id="${this.escapeAttributeValue(askableId)}"]`;
+    if (element.hasAttribute('data-askable')) {
+      const sameTagAskables = Array.from(element.ownerDocument.querySelectorAll(element.tagName.toLowerCase()))
+        .filter((candidate) => candidate.hasAttribute('data-askable'));
+      const index = sameTagAskables.indexOf(element);
+      if (index >= 0) {
+        return `${element.tagName.toLowerCase()}[data-askable]:nth-of-type(${index + 1})`;
+      }
+    }
+    return undefined;
+  }
+
+  private escapeSelectorIdent(value: string): string {
+    const css = globalThis.CSS as { escape?: (value: string) => string } | undefined;
+    return css?.escape ? css.escape(value) : value.replace(/["'\\#.:,[\]>~+*()]/g, '\\$&');
+  }
+
+  private escapeAttributeValue(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   }
 
   private normalizeText(text: string, maxTextLength?: number): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,24 @@
 export { createAskableInspector } from './inspector.js';
 export { a11yTextExtractor } from './a11y.js';
+export {
+  WEB_CONTEXT_PROTOCOL,
+  WEB_CONTEXT_VERSION,
+  createWebContextPacket,
+  isWebContextPacket,
+  webContextPacketSchema,
+} from '@askable-ui/context';
+export type {
+  CreateWebContextPacketOptions,
+  WebContextCapture,
+  WebContextCaptureMode,
+  WebContextGesture,
+  WebContextPacket,
+  WebContextPrivacy,
+  WebContextProvenance,
+  WebContextSource,
+  WebContextSurrounding,
+  WebContextTarget,
+} from '@askable-ui/context';
 export type {
   AskableInspectorHandle,
   AskableInspectorOptions,
@@ -9,6 +28,7 @@ export type {
   AskableContext,
   AskableContextOptions,
   AskableContextOutputOptions,
+  AskableContextPacketOptions,
   AskableContextSubscriber,
   AskableSubscribeOptions,
   AskableEvent,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,12 @@
+import type {
+  WebContextCaptureMode,
+  WebContextGesture,
+  WebContextPacket,
+  WebContextPrivacy,
+  WebContextProvenance,
+  WebContextSource,
+} from '@askable-ui/context';
+
 /** How focus was initiated */
 export type AskableFocusSource = 'dom' | 'select' | 'push';
 
@@ -219,6 +228,25 @@ export interface AskableContextOutputOptions extends AskablePromptContextOptions
   historyLabel?: string;
 }
 
+export interface AskableContextPacketOptions extends AskablePromptContextOptions {
+  /** Override source metadata such as app or route. URL/title/timestamp are inferred in the browser. */
+  source?: Partial<WebContextSource>;
+  /** Override the capture mode. Defaults to element-focus when focused, otherwise full-page. */
+  mode?: WebContextCaptureMode;
+  /** User gesture that produced the packet. Inferred from focus source when possible. */
+  gesture?: WebContextGesture;
+  /** Optional user intent attached to this capture. */
+  intent?: string;
+  /** Include visible annotated elements in the packet. Requires context viewport mode. */
+  includeViewport?: boolean;
+  /** Number of history entries to include. Defaults to 0. */
+  history?: number;
+  /** Privacy metadata for downstream agents and MCP clients. */
+  privacy?: Partial<WebContextPrivacy>;
+  /** Provenance metadata for downstream agents and MCP clients. */
+  provenance?: Partial<WebContextProvenance>;
+}
+
 export interface AskableContext {
   /** Observe a DOM subtree for [data-askable] elements */
   observe(root: HTMLElement | Document, options?: AskableObserveOptions): void;
@@ -250,6 +278,8 @@ export interface AskableContext {
   toViewportContext(options?: AskablePromptContextOptions): string;
   /** Combined current focus + history in a single prompt-ready string */
   toContext(options?: AskableContextOutputOptions): string;
+  /** Serialize current UI state to a structured web context packet for agents and MCP bridges. */
+  toContextPacket(options?: AskableContextPacketOptions): WebContextPacket;
   /** Subscribe to serialized context updates for streaming/chat integrations. Returns an unsubscribe function. */
   subscribe(callback: AskableContextSubscriber, options?: AskableSubscribeOptions): () => void;
   /** Clean up all listeners and observers */

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.6.3';
+const ASKABLE_VERSION = '0.7.0';
 const COPILOTKIT_VERSION = '1.56.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,20 @@
+# @askable-ui/mcp
+
+MCP bridge for exposing structured web context packets to AI agents.
+
+Host applications provide a context provider. The package registers MCP tools
+that return the current packet, the packet schema, and a prompt-ready text
+rendering.
+
+```ts
+import { createAskableMcpServer } from '@askable-ui/mcp';
+
+const server = createAskableMcpServer({
+  provider: {
+    getContext: () => ctx.toContextPacket({ history: 3, includeViewport: true }),
+  },
+});
+```
+
+Transports are intentionally left to the host app so the same server factory can
+be used with stdio, Streamable HTTP, or an embedded web runtime.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -21,6 +21,7 @@
     "directory": "packages/mcp"
   },
   "scripts": {
+    "prebuild": "npm run build -w @askable-ui/context",
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run --passWithNoTests"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@askable-ui/core",
+  "name": "@askable-ui/mcp",
   "version": "0.7.0",
-  "description": "Framework-agnostic context tracker for LLM-aware UIs",
+  "description": "MCP bridge for exposing askable web context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -17,30 +17,29 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
-    "directory": "packages/core"
+    "url": "git+https://github.com/askable-ui/askable.git",
+    "directory": "packages/mcp"
   },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "vitest run",
-    "bench": "node bench/perf.mjs",
-    "bench:ci": "node bench/perf.mjs --budget"
+    "test": "vitest run --passWithNoTests"
   },
   "keywords": [
-    "llm",
-    "context",
-    "ui",
-    "accessibility",
-    "focus"
+    "askable",
+    "mcp",
+    "web-context",
+    "ai",
+    "agent"
   ],
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.7.0"
+    "@askable-ui/context": "^0.7.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "jsdom": "^29.0.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,133 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { webContextPacketSchema } from '@askable-ui/context';
+import type { WebContextPacket } from '@askable-ui/context';
+
+export interface AskableMcpContextOptions {
+  history?: number;
+  includeViewport?: boolean;
+  intent?: string;
+}
+
+export interface AskableMcpContextProvider {
+  getContext(options?: AskableMcpContextOptions): WebContextPacket | Promise<WebContextPacket>;
+  formatContextForPrompt?(packet: WebContextPacket): string | Promise<string>;
+}
+
+export interface AskableMcpServerOptions {
+  name?: string;
+  version?: string;
+  provider: AskableMcpContextProvider;
+}
+
+const contextOptionsShape = {
+  history: z.number().int().min(0).max(50).optional(),
+  includeViewport: z.boolean().optional(),
+  intent: z.string().optional(),
+};
+
+export function createAskableMcpServer(options: AskableMcpServerOptions): McpServer {
+  const server = new McpServer({
+    name: options.name ?? 'askable-web-context',
+    version: options.version ?? '0.1.0',
+  });
+
+  server.registerResource(
+    'web-context-schema',
+    'web-context://schema',
+    {
+      title: 'Web context packet schema',
+      description: 'JSON Schema for askable web context packets.',
+      mimeType: 'application/schema+json',
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: 'application/schema+json',
+          text: JSON.stringify(webContextPacketSchema, null, 2),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    'get_current_context',
+    {
+      title: 'Get current web context',
+      description: 'Return the current selected, focused, or visible web context packet.',
+      inputSchema: contextOptionsShape,
+    },
+    async (args) => {
+      const packet = await options.provider.getContext(args);
+      return {
+        content: [
+          {
+            type: 'text',
+            mimeType: 'application/json',
+            text: JSON.stringify(packet, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'get_context_schema',
+    {
+      title: 'Get web context schema',
+      description: 'Return the JSON Schema for packets emitted by askable web context runtimes.',
+      inputSchema: {},
+    },
+    async () => ({
+      content: [
+        {
+          type: 'text',
+          mimeType: 'application/schema+json',
+          text: JSON.stringify(webContextPacketSchema, null, 2),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    'format_context_for_prompt',
+    {
+      title: 'Format current context for a prompt',
+      description: 'Return a prompt-ready text rendering of the current web context packet.',
+      inputSchema: contextOptionsShape,
+    },
+    async (args) => {
+      const packet = await options.provider.getContext(args);
+      const text = options.provider.formatContextForPrompt
+        ? await options.provider.formatContextForPrompt(packet)
+        : defaultPromptFormatter(packet);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text,
+          },
+        ],
+      };
+    },
+  );
+
+  return server;
+}
+
+export function defaultPromptFormatter(packet: WebContextPacket): string {
+  const parts = [
+    `Context mode: ${packet.capture.mode}`,
+    packet.capture.intent ? `User intent: ${packet.capture.intent}` : undefined,
+    packet.source.url ? `URL: ${packet.source.url}` : undefined,
+    packet.source.title ? `Title: ${packet.source.title}` : undefined,
+    packet.target?.text ? `Target text: ${packet.target.text}` : undefined,
+    packet.target?.metadata ? `Target metadata: ${JSON.stringify(packet.target.metadata)}` : undefined,
+    packet.surrounding?.visible?.length ? `Visible context: ${JSON.stringify(packet.surrounding.visible)}` : undefined,
+    packet.surrounding?.history?.length ? `Recent context: ${JSON.stringify(packet.surrounding.history)}` : undefined,
+  ];
+
+  return parts.filter((part): part is string => Boolean(part)).join('\n');
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.3"
+    "@askable-ui/core": "^0.7.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.3"
+    "@askable-ui/core": "^0.7.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.3"
+    "@askable-ui/core": "^0.7.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.6.3"
+    "@askable-ui/core": "^0.7.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
           text: 'Introduction',
           items: [
             { text: 'What is askable-ui?', link: '/guide/' },
-            { text: 'What’s New in v6.1.0', link: '/guide/whats-new' },
+            { text: 'What’s New in v0.7.0', link: '/guide/whats-new' },
             { text: 'Getting Started', link: '/guide/getting-started' },
             { text: 'How It Works', link: '/guide/how-it-works' },
           ],
@@ -72,6 +72,7 @@ export default defineConfig({
             { text: 'Focus & History', link: '/guide/focus-history' },
             { text: 'Ask AI Buttons (select())', link: '/guide/select' },
             { text: 'Prompt Serialization', link: '/guide/serialization' },
+            { text: 'Web Context Packets', link: '/guide/web-context' },
             { text: 'Migration Guides', link: '/guide/migrations' },
             { text: 'SSR Safety', link: '/guide/ssr' },
             { text: 'Browser Support', link: '/guide/browser-support' },
@@ -96,6 +97,8 @@ export default defineConfig({
           text: 'API Reference',
           items: [
             { text: '@askable-ui/core', link: '/api/core' },
+            { text: '@askable-ui/context', link: '/api/context' },
+            { text: '@askable-ui/mcp', link: '/api/mcp' },
             { text: '@askable-ui/react', link: '/api/react' },
             { text: '@askable-ui/react-native', link: '/api/react-native' },
             { text: '@askable-ui/vue', link: '/api/vue' },

--- a/site/docs/api/context.md
+++ b/site/docs/api/context.md
@@ -1,0 +1,65 @@
+# @askable-ui/context
+
+Shared packet types and schema for structured web context.
+
+```bash
+npm install @askable-ui/context
+```
+
+```ts
+import {
+  WEB_CONTEXT_PROTOCOL,
+  WEB_CONTEXT_VERSION,
+  createWebContextPacket,
+  isWebContextPacket,
+  webContextPacketSchema,
+} from '@askable-ui/context';
+```
+
+## `createWebContextPacket(options)`
+
+Creates a versioned packet with default source timestamp, privacy, and
+provenance fields.
+
+```ts
+const packet = createWebContextPacket({
+  capture: { mode: 'element-focus', gesture: 'click' },
+  target: {
+    text: 'Revenue',
+    metadata: { metric: 'revenue', value: '$2.3M' },
+  },
+});
+```
+
+## `isWebContextPacket(value)`
+
+Runtime guard for checking whether an unknown value matches the supported
+packet envelope.
+
+```ts
+if (isWebContextPacket(value)) {
+  console.log(value.capture.mode);
+}
+```
+
+## `webContextPacketSchema`
+
+JSON Schema for validating packets at MCP, HTTP, browser-extension, or storage
+boundaries.
+
+```ts
+JSON.stringify(webContextPacketSchema, null, 2);
+```
+
+## Packet fields
+
+| Field | Description |
+|---|---|
+| `protocol` | Stable protocol identifier, currently `askable.web-context` |
+| `version` | Packet version, currently `0.1` |
+| `source` | URL, title, app, route, and timestamp |
+| `capture` | Capture mode, gesture, and optional user intent |
+| `target` | Text, label, role, selector, bounds, metadata, and screenshot |
+| `surrounding` | Ancestors, nearby items, visible items, and history |
+| `privacy` | Redaction and consent metadata |
+| `provenance` | Producer and capture method |

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -333,6 +333,38 @@ ctx.toContext({ history: 3, currentLabel: 'Now', historyLabel: 'Before' });
 
 ---
 
+### `toContextPacket(options?)`
+
+Serialize the current UI state to a structured web context packet for agents,
+MCP bridges, browser extensions, or storage.
+
+```ts
+const packet = ctx.toContextPacket({
+  history: 3,
+  includeViewport: true,
+  source: { app: 'analytics-dashboard' },
+  privacy: { consent: 'explicit' },
+});
+```
+
+**Options (`AskableContextPacketOptions`):**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `source` | `Partial<WebContextSource>` | inferred from browser | Override source metadata like app or route |
+| `mode` | `WebContextCaptureMode` | inferred | Capture mode for the packet |
+| `gesture` | `WebContextGesture` | inferred | Gesture that produced the context |
+| `intent` | `string` | — | Optional user intent attached to the capture |
+| `includeViewport` | `boolean` | `false` | Include currently visible annotated elements |
+| `history` | `number` | `0` | Include recent focus history |
+| `privacy` | `Partial<WebContextPrivacy>` | inferred | Redaction and consent metadata |
+| `provenance` | `Partial<WebContextProvenance>` | inferred | Producer and capture method metadata |
+| _...all `AskablePromptContextOptions`_ | | | Passed through to focus/metadata normalization |
+
+**Returns:** `WebContextPacket`
+
+---
+
 ### `serializeFocus(options?)`
 
 Returns structured focus data as `AskableSerializedFocus | null`. Same options as `toPromptContext()`.

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -1,0 +1,40 @@
+# @askable-ui/mcp
+
+MCP bridge for exposing web context packets to agents.
+
+```bash
+npm install @askable-ui/mcp
+```
+
+```ts
+import { createAskableMcpServer } from '@askable-ui/mcp';
+
+const server = createAskableMcpServer({
+  provider: {
+    getContext: (options) => ctx.toContextPacket(options),
+  },
+});
+```
+
+## `createAskableMcpServer(options)`
+
+Creates an MCP server with tools/resources for reading structured web context.
+
+| Option | Type | Description |
+|---|---|---|
+| `provider.getContext` | `(options) => WebContextPacket \| Promise<WebContextPacket>` | Supplies the current packet |
+| `provider.formatContextForPrompt` | `(packet) => string \| Promise<string>` | Optional custom prompt formatter |
+| `name` | `string` | MCP server name |
+| `version` | `string` | MCP server version |
+
+## Registered MCP surface
+
+| Name | Kind | Description |
+|---|---|---|
+| `web-context://schema` | Resource | JSON Schema for packets |
+| `get_current_context` | Tool | Returns the current packet as JSON |
+| `get_context_schema` | Tool | Returns the packet JSON Schema |
+| `format_context_for_prompt` | Tool | Returns prompt-ready text |
+
+The package does not start a transport. Connect the returned server with the MCP
+transport that fits your runtime.

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.6.3`
-- Versioned current docs URL: `/docs/v0.6.3/`
+- Latest stable: `v0.7.0`
+- Versioned current docs URL: `/docs/v0.7.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.6.3/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.7.0/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.6.3**.
+> Current npm release: **v0.7.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/web-context.md
+++ b/site/docs/guide/web-context.md
@@ -1,0 +1,101 @@
+# Web Context Packets
+
+Prompt strings are useful for simple chat integrations. Web context packets are
+for agents, MCP bridges, browser extensions, and tools that need structured
+context instead of prose.
+
+```ts
+const packet = ctx.toContextPacket({
+  history: 3,
+  includeViewport: true,
+  source: { app: 'analytics-dashboard' },
+});
+```
+
+The packet describes:
+
+- where the context came from: URL, title, app, route, timestamp
+- how the context was captured: focused element, semantic push, viewport, region, lasso, circle, or custom capture
+- what the user is pointing at: text, role, label, selector, bounds, metadata, optional screenshots
+- surrounding context: ancestors, visible items, and recent interactions
+- privacy and provenance: redaction state, consent state, producer, and capture method
+
+## Why packets?
+
+`toPromptContext()` optimizes for copy-paste simplicity:
+
+```ts
+ctx.toPromptContext();
+// "User is focused on: — metric: revenue — value \"Revenue\""
+```
+
+`toContextPacket()` optimizes for interoperability:
+
+```json
+{
+  "protocol": "askable.web-context",
+  "version": "0.1",
+  "capture": { "mode": "element-focus", "gesture": "focus" },
+  "target": {
+    "text": "Revenue",
+    "metadata": { "metric": "revenue", "value": "$2.3M" }
+  },
+  "privacy": { "redacted": false, "consent": "implicit" },
+  "provenance": { "producer": "@askable-ui/core", "method": "app" }
+}
+```
+
+Use packets when the receiving system should validate, store, transform, or
+route context before sending it to a model.
+
+## MCP bridge
+
+`@askable-ui/mcp` exposes packets through MCP tools and resources. The host
+application provides a context provider:
+
+```ts
+import { createAskableMcpServer } from '@askable-ui/mcp';
+
+const server = createAskableMcpServer({
+  provider: {
+    getContext: (options) => ctx.toContextPacket(options),
+  },
+});
+```
+
+The server registers:
+
+| Name | Kind | Purpose |
+|---|---|---|
+| `web-context://schema` | Resource | JSON Schema for web context packets |
+| `get_current_context` | Tool | Returns the current structured packet |
+| `get_context_schema` | Tool | Returns the packet schema |
+| `format_context_for_prompt` | Tool | Returns a prompt-ready rendering |
+
+The MCP package does not choose a transport. Use the returned MCP server with
+stdio, Streamable HTTP, or an embedded runtime depending on where context is
+captured.
+
+## Privacy
+
+Packets reflect the same sanitizers as prompt serialization:
+
+```ts
+const ctx = createAskableContext({
+  sanitizeMeta: ({ ssn, ...safe }) => safe,
+  sanitizeText: (text) => text.replace(/\b\d{16}\b/g, '[card]'),
+});
+
+ctx.toContextPacket().privacy.redacted;
+// true
+```
+
+Set explicit consent/provenance metadata when context is captured from browser
+extensions, region selection, or user-triggered actions:
+
+```ts
+ctx.toContextPacket({
+  privacy: { consent: 'explicit' },
+  provenance: { producer: 'my-browser-extension', method: 'extension' },
+});
+```

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,87 +1,89 @@
-# What’s New in v0.6.3
+# What’s New in v0.7.0
 
-askable-ui v0.6.3 rolls up the most recent improvements across the core library, React bindings, and docs.
+askable-ui v0.7.0 starts the structured web context layer for agents, browser tools, and MCP bridges.
 
 ## Highlights
 
-### Streaming context subscriptions
+### Structured web context packets
 
-You can now subscribe to serialized Askable context updates directly from `@askable-ui/core`:
+`@askable-ui/core` now emits versioned web context packets:
 
 ```ts
-const unsubscribe = ctx.subscribe((context, focus) => {
-  streamTransport.send({ context, focus });
-}, {
-  history: 5,
-  debounce: 100,
+const packet = ctx.toContextPacket({
+  history: 3,
+  includeViewport: true,
+  source: { app: 'analytics-dashboard' },
 });
 ```
 
-This is especially useful for AI experiences that keep streaming while the user continues interacting with the UI.
+Packets preserve the same annotated metadata used by prompt serialization, but
+add source, capture, surrounding context, privacy, and provenance fields.
 
-Use it when you want to:
+Use packets when you want to:
 
-- keep Vercel AI SDK sessions aligned with live UI focus
-- update CopilotKit readable context during long-running agent responses
-- debounce rapid UI changes before forwarding them to your model/runtime
+- pass selected/focused UI context through MCP
+- store or validate context before forwarding it to a model
+- bridge app-authored context into browser extensions or agent runtimes
+- include viewport and history context without flattening everything to prose
 
 Related docs:
 
-- [AI SDK integration](/examples/ai-sdk)
-- [CopilotKit example](/examples/copilotkit)
+- [Web Context Packets](/guide/web-context)
 - [@askable-ui/core API](/api/core)
 
-### Per-component activation rules in React
+### New `@askable-ui/context` package
 
-React components can now override activation behavior per component with the `events` prop on `<Askable>`.
+The new context package provides the shared packet contract:
 
-```tsx
-<Askable meta={{ widget: 'revenue' }} events={['hover']}>
-  <RevenueCard />
-</Askable>
-
-<Askable meta={{ widget: 'account-row' }} events={['click']}>
-  <AccountRow />
-</Askable>
-
-<Askable meta={{ widget: 'details-panel' }} events="manual">
-  <Panel />
-</Askable>
+```ts
+import {
+  createWebContextPacket,
+  isWebContextPacket,
+  webContextPacketSchema,
+} from '@askable-ui/context';
 ```
 
-This makes mixed interaction patterns easier inside a single page or shared context:
+It is dependency-free and can be used by non-React runtimes, browser bridges,
+servers, or storage pipelines that need to understand the same packet shape.
 
-- hover-only summary cards
-- click-only rows in dense tables
-- fully manual "Ask AI about this" flows driven by `ctx.select()`
+### New `@askable-ui/mcp` package
 
-Related docs:
+`@askable-ui/mcp` creates an MCP server surface around a context provider:
 
-- [React API](/api/react)
-- [Ask AI button example](/examples/ask-ai-button)
+```ts
+const server = createAskableMcpServer({
+  provider: {
+    getContext: (options) => ctx.toContextPacket(options),
+  },
+});
+```
 
-### Better shared-context guidance
+The server registers tools for reading the current context, reading the schema,
+and formatting a packet for prompts. Transports are left to the host app so this
+can work with stdio, Streamable HTTP, or embedded browser runtimes.
 
-The recent docs updates also clarify how shared contexts behave across React, Vue, and the inspector tooling.
+### 0.7 release path
 
-That includes guidance for:
+All workspace packages have been bumped to `0.7.0`, and the publish workflow now
+publishes packages in dependency order:
 
-- named shared contexts
-- private vs shared contexts
-- matching inspector configuration to custom event/view settings
-- preserving hover-only and focus-only behavior in shared setups
+1. `@askable-ui/context`
+2. `@askable-ui/core`
+3. framework wrappers
+4. `@askable-ui/mcp`
+5. `@askable-ui/create-app`
 
 ## Recommended next step
 
-If you are integrating Askable into an AI copilot, start here:
+If you are integrating Askable into an AI or agent runtime, start here:
 
 1. [Getting Started](/guide/getting-started)
-2. [CopilotKit integration guide](/guide/copilotkit)
-3. [AI SDK integration patterns](/examples/ai-sdk)
+2. [Web Context Packets](/guide/web-context)
+3. [@askable-ui/mcp API](/api/mcp)
 
 ## Version note
 
-The current published docs track **v0.6.3** at both:
+The current published docs track **v0.7.0** at both:
 
 - `/docs/`
-- `/docs/v0.6.3/`
+- `/docs/v0.7.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -36,11 +36,11 @@ features:
     details: Configure which events trigger updates, filter or reorder metadata keys, set token budgets, track multi-step focus history, and use select() for explicit "Ask AI" button patterns.
 
   - icon: 🔌
-    title: Works with any LLM
-    details: toPromptContext() returns a plain string — drop it into OpenAI, Anthropic, Vercel AI SDK, CopilotKit, or any LLM pipeline. No vendor lock-in.
+    title: Works with agents and MCP
+    details: toPromptContext() returns a plain string, while toContextPacket() returns structured web context for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.6.3**.
+> Current npm release: **v0.7.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,15 +59,17 @@ features:
   </video>
 </div>
 
-## Latest in v0.6.3
+## Latest in v0.7.0
 
-- `ctx.subscribe(callback, options?)` for debounced streaming context updates in `@askable-ui/core`
-- per-component React activation overrides with `events={['hover']}`, `events={['click']}`, or `events="manual"`
-- refreshed docs coverage for streaming AI SDK flows, CopilotKit, shared contexts, and inspector alignment
+- `ctx.toContextPacket()` for structured web context packets in `@askable-ui/core`
+- new `@askable-ui/context` package with packet types, schema, and runtime guard
+- new `@askable-ui/mcp` package for exposing web context packets through MCP tools/resources
+- release workflow now publishes the context and MCP packages alongside the existing wrappers
 
 Start here:
 
-- [What’s New in v0.6.3](/guide/whats-new)
+- [What’s New in v0.7.0](/guide/whats-new)
+- [Web Context Packets](/guide/web-context)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)
 

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.6.3",
-    "slug": "v0.6.3"
+    "label": "v0.7.0",
+    "slug": "v0.7.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.6.3`) is built on every deploy and published to both:
+The current release (`v0.7.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.6.3/` (version-specific URL)
+- `/docs/v0.7.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- add @askable-ui/context with versioned web context packet types, schema, packet factory, and runtime guard
- add ctx.toContextPacket() in @askable-ui/core with focused target, ancestors, viewport, history, privacy, and provenance output
- add @askable-ui/mcp server factory with tools/resources for current context, schema, and prompt formatting
- bump workspace packages and examples to 0.7.0 and update docs/release publishing order

## Validation
- npm ci
- npm run build
- npm test
- npm audit --json
- node scripts/check-example-askable-versions.mjs
- npm run build --prefix site/docs
- npm publish --dry-run --access public from packages/context
- npm publish --dry-run --access public from packages/mcp

## Release note
Preview deployments that install example apps may fail until @askable-ui packages are published at 0.7.0 after merge.