### PR TITLE
feat(context): add region capture

### DIFF
--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.7.1",
+    "@askable-ui/react": "^0.8.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.7.1",
-    "@askable-ui/react-native": "^0.7.1",
+    "@askable-ui/core": "^0.8.0",
+    "@askable-ui/react-native": "^0.8.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "workspaces": [
         "packages/*"
       ],
@@ -4919,7 +4919,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.2",
@@ -4928,10 +4928,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.7.1"
+        "@askable-ui/context": "^0.8.0"
       },
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -4941,7 +4941,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4949,10 +4949,10 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.7.1",
+        "@askable-ui/context": "^0.8.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -4963,10 +4963,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.7.1"
+        "@askable-ui/core": "^0.8.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4986,10 +4986,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.7.1"
+        "@askable-ui/core": "^0.8.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -5104,10 +5104,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.7.1"
+        "@askable-ui/core": "^0.8.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -5144,10 +5144,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.7.1"
+        "@askable-ui/core": "^0.8.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,6 +42,32 @@ const formPrompt = ctx.toPromptContext({ scope: 'form-helper' });
 ctx.destroy();
 ```
 
+## Region and Circle Capture
+
+Use `createAskableRegionCapture()` when the user should draw a page region and
+send it as structured context.
+
+```ts
+import { createAskableContext, createAskableRegionCapture } from '@askable-ui/core';
+
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
+
+const capture = createAskableRegionCapture(ctx, {
+  shape: 'circle',
+  intent: 'explain this selected area',
+  includeViewport: true,
+  onCapture(packet) {
+    sendToAgent(packet);
+  },
+});
+
+capture.start();
+```
+
+The packet uses `capture.mode` of `region` or `circle`, marks consent as
+explicit, and includes the selected geometry in `target.bounds`.
+
 ## API Reference
 
 ### `createAskableContext(): AskableContext`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/core"
   },
   "scripts": {
@@ -38,7 +38,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.7.1"
+    "@askable-ui/context": "^0.8.0"
   },
   "devDependencies": {
     "jsdom": "^29.0.1",

--- a/packages/core/src/__tests__/capture.test.ts
+++ b/packages/core/src/__tests__/capture.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { createAskableContext, createAskableRegionCapture } from '../index.js';
+
+function pointerEvent(type: string, x: number, y: number): PointerEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: x,
+    clientY: y,
+  });
+  Object.defineProperty(event, 'pointerId', { value: 1 });
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+  return event as PointerEvent;
+}
+
+afterEach(() => {
+  document.getElementById('askable-region-capture')?.remove();
+});
+
+describe('createAskableRegionCapture', () => {
+  it('captures a dragged region as a Context packet', () => {
+    const ctx = createAskableContext();
+    const onCapture = vi.fn();
+    const capture = createAskableRegionCapture(ctx, {
+      source: { app: 'dashboard' },
+      intent: 'explain this region',
+      onCapture,
+    });
+
+    capture.start();
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointermove', 50, 60));
+    overlay.dispatchEvent(pointerEvent('pointerup', 50, 60));
+
+    expect(onCapture).toHaveBeenCalledTimes(1);
+    const [packet, selection] = onCapture.mock.calls[0];
+    expect(selection).toMatchObject({
+      shape: 'region',
+      bounds: { x: 10, y: 20, width: 40, height: 40 },
+      pointerType: 'mouse',
+    });
+    expect(packet).toMatchObject({
+      protocol: 'askable.context',
+      source: { app: 'dashboard' },
+      capture: {
+        mode: 'region',
+        gesture: 'drag',
+        intent: 'explain this region',
+      },
+      target: {
+        bounds: { x: 10, y: 20, width: 40, height: 40 },
+        metadata: {
+          shape: 'region',
+          pointerType: 'mouse',
+        },
+      },
+      privacy: {
+        consent: 'explicit',
+      },
+    });
+    expect(document.getElementById('askable-region-capture')).toBeNull();
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
+  it('captures a circle with center and radius metadata', () => {
+    const ctx = createAskableContext();
+    const onCapture = vi.fn();
+    const capture = createAskableRegionCapture(ctx, {
+      shape: 'circle',
+      onCapture,
+    });
+
+    capture.start();
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointermove', 50, 80));
+    overlay.dispatchEvent(pointerEvent('pointerup', 50, 80));
+
+    const [packet, selection] = onCapture.mock.calls[0];
+    expect(selection).toMatchObject({
+      shape: 'circle',
+      bounds: { x: 0, y: 20, width: 60, height: 60 },
+      center: { x: 30, y: 50 },
+      radius: 30,
+    });
+    expect(packet.capture).toMatchObject({
+      mode: 'circle',
+      gesture: 'circle',
+    });
+    expect(packet.target).toMatchObject({
+      bounds: { x: 0, y: 20, width: 60, height: 60 },
+      metadata: {
+        shape: 'circle',
+        center: { x: 30, y: 50 },
+        radius: 30,
+      },
+    });
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
+  it('cancels selections smaller than the minimum size', () => {
+    const ctx = createAskableContext();
+    const onCapture = vi.fn();
+    const onCancel = vi.fn();
+    const capture = createAskableRegionCapture(ctx, {
+      minSize: 12,
+      onCapture,
+      onCancel,
+    });
+
+    capture.start();
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointerup', 15, 24));
+
+    expect(onCapture).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('askable-region-capture')).toBeNull();
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
+  it('cancels an active overlay with Escape', () => {
+    const ctx = createAskableContext();
+    const onCancel = vi.fn();
+    const capture = createAskableRegionCapture(ctx, { onCancel });
+
+    capture.start();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('askable-region-capture')).toBeNull();
+
+    capture.destroy();
+    ctx.destroy();
+  });
+});

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -1,0 +1,292 @@
+import type {
+  WebContextCaptureMode,
+  WebContextGesture,
+  WebContextPacket,
+  WebContextRect,
+} from '@askable-ui/context';
+import type {
+  AskableContext,
+  AskableContextPacketOptions,
+} from './types.js';
+
+export type AskableRegionCaptureShape = 'region' | 'circle';
+
+export interface AskableRegionCaptureSelection {
+  shape: AskableRegionCaptureShape;
+  bounds: WebContextRect;
+  center?: { x: number; y: number };
+  radius?: number;
+  pointerType?: string;
+  startedAt: string;
+  endedAt: string;
+}
+
+export interface AskableRegionCaptureOptions extends Omit<AskableContextPacketOptions, 'mode' | 'gesture' | 'target'> {
+  /** Capture shape. Defaults to rectangular region selection. */
+  shape?: AskableRegionCaptureShape;
+  /** Minimum width/height in CSS pixels before a selection is accepted. Defaults to 6. */
+  minSize?: number;
+  /** Remove the overlay after the first accepted capture. Defaults to true. */
+  once?: boolean;
+  /** Called after a region/circle is accepted and serialized to a Context packet. */
+  onCapture?: (packet: WebContextPacket, selection: AskableRegionCaptureSelection) => void;
+  /** Called when an active capture is cancelled. */
+  onCancel?: () => void;
+}
+
+export interface AskableRegionCaptureHandle {
+  start(): void;
+  cancel(): void;
+  destroy(): void;
+  isActive(): boolean;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+const OVERLAY_ID = 'askable-region-capture';
+const SELECTION_ATTR = 'data-askable-region-capture-selection';
+
+export function createAskableRegionCapture(
+  ctx: AskableContext,
+  options: AskableRegionCaptureOptions = {},
+): AskableRegionCaptureHandle {
+  if (typeof document === 'undefined') {
+    return {
+      start: () => undefined,
+      cancel: () => undefined,
+      destroy: () => undefined,
+      isActive: () => false,
+    };
+  }
+
+  let overlay: HTMLDivElement | null = null;
+  let selectionEl: HTMLDivElement | null = null;
+  let startPoint: Point | null = null;
+  let startedAt = '';
+  let pointerType: string | undefined;
+  let active = false;
+
+  const shape = options.shape ?? 'region';
+  const minSize = options.minSize ?? 6;
+  const once = options.once ?? true;
+
+  const removeOverlay = () => {
+    overlay?.removeEventListener('pointerdown', onPointerDown);
+    overlay?.removeEventListener('pointermove', onPointerMove);
+    overlay?.removeEventListener('pointerup', onPointerUp);
+    overlay?.removeEventListener('pointercancel', onPointerCancel);
+    document.removeEventListener('keydown', onKeyDown);
+    overlay?.remove();
+    overlay = null;
+    selectionEl = null;
+    startPoint = null;
+    active = false;
+  };
+
+  const cancel = () => {
+    const wasActive = Boolean(overlay);
+    removeOverlay();
+    if (wasActive) options.onCancel?.();
+  };
+
+  const ensureOverlay = () => {
+    document.getElementById(OVERLAY_ID)?.remove();
+
+    overlay = document.createElement('div');
+    overlay.id = OVERLAY_ID;
+    overlay.setAttribute('aria-label', 'Context region capture');
+    overlay.style.cssText = [
+      'position:fixed',
+      'inset:0',
+      'z-index:2147483647',
+      'cursor:crosshair',
+      'background:rgba(15,23,42,0.08)',
+      'touch-action:none',
+      'user-select:none',
+    ].join(';');
+
+    selectionEl = document.createElement('div');
+    selectionEl.setAttribute(SELECTION_ATTR, shape);
+    selectionEl.style.cssText = [
+      'position:absolute',
+      'box-sizing:border-box',
+      'border:2px solid #2563eb',
+      'background:rgba(37,99,235,0.14)',
+      'box-shadow:0 0 0 9999px rgba(15,23,42,0.12)',
+      'pointer-events:none',
+      'display:none',
+    ].join(';');
+    if (shape === 'circle') selectionEl.style.borderRadius = '9999px';
+
+    overlay.appendChild(selectionEl);
+    overlay.addEventListener('pointerdown', onPointerDown);
+    overlay.addEventListener('pointermove', onPointerMove);
+    overlay.addEventListener('pointerup', onPointerUp);
+    overlay.addEventListener('pointercancel', onPointerCancel);
+    document.addEventListener('keydown', onKeyDown);
+    document.body.appendChild(overlay);
+  };
+
+  const updateSelection = (bounds: WebContextRect) => {
+    if (!selectionEl) return;
+    selectionEl.style.display = 'block';
+    selectionEl.style.left = `${bounds.x}px`;
+    selectionEl.style.top = `${bounds.y}px`;
+    selectionEl.style.width = `${bounds.width}px`;
+    selectionEl.style.height = `${bounds.height}px`;
+  };
+
+  function onPointerDown(event: PointerEvent) {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    pointerType = event.pointerType || undefined;
+    startPoint = pointFromEvent(event);
+    startedAt = new Date().toISOString();
+    active = true;
+    selectionEl!.style.display = 'none';
+    overlay?.setPointerCapture?.(event.pointerId);
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (!startPoint || !active) return;
+    event.preventDefault();
+    updateSelection(boundsForShape(shape, startPoint, pointFromEvent(event)));
+  }
+
+  function onPointerUp(event: PointerEvent) {
+    if (!startPoint || !active) return;
+    event.preventDefault();
+    const endPoint = pointFromEvent(event);
+    const selection = createSelection(shape, startPoint, endPoint, pointerType, startedAt);
+
+    if (selection.bounds.width < minSize || selection.bounds.height < minSize) {
+      cancel();
+      return;
+    }
+
+    const packet = ctx.toContextPacket({
+      ...options,
+      mode: captureModeForShape(shape),
+      gesture: gestureForShape(shape),
+      target: {
+        bounds: selection.bounds,
+        metadata: {
+          shape: selection.shape,
+          ...(selection.center ? { center: selection.center } : {}),
+          ...(selection.radius !== undefined ? { radius: selection.radius } : {}),
+          ...(selection.pointerType ? { pointerType: selection.pointerType } : {}),
+        },
+      },
+      privacy: {
+        consent: 'explicit',
+        ...options.privacy,
+      },
+      provenance: {
+        producer: '@askable-ui/core',
+        method: 'app',
+        ...options.provenance,
+      },
+    });
+
+    options.onCapture?.(packet, selection);
+
+    if (once) {
+      removeOverlay();
+      return;
+    }
+
+    startPoint = null;
+    active = false;
+    if (selectionEl) selectionEl.style.display = 'none';
+  }
+
+  function onPointerCancel() {
+    cancel();
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape') cancel();
+  }
+
+  return {
+    start() {
+      ensureOverlay();
+    },
+    cancel,
+    destroy: removeOverlay,
+    isActive: () => active,
+  };
+}
+
+function pointFromEvent(event: PointerEvent): Point {
+  return { x: event.clientX, y: event.clientY };
+}
+
+function boundsForShape(shape: AskableRegionCaptureShape, start: Point, end: Point): WebContextRect {
+  if (shape === 'circle') {
+    const center = {
+      x: (start.x + end.x) / 2,
+      y: (start.y + end.y) / 2,
+    };
+    const radius = Math.max(Math.abs(end.x - start.x), Math.abs(end.y - start.y)) / 2;
+    return {
+      x: center.x - radius,
+      y: center.y - radius,
+      width: radius * 2,
+      height: radius * 2,
+    };
+  }
+
+  return {
+    x: Math.min(start.x, end.x),
+    y: Math.min(start.y, end.y),
+    width: Math.abs(end.x - start.x),
+    height: Math.abs(end.y - start.y),
+  };
+}
+
+function createSelection(
+  shape: AskableRegionCaptureShape,
+  start: Point,
+  end: Point,
+  pointerType: string | undefined,
+  startedAt: string,
+): AskableRegionCaptureSelection {
+  const bounds = boundsForShape(shape, start, end);
+  const endedAt = new Date().toISOString();
+
+  if (shape === 'circle') {
+    const center = {
+      x: bounds.x + bounds.width / 2,
+      y: bounds.y + bounds.height / 2,
+    };
+    return {
+      shape,
+      bounds,
+      center,
+      radius: bounds.width / 2,
+      ...(pointerType ? { pointerType } : {}),
+      startedAt,
+      endedAt,
+    };
+  }
+
+  return {
+    shape,
+    bounds,
+    ...(pointerType ? { pointerType } : {}),
+    startedAt,
+    endedAt,
+  };
+}
+
+function captureModeForShape(shape: AskableRegionCaptureShape): WebContextCaptureMode {
+  return shape === 'circle' ? 'circle' : 'region';
+}
+
+function gestureForShape(shape: AskableRegionCaptureShape): WebContextGesture {
+  return shape === 'circle' ? 'circle' : 'drag';
+}

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -340,6 +340,8 @@ export class AskableContextImpl implements AskableContext {
       : [];
     const ancestors = currentFocus ? this.focusAncestorsToTargets(currentFocus, resolved) : [];
 
+    const target = options?.target ?? (currentFocus ? this.focusToTarget(currentFocus, resolved) : undefined);
+
     return createWebContextPacket({
       source: this.resolvePacketSource(options?.source),
       capture: {
@@ -347,7 +349,7 @@ export class AskableContextImpl implements AskableContext {
         gesture: options?.gesture ?? this.resolveGesture(currentFocus),
         ...(options?.intent ? { intent: options.intent } : {}),
       },
-      ...(currentFocus ? { target: this.focusToTarget(currentFocus, resolved) } : {}),
+      ...(target ? { target } : {}),
       ...((ancestors.length > 0 || history.length > 0 || visible.length > 0) ? {
         surrounding: {
           ...(ancestors.length > 0 ? { ancestors } : {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { createAskableInspector } from './inspector.js';
+export { createAskableRegionCapture } from './capture.js';
 export { a11yTextExtractor } from './a11y.js';
 export {
   WEB_CONTEXT_PROTOCOL,
@@ -24,6 +25,12 @@ export type {
   AskableInspectorOptions,
   AskableInspectorPosition,
 } from './inspector.js';
+export type {
+  AskableRegionCaptureHandle,
+  AskableRegionCaptureOptions,
+  AskableRegionCaptureSelection,
+  AskableRegionCaptureShape,
+} from './capture.js';
 export type {
   AskableContext,
   AskableContextOptions,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,6 +5,7 @@ import type {
   WebContextPrivacy,
   WebContextProvenance,
   WebContextSource,
+  WebContextTarget,
 } from '@askable-ui/context';
 
 /** How focus was initiated */
@@ -235,6 +236,8 @@ export interface AskableContextPacketOptions extends AskablePromptContextOptions
   mode?: WebContextCaptureMode;
   /** User gesture that produced the packet. Inferred from focus source when possible. */
   gesture?: WebContextGesture;
+  /** Override the packet target. Useful for region, lasso, circle, and other explicit captures. */
+  target?: WebContextTarget;
   /** Optional user intent attached to this capture. */
   intent?: string;
   /** Include visible annotated elements in the packet. Requires context viewport mode. */

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.7.1';
+const ASKABLE_VERSION = '0.8.0';
 const COPILOTKIT_VERSION = '1.56.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "MCP bridge for exposing Context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,7 +36,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.7.1",
+    "@askable-ui/context": "^0.8.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/react-native"
   },
   "scripts": {
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.7.1"
+    "@askable-ui/core": "^0.8.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/react"
   },
   "scripts": {
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.7.1"
+    "@askable-ui/core": "^0.8.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -23,7 +23,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/svelte"
   },
   "scripts": {
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.7.1"
+    "@askable-ui/core": "^0.8.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/askable-ui/askable.git",
+    "url": "git+https://github.com/askable-ui/askable.git",
     "directory": "packages/vue"
   },
   "scripts": {
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.7.1"
+    "@askable-ui/core": "^0.8.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -354,6 +354,7 @@ const packet = ctx.toContextPacket({
 | `source` | `Partial<WebContextSource>` | inferred from browser | Override source metadata like app or route |
 | `mode` | `WebContextCaptureMode` | inferred | Capture mode for the packet |
 | `gesture` | `WebContextGesture` | inferred | Gesture that produced the context |
+| `target` | `WebContextTarget` | inferred from focus | Override the packet target for region, circle, lasso, or custom captures |
 | `intent` | `string` | — | Optional user intent attached to the capture |
 | `includeViewport` | `boolean` | `false` | Include currently visible annotated elements |
 | `history` | `number` | `0` | Include recent focus history |
@@ -386,6 +387,46 @@ ctx.destroy();
 ```
 
 ---
+
+---
+
+## `createAskableRegionCapture(ctx, options?)`
+
+Mounts a temporary browser overlay that lets the user drag a rectangle or circle,
+then emits a structured Context packet with explicit consent metadata.
+
+```ts
+import { createAskableContext, createAskableRegionCapture } from '@askable-ui/core';
+
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
+
+const capture = createAskableRegionCapture(ctx, {
+  shape: 'circle',
+  intent: 'explain this selected area',
+  includeViewport: true,
+  onCapture: (packet, selection) => {
+    sendToAgent(packet);
+    console.log(selection.bounds);
+  },
+});
+
+capture.start();
+```
+
+**Options (`AskableRegionCaptureOptions`):**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `shape` | `'region' \| 'circle'` | `'region'` | Shape produced by the drag gesture |
+| `minSize` | `number` | `6` | Minimum accepted width/height in CSS pixels |
+| `once` | `boolean` | `true` | Remove the overlay after the first accepted capture |
+| `onCapture` | `(packet, selection) => void` | — | Called with the Context packet and selection geometry |
+| `onCancel` | `() => void` | — | Called when the capture is cancelled |
+| _...most `AskableContextPacketOptions`_ | | | Passed through to `toContextPacket()` |
+
+**Returns:** `AskableRegionCaptureHandle` — object with `start()`, `cancel()`,
+`destroy()`, and `isActive()` methods.
 
 ---
 

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.7.1`
-- Versioned current docs URL: `/docs/v0.7.1/`
+- Latest stable: `v0.8.0`
+- Versioned current docs URL: `/docs/v0.8.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.7.1/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.8.0/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -101,3 +101,30 @@ ctx.toContextPacket({
   provenance: { producer: 'my-browser-extension', method: 'extension' },
 });
 ```
+
+## Region and circle capture
+
+For "send this part of the page" interactions, `@askable-ui/core` can mount a
+temporary drag overlay and emit a packet with region geometry:
+
+```ts
+import { createAskableContext, createAskableRegionCapture } from '@askable-ui/core';
+
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
+
+const capture = createAskableRegionCapture(ctx, {
+  shape: 'circle',
+  intent: 'explain this selected chart segment',
+  includeViewport: true,
+  onCapture: (packet) => {
+    sendToAgent(packet);
+  },
+});
+
+capture.start();
+```
+
+The resulting packet uses `capture.mode` of `region` or `circle`, sets
+`privacy.consent` to `explicit`, and places the selected bounds on
+`target.bounds`.

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.7.1**.
+> Current npm release: **v0.8.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,39 +1,61 @@
-# What’s New in v0.7.1
+# What’s New in v0.8.0
 
-askable-ui v0.7.1 aligns the structured Context packet identity with the new open spec repo.
+askable-ui v0.8.0 adds explicit region and circle capture for "send this part
+of the page" agent workflows.
 
 ## Highlights
 
-### Structured Context packets
+### Region and circle capture
 
-`@askable-ui/core` now emits versioned Context packets:
+`@askable-ui/core` now exports `createAskableRegionCapture()`:
 
 ```ts
-const packet = ctx.toContextPacket({
-  history: 3,
+const capture = createAskableRegionCapture(ctx, {
+  shape: 'circle',
+  intent: 'explain this selected area',
   includeViewport: true,
-  source: { app: 'analytics-dashboard' },
+  onCapture: (packet) => sendToAgent(packet),
 });
+
+capture.start();
 ```
 
-Packets preserve the same annotated metadata used by prompt serialization, but
-add source, capture, surrounding context, privacy, and provenance fields.
+The helper mounts a temporary drag overlay and emits a Context packet with
+`capture.mode` set to `region` or `circle`, explicit consent metadata, and the
+selected geometry in `target.bounds`.
 
-Use packets when you want to:
+Use it when you want to:
 
-- pass selected/focused UI context through MCP
-- store or validate context before forwarding it to a model
-- bridge app-authored context into browser extensions or agent runtimes
-- include viewport and history context without flattening everything to prose
+- let a user circle part of a chart, table, or canvas
+- send a visible page region to an agent
+- combine manual selection geometry with viewport and focus context
+- build screenshot or browser-extension capture flows on top of the same packet shape
 
 Related docs:
 
 - [Context Packets](/guide/context)
 - [@askable-ui/core API](/api/core)
 
-### New `@askable-ui/context` package
+### Packet target overrides
 
-The new context package provides the shared packet contract:
+`ctx.toContextPacket()` now accepts an explicit `target`, so custom capture
+tools can set bounds or metadata without pretending the current DOM focus is the
+selected object.
+
+```ts
+ctx.toContextPacket({
+  mode: 'region',
+  gesture: 'drag',
+  target: {
+    bounds: { x: 24, y: 48, width: 320, height: 180 },
+    metadata: { shape: 'region' },
+  },
+});
+```
+
+### Existing Context package
+
+`@askable-ui/context` continues to provide the shared packet contract:
 
 ```ts
 import {
@@ -46,7 +68,7 @@ import {
 It is dependency-free and backed by the public [askable-ui/context](https://github.com/askable-ui/context) spec repo. It can be used by non-React runtimes, browser bridges,
 servers, or storage pipelines that need to understand the same packet shape.
 
-### New `@askable-ui/mcp` package
+### MCP bridge
 
 `@askable-ui/mcp` creates an MCP server surface around a context provider:
 
@@ -62,9 +84,9 @@ The server registers tools for reading the current context, reading the schema,
 and formatting a packet for prompts. Transports are left to the host app so this
 can work with stdio, Streamable HTTP, or embedded browser runtimes.
 
-### 0.7 release path
+### 0.8 release path
 
-All workspace packages have been bumped to `0.7.1`, and the publish workflow now
+All workspace packages have been bumped to `0.8.0`, and the publish workflow now
 publishes packages in dependency order:
 
 1. `@askable-ui/context`
@@ -83,7 +105,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.7.1** at both:
+The current published docs track **v0.8.0** at both:
 
 - `/docs/`
-- `/docs/v0.7.1/`
+- `/docs/v0.8.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.7.1**.
+> Current npm release: **v0.8.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,16 +59,16 @@ features:
   </video>
 </div>
 
-## Latest in v0.7.1
+## Latest in v0.8.0
 
-- `ctx.toContextPacket()` for structured Context packets in `@askable-ui/core`
-- new `@askable-ui/context` package with packet types, schema, and runtime guard
-- new `@askable-ui/mcp` package for exposing Context packets through MCP tools/resources
-- release workflow now publishes the context and MCP packages alongside the existing wrappers
+- `createAskableRegionCapture()` for user-drawn region and circle context
+- `ctx.toContextPacket({ target })` for custom capture targets
+- normalized package repository metadata for cleaner npm publishes
+- continued support for Context packets, MCP tools/resources, and framework wrappers
 
 Start here:
 
-- [What’s New in v0.7.1](/guide/whats-new)
+- [What’s New in v0.8.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.7.1",
-    "slug": "v0.7.1"
+    "label": "v0.8.0",
+    "slug": "v0.8.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.7.1`) is built on every deploy and published to both:
+The current release (`v0.8.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.7.1/` (version-specific URL)
+- `/docs/v0.8.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- add createAskableRegionCapture() for user-drawn region and circle Context packets
- allow explicit packet target overrides for custom capture flows
- bump packages and docs to v0.8.0
- normalize package repository URLs for cleaner npm publishes

## Validation
- npm test
- npm run build
- npm run build --prefix site/docs
- node scripts/check-example-askable-versions.mjs
- npm audit --json