### PR TITLE
feat(react): add region capture hook

### DIFF
--- a/e2e/observer.spec.ts
+++ b/e2e/observer.spec.ts
@@ -173,6 +173,80 @@ test.describe('keyboard focus tracking', () => {
   });
 });
 
+test.describe('region capture', () => {
+  test('dragging a region emits a structured Context packet', async ({ harness }) => {
+    const page = await harness(
+      `<div id="target" data-askable='{"widget":"chart"}' style="width:240px;height:120px">Chart</div>`,
+      `
+      window.capturedPacket = null;
+      window.regionCapture = AskableCore.createAskableRegionCapture(window.ctx, {
+        source: { app: 'e2e' },
+        intent: 'explain selected region',
+        onCapture: (packet) => { window.capturedPacket = packet; },
+      });
+      window.regionCapture.start();
+      `,
+    );
+
+    await page.mouse.move(20, 30);
+    await page.mouse.down();
+    await page.mouse.move(100, 110);
+    await page.mouse.up();
+
+    const packet = await page.evaluate(() => (window as any).capturedPacket);
+    expect(packet).toMatchObject({
+      protocol: 'askable.context',
+      source: { app: 'e2e' },
+      capture: {
+        mode: 'region',
+        gesture: 'drag',
+        intent: 'explain selected region',
+      },
+      target: {
+        bounds: { x: 20, y: 30, width: 80, height: 80 },
+        metadata: { shape: 'region' },
+      },
+      privacy: {
+        consent: 'explicit',
+      },
+    });
+    expect(packet.target.metadata.pointerType).toBe('mouse');
+  });
+
+  test('dragging a circle emits center and radius metadata', async ({ harness }) => {
+    const page = await harness(
+      `<div id="target" data-askable='{"widget":"chart"}' style="width:240px;height:120px">Chart</div>`,
+      `
+      window.capturedPacket = null;
+      window.regionCapture = AskableCore.createAskableRegionCapture(window.ctx, {
+        shape: 'circle',
+        onCapture: (packet) => { window.capturedPacket = packet; },
+      });
+      window.regionCapture.start();
+      `,
+    );
+
+    await page.mouse.move(20, 30);
+    await page.mouse.down();
+    await page.mouse.move(100, 70);
+    await page.mouse.up();
+
+    const packet = await page.evaluate(() => (window as any).capturedPacket);
+    expect(packet.capture).toMatchObject({
+      mode: 'circle',
+      gesture: 'circle',
+    });
+    expect(packet.target).toMatchObject({
+      bounds: { x: 20, y: 10, width: 80, height: 80 },
+      metadata: {
+        shape: 'circle',
+        center: { x: 60, y: 50 },
+        radius: 40,
+      },
+    });
+  });
+});
+
 test.describe('nested elements — deepest strategy (default)', () => {
   test('clicking nested inner element wins', async ({ harness }) => {
     const page = await harness(`

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.8.0",
+    "@askable-ui/react": "^0.8.1",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.0",
-    "@askable-ui/react-native": "^0.8.0",
+    "@askable-ui/core": "^0.8.1",
+    "@askable-ui/react-native": "^0.8.1",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "workspaces": [
         "packages/*"
       ],
@@ -4919,7 +4919,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.2",
@@ -4928,10 +4928,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.8.0"
+        "@askable-ui/context": "^0.8.1"
       },
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -4941,7 +4941,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4949,10 +4949,10 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.8.0",
+        "@askable-ui/context": "^0.8.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -4963,10 +4963,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.0"
+        "@askable-ui/core": "^0.8.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4986,10 +4986,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.0"
+        "@askable-ui/core": "^0.8.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -5104,10 +5104,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.0"
+        "@askable-ui/core": "^0.8.1"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -5144,10 +5144,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.0"
+        "@askable-ui/core": "^0.8.1"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.8.0"
+    "@askable-ui/context": "^0.8.1"
   },
   "devDependencies": {
     "jsdom": "^29.0.1",

--- a/packages/create-askable-app/README.md
+++ b/packages/create-askable-app/README.md
@@ -15,6 +15,7 @@ The generated app includes:
 
 - a small analytics dashboard annotated with `data-askable`
 - `useAskable()` pre-wired for hover + click focus tracking
+- region and circle capture buttons for explicit page-area context
 - `useCopilotReadable()` pushing current and recent Askable context into CopilotKit
 - a local Express runtime wired to `@copilotkit/runtime`
 - a starter README and `.env.example`

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.8.0';
-const COPILOTKIT_VERSION = '1.56.2';
+const ASKABLE_VERSION = '0.8.1';
+const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/create-askable-app/template/src/App.tsx
+++ b/packages/create-askable-app/template/src/App.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import { CopilotSidebar } from '@copilotkit/react-ui';
 import { useCopilotReadable } from '@copilotkit/react-core';
-import { useAskable } from '@askable-ui/react';
+import { useAskable, useAskableRegionCapture } from '@askable-ui/react';
 
 type MetricCard = {
   id: string;
@@ -61,7 +61,20 @@ function askableMeta(meta: Record<string, string>) {
 export default function App() {
   const { ctx, promptContext } = useAskable();
   const [selectedPanel, setSelectedPanel] = useState<string | null>(null);
+  const [regionContext, setRegionContext] = useState('No page region captured yet.');
   const panelRefs = useRef<Record<string, HTMLElement | null>>({});
+  const regionCapture = useAskableRegionCapture({
+    ctx,
+    includeViewport: true,
+    source: { app: 'askable-starter' },
+    onCapture(packet, selection) {
+      setRegionContext(JSON.stringify({
+        capture: packet.capture,
+        target: packet.target,
+        selection,
+      }, null, 2));
+    },
+  });
 
   const currentContext = promptContext || 'No panel selected yet. Hover or click a KPI card or deal row to feed Askable context into CopilotKit.';
   const recentContext = useMemo(() => {
@@ -83,6 +96,14 @@ export default function App() {
       value: recentContext,
     },
     [recentContext],
+  );
+
+  useCopilotReadable(
+    {
+      description: 'The last explicit region or circle the user selected on the page.',
+      value: regionContext,
+    },
+    [regionContext],
   );
 
   function focusPanel(id: string) {
@@ -112,6 +133,25 @@ export default function App() {
             <button type="button" className="secondary" onClick={() => focusPanel('northstar')}>
               Ask about Northstar
             </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => regionCapture.start({ shape: 'region', intent: 'explain this selected page region' })}
+            >
+              Select region
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => regionCapture.start({ shape: 'circle', intent: 'explain this circled area' })}
+            >
+              Circle area
+            </button>
+            {regionCapture.active && (
+              <button type="button" className="secondary" onClick={regionCapture.cancel}>
+                Cancel selection
+              </button>
+            )}
           </div>
         </section>
 
@@ -186,6 +226,8 @@ export default function App() {
             <pre>{currentContext}</pre>
             <h3>Recent focus history</h3>
             <pre>{recentContext}</pre>
+            <h3>Selected page region</h3>
+            <pre>{regionContext}</pre>
           </article>
         </section>
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP bridge for exposing Context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,7 +36,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.8.0",
+    "@askable-ui/context": "^0.8.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.0"
+    "@askable-ui/core": "^0.8.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -11,7 +11,7 @@ npm install @askable-ui/react @askable-ui/core
 ## Quick Start
 
 ```tsx
-import { Askable, useAskable } from '@askable-ui/react';
+import { Askable, useAskable, useAskableRegionCapture } from '@askable-ui/react';
 
 // Wrap any element to make it LLM-aware
 function Dashboard() {
@@ -24,7 +24,11 @@ function Dashboard() {
 
 // Access focus context anywhere in your tree
 function AIChatInput() {
-  const { focus, promptContext } = useAskable();
+  const { focus, promptContext, ctx } = useAskable();
+  const capture = useAskableRegionCapture({
+    ctx,
+    onCapture: (packet) => sendToAgent(packet),
+  });
 
   async function handleSubmit(question: string) {
     const res = await fetch('/api/chat', {
@@ -41,6 +45,9 @@ function AIChatInput() {
 
   return (
     <div>
+      <button onClick={() => capture.start({ shape: 'circle' })}>
+        Circle context
+      </button>
       {focus && <p>Asking about: {JSON.stringify(focus.meta)}</p>}
       <input onKeyDown={(e) => e.key === 'Enter' && handleSubmit(e.currentTarget.value)} />
     </div>
@@ -158,6 +165,8 @@ const { focus: focusOnly } = useAskable({ events: ['focus'] });
   - `ctx.toHistoryContext(limit?, options?)` — history as a prompt-ready string
   - `ctx.toPromptContext(options?)` — full serialization options (format, maxTokens, excludeKeys, …)
   - `ctx.serializeFocus(options?)` — structured `AskableSerializedFocus` object
+  - `ctx.toContextPacket()` — structured Context packet for agents and MCP bridges
+- `useAskableRegionCapture()` — explicit region/circle capture for visual page selection
 
 The hook manages a shared singleton context per `name + events + viewport` configuration. Multiple `useAskable()` consumers with the same shared configuration reuse one observer lifecycle, while differing configurations get isolated shared contexts of their own. Each shared context is automatically destroyed when its last consumer unmounts.
 
@@ -194,6 +203,38 @@ function RevenueCard({ data }) {
         Ask AI ✦
       </button>
     </Askable>
+  );
+}
+```
+
+### Region and circle capture
+
+Use `useAskableRegionCapture()` when a user should select an area of the page
+and send that geometry as structured context.
+
+```tsx
+import { useAskable, useAskableRegionCapture } from '@askable-ui/react';
+
+function RegionTools() {
+  const { ctx } = useAskable({ viewport: true });
+  const capture = useAskableRegionCapture({
+    ctx,
+    includeViewport: true,
+    onCapture(packet) {
+      sendToAgent(packet);
+    },
+  });
+
+  return (
+    <>
+      <button onClick={() => capture.start({ shape: 'region' })}>
+        Select region
+      </button>
+      <button onClick={() => capture.start({ shape: 'circle' })}>
+        Circle area
+      </button>
+      {capture.active && <button onClick={capture.cancel}>Cancel</button>}
+    </>
   );
 }
 ```

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.0"
+    "@askable-ui/core": "^0.8.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/react/src/__tests__/useAskableRegionCapture.test.tsx
+++ b/packages/react/src/__tests__/useAskableRegionCapture.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useAskableRegionCapture } from '../useAskableRegionCapture.js';
+
+function pointerEvent(type: string, x: number, y: number): PointerEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: x,
+    clientY: y,
+  });
+  Object.defineProperty(event, 'pointerId', { value: 1 });
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+  return event as PointerEvent;
+}
+
+afterEach(() => {
+  document.getElementById('askable-region-capture')?.remove();
+});
+
+describe('useAskableRegionCapture', () => {
+  it('starts capture and exposes the captured packet', async () => {
+    function Consumer() {
+      const capture = useAskableRegionCapture({
+        source: { app: 'react-test' },
+        intent: 'explain selected area',
+      });
+
+      return (
+        <div>
+          <button type="button" onClick={() => capture.start()}>
+            Start
+          </button>
+          <span data-testid="active">{String(capture.active)}</span>
+          <span data-testid="packet">{capture.lastPacket ? JSON.stringify(capture.lastPacket) : 'null'}</span>
+        </div>
+      );
+    }
+
+    render(<Consumer />);
+
+    act(() => {
+      fireEvent.click(screen.getByText('Start'));
+    });
+
+    expect(screen.getByTestId('active').textContent).toBe('true');
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    act(() => {
+      overlay.dispatchEvent(pointerEvent('pointerdown', 20, 30));
+      overlay.dispatchEvent(pointerEvent('pointermove', 80, 90));
+      overlay.dispatchEvent(pointerEvent('pointerup', 80, 90));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active').textContent).toBe('false');
+      expect(screen.getByTestId('packet').textContent).not.toBe('null');
+    });
+
+    const packet = JSON.parse(screen.getByTestId('packet').textContent!);
+    expect(packet).toMatchObject({
+      protocol: 'askable.context',
+      source: { app: 'react-test' },
+      capture: {
+        mode: 'region',
+        gesture: 'drag',
+        intent: 'explain selected area',
+      },
+      target: {
+        bounds: { x: 20, y: 30, width: 60, height: 60 },
+        metadata: { shape: 'region', pointerType: 'mouse' },
+      },
+      privacy: { consent: 'explicit' },
+    });
+  });
+
+  it('supports circle capture overrides at start time', async () => {
+    function Consumer() {
+      const capture = useAskableRegionCapture();
+
+      return (
+        <div>
+          <button type="button" onClick={() => capture.start({ shape: 'circle' })}>
+            Circle
+          </button>
+          <span data-testid="packet">{capture.lastPacket ? JSON.stringify(capture.lastPacket) : 'null'}</span>
+        </div>
+      );
+    }
+
+    render(<Consumer />);
+
+    act(() => {
+      fireEvent.click(screen.getByText('Circle'));
+    });
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    act(() => {
+      overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+      overlay.dispatchEvent(pointerEvent('pointermove', 50, 80));
+      overlay.dispatchEvent(pointerEvent('pointerup', 50, 80));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('packet').textContent).not.toBe('null');
+    });
+
+    const packet = JSON.parse(screen.getByTestId('packet').textContent!);
+    expect(packet.capture).toMatchObject({ mode: 'circle', gesture: 'circle' });
+    expect(packet.target).toMatchObject({
+      bounds: { x: 0, y: 20, width: 60, height: 60 },
+      metadata: {
+        shape: 'circle',
+        center: { x: 30, y: 50 },
+        radius: 30,
+      },
+    });
+  });
+
+  it('cancels the active overlay from React state', async () => {
+    function Consumer() {
+      const capture = useAskableRegionCapture();
+
+      return (
+        <div>
+          <button type="button" onClick={() => capture.start()}>
+            Start
+          </button>
+          <button type="button" onClick={() => capture.cancel()}>
+            Cancel
+          </button>
+          <span data-testid="active">{String(capture.active)}</span>
+        </div>
+      );
+    }
+
+    render(<Consumer />);
+
+    act(() => {
+      fireEvent.click(screen.getByText('Start'));
+    });
+    expect(screen.getByTestId('active').textContent).toBe('true');
+
+    act(() => {
+      fireEvent.click(screen.getByText('Cancel'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active').textContent).toBe('false');
+    });
+    expect(document.getElementById('askable-region-capture')).toBeNull();
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,10 @@
 export { Askable } from './Askable.js';
 export { AskableInspector } from './AskableInspector.js';
 export { useAskable } from './useAskable.js';
+export { useAskableRegionCapture } from './useAskableRegionCapture.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
+export type {
+  UseAskableRegionCaptureOptions,
+  UseAskableRegionCaptureResult,
+} from './useAskableRegionCapture.js';
 export type { AskableInspectorProps } from './AskableInspector.js';

--- a/packages/react/src/useAskableRegionCapture.ts
+++ b/packages/react/src/useAskableRegionCapture.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createAskableRegionCapture,
+  type AskableContext,
+  type AskableRegionCaptureHandle,
+  type AskableRegionCaptureOptions,
+  type AskableRegionCaptureSelection,
+  type WebContextPacket,
+} from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export interface UseAskableRegionCaptureOptions
+  extends AskableRegionCaptureOptions,
+    Omit<UseAskableOptions, 'inspector'> {}
+
+export interface UseAskableRegionCaptureResult {
+  ctx: AskableContext;
+  active: boolean;
+  lastPacket: WebContextPacket | null;
+  lastSelection: AskableRegionCaptureSelection | null;
+  start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
+  cancel: () => void;
+  destroy: () => void;
+  isActive: () => boolean;
+}
+
+export function useAskableRegionCapture(
+  options: UseAskableRegionCaptureOptions = {},
+): UseAskableRegionCaptureResult {
+  const { ctx } = useAskable(options);
+  const optionsRef = useRef(options);
+  const handleRef = useRef<AskableRegionCaptureHandle | null>(null);
+  const [active, setActive] = useState(false);
+  const [lastPacket, setLastPacket] = useState<WebContextPacket | null>(null);
+  const [lastSelection, setLastSelection] = useState<AskableRegionCaptureSelection | null>(null);
+
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
+  const destroy = useCallback(() => {
+    handleRef.current?.destroy();
+    handleRef.current = null;
+    setActive(false);
+  }, []);
+
+  const cancel = useCallback(() => {
+    handleRef.current?.cancel();
+    handleRef.current = null;
+    setActive(false);
+  }, []);
+
+  const start = useCallback((overrides?: Partial<AskableRegionCaptureOptions>) => {
+    handleRef.current?.destroy();
+
+    const currentOptions = {
+      ...optionsRef.current,
+      ...overrides,
+    };
+
+    const handle = createAskableRegionCapture(ctx, {
+      ...currentOptions,
+      onCapture(packet, selection) {
+        setLastPacket(packet);
+        setLastSelection(selection);
+        setActive(false);
+        currentOptions.onCapture?.(packet, selection);
+      },
+      onCancel() {
+        setActive(false);
+        currentOptions.onCancel?.();
+      },
+    });
+
+    handleRef.current = handle;
+    handle.start();
+    setActive(true);
+  }, [ctx]);
+
+  const isActive = useCallback(() => handleRef.current?.isActive() ?? active, [active]);
+
+  useEffect(() => destroy, [destroy]);
+
+  return {
+    ctx,
+    active,
+    lastPacket,
+    lastSelection,
+    start,
+    cancel,
+    destroy,
+    isActive,
+  };
+}

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.0"
+    "@askable-ui/core": "^0.8.1"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.0"
+    "@askable-ui/core": "^0.8.1"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -280,3 +280,63 @@ function PrivatePanel({ panelEl }: { panelEl: HTMLElement }) {
   return <textarea defaultValue={promptContext} />;
 }
 ```
+
+---
+
+## `useAskableRegionCapture(options?)`
+
+React hook for explicit region and circle capture. It mounts a temporary browser
+overlay, tracks active state, and stores the last captured Context packet.
+
+```tsx
+import { useAskable, useAskableRegionCapture } from '@askable-ui/react';
+
+function DashboardCapture() {
+  const { ctx } = useAskable({ viewport: true });
+  const capture = useAskableRegionCapture({
+    ctx,
+    includeViewport: true,
+    onCapture(packet) {
+      sendToAgent(packet);
+    },
+  });
+
+  return (
+    <>
+      <button onClick={() => capture.start({ shape: 'region' })}>
+        Select region
+      </button>
+      <button onClick={() => capture.start({ shape: 'circle' })}>
+        Circle area
+      </button>
+      {capture.active && <button onClick={capture.cancel}>Cancel</button>}
+    </>
+  );
+}
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `shape` | `'region' \| 'circle'` | Default shape for `start()` |
+| `minSize` | `number` | Minimum accepted width/height in CSS pixels |
+| `once` | `boolean` | Remove the overlay after the first accepted capture |
+| `onCapture` | `(packet, selection) => void` | Called when the user completes a selection |
+| `onCancel` | `() => void` | Called when selection is cancelled |
+| `ctx` | `AskableContext` | Reuse an existing context |
+| `includeViewport` | `boolean` | Include visible annotated elements in the emitted packet |
+| `source`, `intent`, `privacy`, `provenance` | context packet options | Passed through to packet serialization |
+
+**Returns:**
+
+| Value | Type | Description |
+|---|---|---|
+| `ctx` | `AskableContext` | Context used for packet serialization |
+| `active` | `boolean` | Whether the overlay is currently active |
+| `lastPacket` | `WebContextPacket \| null` | Last captured packet |
+| `lastSelection` | `AskableRegionCaptureSelection \| null` | Last captured geometry |
+| `start(overrides?)` | `function` | Start capture, optionally overriding shape/intent/etc. |
+| `cancel()` | `function` | Cancel the active overlay |
+| `destroy()` | `function` | Remove the overlay without firing cancel |
+| `isActive()` | `function` | Read active state from the live capture handle |

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.8.0`
-- Versioned current docs URL: `/docs/v0.8.0/`
+- Latest stable: `v0.8.1`
+- Versioned current docs URL: `/docs/v0.8.1/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.8.0/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.8.1/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -128,3 +128,16 @@ capture.start();
 The resulting packet uses `capture.mode` of `region` or `circle`, sets
 `privacy.consent` to `explicit`, and places the selected bounds on
 `target.bounds`.
+
+React apps can use the wrapper hook instead:
+
+```tsx
+import { useAskable, useAskableRegionCapture } from '@askable-ui/react';
+
+const { ctx } = useAskable({ viewport: true });
+const capture = useAskableRegionCapture({
+  ctx,
+  includeViewport: true,
+  onCapture: (packet) => sendToAgent(packet),
+});
+```

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.8.0**.
+> Current npm release: **v0.8.1**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/react.md
+++ b/site/docs/guide/react.md
@@ -131,6 +131,42 @@ function MetricCard({ data }) {
 
 See [Ask AI Button](/examples/ask-ai-button) for a full working example.
 
+## Region and circle capture
+
+For visual "send this part of the page" flows, use
+`useAskableRegionCapture()` with the same context that powers the rest of your
+React UI.
+
+```tsx
+import { useAskable, useAskableRegionCapture } from '@askable-ui/react';
+
+function RegionTools() {
+  const { ctx } = useAskable({ viewport: true });
+  const capture = useAskableRegionCapture({
+    ctx,
+    includeViewport: true,
+    onCapture(packet) {
+      sendToAgent(packet);
+    },
+  });
+
+  return (
+    <div>
+      <button onClick={() => capture.start({ shape: 'region' })}>
+        Select region
+      </button>
+      <button onClick={() => capture.start({ shape: 'circle' })}>
+        Circle area
+      </button>
+      {capture.active && <button onClick={capture.cancel}>Cancel</button>}
+    </div>
+  );
+}
+```
+
+Region packets use `capture.mode: 'region'`; circle packets use
+`capture.mode: 'circle'` and include center/radius metadata.
+
 ## History-aware context
 
 Feed multi-step interaction history into your LLM instead of just the current focus:

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,28 +1,31 @@
-# What’s New in v0.8.0
+# What’s New in v0.8.1
 
-askable-ui v0.8.0 adds explicit region and circle capture for "send this part
-of the page" agent workflows.
+askable-ui v0.8.1 adds React and starter-app support for explicit region and
+circle capture in "send this part of the page" agent workflows.
 
 ## Highlights
 
-### Region and circle capture
+### React region and circle capture
 
-`@askable-ui/core` now exports `createAskableRegionCapture()`:
+`@askable-ui/react` now exports `useAskableRegionCapture()`:
 
-```ts
-const capture = createAskableRegionCapture(ctx, {
+```tsx
+const { ctx } = useAskable({ viewport: true });
+const capture = useAskableRegionCapture({
+  ctx,
   shape: 'circle',
   intent: 'explain this selected area',
   includeViewport: true,
   onCapture: (packet) => sendToAgent(packet),
 });
 
-capture.start();
+capture.start({ shape: 'circle' });
 ```
 
-The helper mounts a temporary drag overlay and emits a Context packet with
+The hook mounts a temporary drag overlay and emits a Context packet with
 `capture.mode` set to `region` or `circle`, explicit consent metadata, and the
-selected geometry in `target.bounds`.
+selected geometry in `target.bounds`. It also exposes `active`, `lastPacket`,
+`lastSelection`, `cancel()`, and `destroy()` for React UI state.
 
 Use it when you want to:
 
@@ -34,66 +37,21 @@ Use it when you want to:
 Related docs:
 
 - [Context Packets](/guide/context)
-- [@askable-ui/core API](/api/core)
+- [@askable-ui/react API](/api/react)
 
-### Packet target overrides
+### Browser-level capture coverage
 
-`ctx.toContextPacket()` now accepts an explicit `target`, so custom capture
-tools can set bounds or metadata without pretending the current DOM focus is the
-selected object.
+The core capture path now has Playwright coverage that exercises real pointer
+drag selection in Chromium, Firefox, and WebKit through the bundled browser API.
 
-```ts
-ctx.toContextPacket({
-  mode: 'region',
-  gesture: 'drag',
-  target: {
-    bounds: { x: 24, y: 48, width: 320, height: 180 },
-    metadata: { shape: 'region' },
-  },
-});
-```
+### Starter app capture controls
 
-### Existing Context package
-
-`@askable-ui/context` continues to provide the shared packet contract:
-
-```ts
-import {
-  createWebContextPacket,
-  isWebContextPacket,
-  webContextPacketSchema,
-} from '@askable-ui/context';
-```
-
-It is dependency-free and backed by the public [askable-ui/context](https://github.com/askable-ui/context) spec repo. It can be used by non-React runtimes, browser bridges,
-servers, or storage pipelines that need to understand the same packet shape.
-
-### MCP bridge
-
-`@askable-ui/mcp` creates an MCP server surface around a context provider:
-
-```ts
-const server = createAskableMcpServer({
-  provider: {
-    getContext: (options) => ctx.toContextPacket(options),
-  },
-});
-```
-
-The server registers tools for reading the current context, reading the schema,
-and formatting a packet for prompts. Transports are left to the host app so this
-can work with stdio, Streamable HTTP, or embedded browser runtimes.
+`npm create @askable-ui/app` now scaffolds region and circle capture buttons and
+pushes the last selected page area into CopilotKit readable context.
 
 ### 0.8 release path
 
-All workspace packages have been bumped to `0.8.0`, and the publish workflow now
-publishes packages in dependency order:
-
-1. `@askable-ui/context`
-2. `@askable-ui/core`
-3. framework wrappers
-4. `@askable-ui/mcp`
-5. `@askable-ui/create-app`
+All workspace packages have been bumped to `0.8.1`.
 
 ## Recommended next step
 
@@ -105,7 +63,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.8.0** at both:
+The current published docs track **v0.8.1** at both:
 
 - `/docs/`
-- `/docs/v0.8.0/`
+- `/docs/v0.8.1/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.8.0**.
+> Current npm release: **v0.8.1**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,16 +59,16 @@ features:
   </video>
 </div>
 
-## Latest in v0.8.0
+## Latest in v0.8.1
 
-- `createAskableRegionCapture()` for user-drawn region and circle context
-- `ctx.toContextPacket({ target })` for custom capture targets
-- normalized package repository metadata for cleaner npm publishes
+- `useAskableRegionCapture()` for React region and circle context selection
+- starter app region/circle buttons wired into CopilotKit readable context
+- full browser e2e coverage for core region and circle packet capture
 - continued support for Context packets, MCP tools/resources, and framework wrappers
 
 Start here:
 
-- [What’s New in v0.8.0](/guide/whats-new)
+- [What’s New in v0.8.1](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.8.0",
-    "slug": "v0.8.0"
+    "label": "v0.8.1",
+    "slug": "v0.8.1"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.8.0`) is built on every deploy and published to both:
+The current release (`v0.8.1`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.8.0/` (version-specific URL)
+- `/docs/v0.8.1/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- add useAskableRegionCapture() for React region/circle Context packet capture
- wire region and circle capture into the starter app
- add browser e2e coverage for core region/circle capture
- bump workspace/docs to v0.8.1 and update scaffold dependencies

## Validation
- npm test
- npm run build
- npm run build --prefix site/docs
- node scripts/check-example-askable-versions.mjs
- npm audit --json
- npm run test:e2e
- generated starter app install/build with local packages
- generated starter runtime smoke: Select region/Circle area overlay and circle packet UI update