### PR TITLE
feat(adapters): add vue and svelte region capture

### DIFF
--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.8.1",
+    "@askable-ui/react": "^0.8.2",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.1",
-    "@askable-ui/react-native": "^0.8.1",
+    "@askable-ui/core": "^0.8.2",
+    "@askable-ui/react-native": "^0.8.2",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "workspaces": [
         "packages/*"
       ],
@@ -4919,7 +4919,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.2",
@@ -4928,10 +4928,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.8.1"
+        "@askable-ui/context": "^0.8.2"
       },
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -4941,7 +4941,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4949,10 +4949,10 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.8.1",
+        "@askable-ui/context": "^0.8.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -4963,10 +4963,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.1"
+        "@askable-ui/core": "^0.8.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4986,10 +4986,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.1"
+        "@askable-ui/core": "^0.8.2"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -5104,10 +5104,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.1"
+        "@askable-ui/core": "^0.8.2"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -5144,10 +5144,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.1"
+        "@askable-ui/core": "^0.8.2"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.8.1"
+    "@askable-ui/context": "^0.8.2"
   },
   "devDependencies": {
     "jsdom": "^29.0.1",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.8.1';
+const ASKABLE_VERSION = '0.8.2';
 const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "MCP bridge for exposing Context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,7 +36,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.8.1",
+    "@askable-ui/context": "^0.8.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.1"
+    "@askable-ui/core": "^0.8.2"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.1"
+    "@askable-ui/core": "^0.8.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -74,6 +74,38 @@ const { focus, promptContext, ctx, destroy } = createAskableStore({ events: ['cl
 - `ctx.toPromptContext(options?)` — full serialization options (format, maxTokens, excludeKeys, …)
 - `ctx.serializeFocus(options?)` — structured `AskableSerializedFocus` object
 
+### `createAskableRegionCaptureStore(options?)`
+
+Starts an explicit region or circle selection overlay and exposes the captured Context packet as Svelte stores.
+
+```svelte
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { createAskableRegionCaptureStore } from '@askable-ui/svelte';
+
+  const capture = createAskableRegionCaptureStore({
+    includeViewport: true,
+    source: { app: 'analytics-dashboard' },
+    intent: 'answer with this selected area as context',
+  });
+  const { active, lastPacket } = capture;
+
+  onDestroy(capture.destroy);
+</script>
+
+<button on:click={() => capture.start()}>Select region</button>
+<button on:click={() => capture.start({ shape: 'circle' })}>Circle area</button>
+{#if $active}
+  <button on:click={capture.cancel}>Cancel</button>
+{/if}
+
+{#if $lastPacket}
+  <pre>{JSON.stringify($lastPacket, null, 2)}</pre>
+{/if}
+```
+
+The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+
 ### "Ask AI" button pattern
 
 Use `ctx.select()` to set context explicitly when a user clicks a button:

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.1"
+    "@askable-ui/core": "^0.8.2"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/svelte/src/__tests__/store.test.ts
+++ b/packages/svelte/src/__tests__/store.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { get } from 'svelte/store';
-import { createAskableStore } from '../askable.js';
+import { createAskableRegionCaptureStore, createAskableStore } from '../askable.js';
+
+function pointerEvent(type: string, x: number, y: number): PointerEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: x,
+    clientY: y,
+  });
+  Object.defineProperty(event, 'pointerId', { value: 1 });
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+  return event as PointerEvent;
+}
 
 describe('createAskableStore', () => {
   const elements: HTMLElement[] = [];
@@ -8,6 +20,7 @@ describe('createAskableStore', () => {
   afterEach(() => {
     elements.forEach((el) => el.parentNode?.removeChild(el));
     elements.length = 0;
+    document.getElementById('askable-region-capture')?.remove();
   });
 
   function makeEl(meta: object | string, text = ''): HTMLElement {
@@ -113,5 +126,79 @@ describe('createAskableStore', () => {
 
     unsub();
     scopedCtx.destroy();
+  });
+});
+
+describe('createAskableRegionCaptureStore', () => {
+  afterEach(() => {
+    document.getElementById('askable-region-capture')?.remove();
+  });
+
+  it('starts capture and exposes the captured packet', () => {
+    const capture = createAskableRegionCaptureStore({
+      source: { app: 'svelte-test' },
+      intent: 'explain selected area',
+    });
+
+    capture.start();
+    expect(get(capture.active)).toBe(true);
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 20, 30));
+    overlay.dispatchEvent(pointerEvent('pointermove', 80, 90));
+    overlay.dispatchEvent(pointerEvent('pointerup', 80, 90));
+
+    expect(get(capture.active)).toBe(false);
+    expect(get(capture.lastPacket)).toMatchObject({
+      protocol: 'askable.context',
+      source: { app: 'svelte-test' },
+      capture: {
+        mode: 'region',
+        gesture: 'drag',
+        intent: 'explain selected area',
+      },
+      target: {
+        bounds: { x: 20, y: 30, width: 60, height: 60 },
+        metadata: { shape: 'region', pointerType: 'mouse' },
+      },
+      privacy: { consent: 'explicit' },
+    });
+
+    capture.destroy();
+  });
+
+  it('supports circle capture overrides at start time', () => {
+    const capture = createAskableRegionCaptureStore();
+
+    capture.start({ shape: 'circle' });
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointermove', 50, 80));
+    overlay.dispatchEvent(pointerEvent('pointerup', 50, 80));
+
+    expect(get(capture.lastPacket)?.capture).toMatchObject({ mode: 'circle', gesture: 'circle' });
+    expect(get(capture.lastSelection)).toMatchObject({
+      shape: 'circle',
+      bounds: { x: 0, y: 20, width: 60, height: 60 },
+      center: { x: 30, y: 50 },
+      radius: 30,
+    });
+
+    capture.destroy();
+  });
+
+  it('cancels active capture from store state', () => {
+    const capture = createAskableRegionCaptureStore();
+
+    capture.start();
+    expect(get(capture.active)).toBe(true);
+
+    capture.cancel();
+
+    expect(get(capture.active)).toBe(false);
+    expect(document.getElementById('askable-region-capture')).toBeNull();
+
+    capture.destroy();
   });
 });

--- a/packages/svelte/src/askable.ts
+++ b/packages/svelte/src/askable.ts
@@ -1,6 +1,16 @@
 import { writable, derived, readonly } from 'svelte/store';
-import { createAskableContext, createAskableInspector } from '@askable-ui/core';
-import type { AskableEvent, AskableFocus, AskableContext, AskableInspectorOptions, AskableContextOptions } from '@askable-ui/core';
+import { createAskableContext, createAskableInspector, createAskableRegionCapture } from '@askable-ui/core';
+import type {
+  AskableEvent,
+  AskableFocus,
+  AskableContext,
+  AskableInspectorOptions,
+  AskableContextOptions,
+  AskableRegionCaptureHandle,
+  AskableRegionCaptureOptions,
+  AskableRegionCaptureSelection,
+  WebContextPacket,
+} from '@askable-ui/core';
 
 export interface AskableStoreOptions extends Pick<AskableContextOptions, 'name'> {
   events?: AskableEvent[];
@@ -13,6 +23,19 @@ export interface AskableStore {
   promptContext: ReturnType<typeof derived>;
   ctx: AskableContext;
   destroy: () => void;
+}
+
+export interface AskableRegionCaptureStoreOptions extends AskableStoreOptions, AskableRegionCaptureOptions {}
+
+export interface AskableRegionCaptureStore {
+  active: ReturnType<typeof readonly>;
+  lastPacket: ReturnType<typeof readonly>;
+  lastSelection: ReturnType<typeof readonly>;
+  ctx: AskableContext;
+  start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
+  cancel: () => void;
+  destroy: () => void;
+  isActive: () => boolean;
 }
 
 export function createAskableStore(options?: AskableStoreOptions) {
@@ -53,4 +76,75 @@ export function createAskableStore(options?: AskableStoreOptions) {
   }
 
   return { focus, promptContext, ctx, destroy };
+}
+
+export function createAskableRegionCaptureStore(
+  options: AskableRegionCaptureStoreOptions = {},
+): AskableRegionCaptureStore {
+  const { ctx, name, events, inspector, ...regionOptions } = options;
+  const askable = createAskableStore({ ctx, name, events, inspector });
+  const _active = writable(false);
+  const _lastPacket = writable<WebContextPacket | null>(null);
+  const _lastSelection = writable<AskableRegionCaptureSelection | null>(null);
+  let handle: AskableRegionCaptureHandle | null = null;
+
+  function destroyCapture() {
+    handle?.destroy();
+    handle = null;
+    _active.set(false);
+  }
+
+  function start(overrides?: Partial<AskableRegionCaptureOptions>) {
+    handle?.destroy();
+
+    const currentOptions = {
+      ...regionOptions,
+      ...overrides,
+    };
+
+    handle = createAskableRegionCapture(askable.ctx, {
+      ...currentOptions,
+      onCapture(packet, selection) {
+        _lastPacket.set(packet);
+        _lastSelection.set(selection);
+        handle = null;
+        _active.set(false);
+        currentOptions.onCapture?.(packet, selection);
+      },
+      onCancel() {
+        handle = null;
+        _active.set(false);
+        currentOptions.onCancel?.();
+      },
+    });
+
+    handle.start();
+    _active.set(true);
+  }
+
+  function cancel() {
+    handle?.cancel();
+    handle = null;
+    _active.set(false);
+  }
+
+  function destroy() {
+    destroyCapture();
+    askable.destroy();
+  }
+
+  function isActive() {
+    return handle?.isActive() ?? false;
+  }
+
+  return {
+    active: readonly(_active),
+    lastPacket: readonly(_lastPacket),
+    lastSelection: readonly(_lastSelection),
+    ctx: askable.ctx,
+    start,
+    cancel,
+    destroy,
+    isActive,
+  };
 }

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,6 +1,11 @@
 // Svelte 4 — store-based API
-export { createAskableStore } from './askable.js';
-export type { AskableStore, AskableStoreOptions } from './askable.js';
+export { createAskableRegionCaptureStore, createAskableStore } from './askable.js';
+export type {
+  AskableRegionCaptureStore,
+  AskableRegionCaptureStoreOptions,
+  AskableStore,
+  AskableStoreOptions,
+} from './askable.js';
 
 // Svelte 5 runes-based API:
 //   import { useAskable } from '@askable-ui/svelte/useAskable.svelte'

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -71,6 +71,36 @@ const { focus, promptContext } = useAskable({ events: ['click'] });
 
 The composable manages a shared singleton context per `events` configuration. Multiple `useAskable()` consumers with the same `events` reuse one observer lifecycle, while differing `events` configurations get isolated shared contexts of their own. Each shared context is automatically destroyed when its last consumer unmounts.
 
+### `useAskableRegionCapture(options?)`
+
+Starts an explicit region or circle selection overlay and emits a structured Context packet through the same `AskableContext`.
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useAskableRegionCapture } from '@askable-ui/vue';
+
+const capture = useAskableRegionCapture({
+  includeViewport: true,
+  source: { app: 'analytics-dashboard' },
+  intent: 'answer with this selected area as context',
+});
+
+const selectedContext = computed(() =>
+  capture.lastPacket.value ? JSON.stringify(capture.lastPacket.value, null, 2) : ''
+);
+</script>
+
+<template>
+  <button @click="capture.start()">Select region</button>
+  <button @click="capture.start({ shape: 'circle' })">Circle area</button>
+  <button v-if="capture.active.value" @click="capture.cancel()">Cancel</button>
+  <pre v-if="selectedContext">{{ selectedContext }}</pre>
+</template>
+```
+
+The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+
 ### "Ask AI" button pattern
 
 Use `ctx.select()` to set context explicitly when a user clicks a button:

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.1"
+    "@askable-ui/core": "^0.8.2"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/src/__tests__/useAskableRegionCapture.test.ts
+++ b/packages/vue/src/__tests__/useAskableRegionCapture.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { computed, defineComponent, nextTick } from 'vue';
+import { useAskableRegionCapture } from '../useAskableRegionCapture.js';
+import { track } from './helpers.js';
+
+function pointerEvent(type: string, x: number, y: number): PointerEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: x,
+    clientY: y,
+  });
+  Object.defineProperty(event, 'pointerId', { value: 1 });
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+  return event as PointerEvent;
+}
+
+async function flushAll() {
+  await flushPromises();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+afterEach(() => {
+  document.getElementById('askable-region-capture')?.remove();
+});
+
+describe('useAskableRegionCapture (Vue)', () => {
+  it('starts capture and exposes the captured packet', async () => {
+    const Consumer = defineComponent({
+      name: 'RegionCaptureConsumer',
+      setup() {
+        const capture = useAskableRegionCapture({
+          source: { app: 'vue-test' },
+          intent: 'explain selected area',
+        });
+        const packet = computed(() => capture.lastPacket.value ? JSON.stringify(capture.lastPacket.value) : 'null');
+        return {
+          active: capture.active,
+          packet,
+          start: capture.start,
+        };
+      },
+      template: `
+        <div>
+          <button type="button" @click="start()">Start</button>
+          <span data-testid="active">{{ String(active) }}</span>
+          <span data-testid="packet">{{ packet }}</span>
+        </div>
+      `,
+    });
+
+    const wrapper = track(mount(Consumer, { attachTo: document.body }));
+    await flushAll();
+
+    await wrapper.find('button').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="active"]').text()).toBe('true');
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 20, 30));
+    overlay.dispatchEvent(pointerEvent('pointermove', 80, 90));
+    overlay.dispatchEvent(pointerEvent('pointerup', 80, 90));
+    await flushAll();
+
+    expect(wrapper.find('[data-testid="active"]').text()).toBe('false');
+    const packet = JSON.parse(wrapper.find('[data-testid="packet"]').text());
+    expect(packet).toMatchObject({
+      protocol: 'askable.context',
+      source: { app: 'vue-test' },
+      capture: {
+        mode: 'region',
+        gesture: 'drag',
+        intent: 'explain selected area',
+      },
+      target: {
+        bounds: { x: 20, y: 30, width: 60, height: 60 },
+        metadata: { shape: 'region', pointerType: 'mouse' },
+      },
+      privacy: { consent: 'explicit' },
+    });
+  });
+
+  it('supports circle capture overrides at start time', async () => {
+    const Consumer = defineComponent({
+      name: 'CircleCaptureConsumer',
+      setup() {
+        const capture = useAskableRegionCapture();
+        const packet = computed(() => capture.lastPacket.value ? JSON.stringify(capture.lastPacket.value) : 'null');
+        return {
+          packet,
+          startCircle: () => capture.start({ shape: 'circle' }),
+        };
+      },
+      template: `
+        <div>
+          <button type="button" @click="startCircle()">Circle</button>
+          <span data-testid="packet">{{ packet }}</span>
+        </div>
+      `,
+    });
+
+    const wrapper = track(mount(Consumer, { attachTo: document.body }));
+    await flushAll();
+
+    await wrapper.find('button').trigger('click');
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointermove', 50, 80));
+    overlay.dispatchEvent(pointerEvent('pointerup', 50, 80));
+    await flushAll();
+
+    const packet = JSON.parse(wrapper.find('[data-testid="packet"]').text());
+    expect(packet.capture).toMatchObject({ mode: 'circle', gesture: 'circle' });
+    expect(packet.target).toMatchObject({
+      bounds: { x: 0, y: 20, width: 60, height: 60 },
+      metadata: {
+        shape: 'circle',
+        center: { x: 30, y: 50 },
+        radius: 30,
+      },
+    });
+  });
+
+  it('cancels active capture from Vue state', async () => {
+    const Consumer = defineComponent({
+      name: 'CancelCaptureConsumer',
+      setup() {
+        const capture = useAskableRegionCapture();
+        return {
+          active: capture.active,
+          start: capture.start,
+          cancel: capture.cancel,
+        };
+      },
+      template: `
+        <div>
+          <button data-testid="start" type="button" @click="start()">Start</button>
+          <button data-testid="cancel" type="button" @click="cancel()">Cancel</button>
+          <span data-testid="active">{{ String(active) }}</span>
+        </div>
+      `,
+    });
+
+    const wrapper = track(mount(Consumer, { attachTo: document.body }));
+    await flushAll();
+
+    await wrapper.find('[data-testid="start"]').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="active"]').text()).toBe('true');
+
+    await wrapper.find('[data-testid="cancel"]').trigger('click');
+    await flushAll();
+
+    expect(wrapper.find('[data-testid="active"]').text()).toBe('false');
+    expect(document.getElementById('askable-region-capture')).toBeNull();
+  });
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,4 +1,9 @@
 export { Askable } from './Askable.js';
 export { AskableInspector } from './AskableInspector.js';
 export { useAskable } from './useAskable.js';
+export { useAskableRegionCapture } from './useAskableRegionCapture.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
+export type {
+  UseAskableRegionCaptureOptions,
+  UseAskableRegionCaptureResult,
+} from './useAskableRegionCapture.js';

--- a/packages/vue/src/useAskableRegionCapture.ts
+++ b/packages/vue/src/useAskableRegionCapture.ts
@@ -1,0 +1,92 @@
+import { onUnmounted, ref, shallowRef } from 'vue';
+import {
+  createAskableRegionCapture,
+  type AskableContext,
+  type AskableRegionCaptureHandle,
+  type AskableRegionCaptureOptions,
+  type AskableRegionCaptureSelection,
+  type WebContextPacket,
+} from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export interface UseAskableRegionCaptureOptions
+  extends AskableRegionCaptureOptions,
+    Omit<UseAskableOptions, 'inspector'> {}
+
+export interface UseAskableRegionCaptureResult {
+  ctx: AskableContext;
+  active: ReturnType<typeof ref<boolean>>;
+  lastPacket: ReturnType<typeof shallowRef<WebContextPacket | null>>;
+  lastSelection: ReturnType<typeof shallowRef<AskableRegionCaptureSelection | null>>;
+  start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
+  cancel: () => void;
+  destroy: () => void;
+  isActive: () => boolean;
+}
+
+export function useAskableRegionCapture(
+  options: UseAskableRegionCaptureOptions = {},
+): UseAskableRegionCaptureResult {
+  const { ctx } = useAskable(options);
+  const active = ref(false);
+  const lastPacket = shallowRef<WebContextPacket | null>(null);
+  const lastSelection = shallowRef<AskableRegionCaptureSelection | null>(null);
+  let handle: AskableRegionCaptureHandle | null = null;
+
+  function destroy() {
+    handle?.destroy();
+    handle = null;
+    active.value = false;
+  }
+
+  function cancel() {
+    handle?.cancel();
+    handle = null;
+    active.value = false;
+  }
+
+  function start(overrides?: Partial<AskableRegionCaptureOptions>) {
+    handle?.destroy();
+
+    const currentOptions = {
+      ...options,
+      ...overrides,
+    };
+
+    handle = createAskableRegionCapture(ctx, {
+      ...currentOptions,
+      onCapture(packet, selection) {
+        lastPacket.value = packet;
+        lastSelection.value = selection;
+        handle = null;
+        active.value = false;
+        currentOptions.onCapture?.(packet, selection);
+      },
+      onCancel() {
+        handle = null;
+        active.value = false;
+        currentOptions.onCancel?.();
+      },
+    });
+
+    handle.start();
+    active.value = true;
+  }
+
+  function isActive() {
+    return handle?.isActive() ?? active.value;
+  }
+
+  onUnmounted(destroy);
+
+  return {
+    ctx,
+    active,
+    lastPacket,
+    lastSelection,
+    start,
+    cancel,
+    destroy,
+    isActive,
+  };
+}

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -142,3 +142,57 @@ const chatStore = createAskableStore({ ctx: sharedCtx });
 ```
 
 Use the private default for isolated widgets. Pass a shared `ctx` when multiple Svelte components need to agree on one Askable focus/history stream.
+
+---
+
+## `createAskableRegionCaptureStore(options?)`
+
+Factory that starts an explicit region or circle selection overlay and exposes the captured Context packet as Svelte stores.
+
+```ts
+import { createAskableRegionCaptureStore } from '@askable-ui/svelte';
+
+const capture = createAskableRegionCaptureStore({
+  includeViewport: true,
+  source: { app: 'dashboard' },
+  intent: 'answer with this selected area as context',
+});
+
+capture.start();
+capture.start({ shape: 'circle' });
+capture.cancel();
+```
+
+Always call `destroy()` in `onDestroy`:
+
+```ts
+import { onDestroy } from 'svelte';
+
+onDestroy(capture.destroy);
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `shape` | `'region' \| 'circle'` | Initial capture shape. Default: `'region'` |
+| `includeViewport` | `boolean` | Include viewport metadata in the emitted Context packet |
+| `source` | `WebContextSource` | App/page source metadata attached to the packet |
+| `intent` | `string` | User intent attached to the capture |
+| `ctx` | `AskableContext` | Optional context to share with other Svelte stores/components |
+| `events` | `AskableEvent[]` | Observation events for the underlying store context |
+| `onCapture` | `(packet, selection) => void` | Called after a region or circle is accepted |
+| `onCancel` | `() => void` | Called after active capture is cancelled |
+
+**Returns:**
+
+| Value | Type | Description |
+|---|---|---|
+| `active` | `Readable<boolean>` | Whether the overlay is active |
+| `lastPacket` | `Readable<WebContextPacket \| null>` | Last captured Context packet |
+| `lastSelection` | `Readable<AskableRegionCaptureSelection \| null>` | Last raw region/circle selection geometry |
+| `start` | `(overrides?) => void` | Starts capture, optionally overriding options for one capture |
+| `cancel` | `() => void` | Cancels the active overlay |
+| `destroy` | `() => void` | Cancels capture and destroys the underlying store context |
+| `isActive` | `() => boolean` | Reads the current overlay state |
+| `ctx` | `AskableContext` | Store context instance |

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.8.1`
-- Versioned current docs URL: `/docs/v0.8.1/`
+- Latest stable: `v0.8.2`
+- Versioned current docs URL: `/docs/v0.8.2/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.8.1/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.8.2/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -137,3 +137,50 @@ panelCtx.observe(panelEl, { events: ['click'] });
 
 const panel = useAskable({ ctx: panelCtx });
 ```
+
+---
+
+## `useAskableRegionCapture(options?)`
+
+Composable that starts an explicit region or circle selection overlay and emits a structured Context packet through the same `AskableContext`.
+
+```ts
+import { useAskableRegionCapture } from '@askable-ui/vue';
+
+const capture = useAskableRegionCapture({
+  includeViewport: true,
+  source: { app: 'dashboard' },
+  intent: 'answer with this selected area as context',
+});
+
+capture.start();
+capture.start({ shape: 'circle' });
+capture.cancel();
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `shape` | `'region' \| 'circle'` | Initial capture shape. Default: `'region'` |
+| `includeViewport` | `boolean` | Include viewport metadata in the emitted Context packet |
+| `source` | `WebContextSource` | App/page source metadata attached to the packet |
+| `intent` | `string` | User intent attached to the capture |
+| `ctx` | `AskableContext` | Optional context to share with other Vue consumers |
+| `name` | `string` | Optional shared context name when `ctx` is not provided |
+| `events` | `AskableEvent[]` | Observation events for the underlying `useAskable()` context |
+| `onCapture` | `(packet, selection) => void` | Called after a region or circle is accepted |
+| `onCancel` | `() => void` | Called after active capture is cancelled |
+
+**Returns:**
+
+| Value | Type | Description |
+|---|---|---|
+| `active` | `Ref<boolean>` | Whether the overlay is active |
+| `lastPacket` | `ShallowRef<WebContextPacket \| null>` | Last captured Context packet |
+| `lastSelection` | `ShallowRef<AskableRegionCaptureSelection \| null>` | Last raw region/circle selection geometry |
+| `start` | `(overrides?) => void` | Starts capture, optionally overriding options for one capture |
+| `cancel` | `() => void` | Cancels the active overlay |
+| `destroy` | `() => void` | Cancels capture and removes overlay listeners |
+| `isActive` | `() => boolean` | Reads the current overlay state |
+| `ctx` | `AskableContext` | Shared or provided context instance |

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -129,7 +129,7 @@ The resulting packet uses `capture.mode` of `region` or `circle`, sets
 `privacy.consent` to `explicit`, and places the selected bounds on
 `target.bounds`.
 
-React apps can use the wrapper hook instead:
+Framework apps can use wrapper APIs instead:
 
 ```tsx
 import { useAskable, useAskableRegionCapture } from '@askable-ui/react';
@@ -137,6 +137,24 @@ import { useAskable, useAskableRegionCapture } from '@askable-ui/react';
 const { ctx } = useAskable({ viewport: true });
 const capture = useAskableRegionCapture({
   ctx,
+  includeViewport: true,
+  onCapture: (packet) => sendToAgent(packet),
+});
+```
+
+```ts
+import { useAskableRegionCapture } from '@askable-ui/vue';
+
+const capture = useAskableRegionCapture({
+  includeViewport: true,
+  onCapture: (packet) => sendToAgent(packet),
+});
+```
+
+```ts
+import { createAskableRegionCaptureStore } from '@askable-ui/svelte';
+
+const capture = createAskableRegionCaptureStore({
   includeViewport: true,
   onCapture: (packet) => sendToAgent(packet),
 });

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.8.1**.
+> Current npm release: **v0.8.2**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,13 +1,13 @@
-# What’s New in v0.8.1
+# What’s New in v0.8.2
 
-askable-ui v0.8.1 adds React and starter-app support for explicit region and
-circle capture in "send this part of the page" agent workflows.
+askable-ui v0.8.2 expands explicit region and circle capture across the web
+framework adapters for "send this part of the page" agent workflows.
 
 ## Highlights
 
-### React region and circle capture
+### Framework region and circle capture
 
-`@askable-ui/react` now exports `useAskableRegionCapture()`:
+React exports `useAskableRegionCapture()`:
 
 ```tsx
 const { ctx } = useAskable({ viewport: true });
@@ -22,10 +22,32 @@ const capture = useAskableRegionCapture({
 capture.start({ shape: 'circle' });
 ```
 
-The hook mounts a temporary drag overlay and emits a Context packet with
+Vue now exports the matching composable:
+
+```ts
+const capture = useAskableRegionCapture({
+  includeViewport: true,
+  source: { app: 'dashboard' },
+});
+
+capture.start();
+capture.start({ shape: 'circle' });
+```
+
+Svelte now exports a store-based helper:
+
+```ts
+const capture = createAskableRegionCaptureStore({
+  intent: 'explain this selected area',
+});
+
+capture.start({ shape: 'circle' });
+```
+
+Each wrapper mounts a temporary drag overlay and emits a Context packet with
 `capture.mode` set to `region` or `circle`, explicit consent metadata, and the
-selected geometry in `target.bounds`. It also exposes `active`, `lastPacket`,
-`lastSelection`, `cancel()`, and `destroy()` for React UI state.
+selected geometry in `target.bounds`. They also expose `active`, `lastPacket`,
+`lastSelection`, `cancel()`, and `destroy()` for framework-native UI state.
 
 Use it when you want to:
 
@@ -38,6 +60,8 @@ Related docs:
 
 - [Context Packets](/guide/context)
 - [@askable-ui/react API](/api/react)
+- [@askable-ui/vue API](/api/vue)
+- [@askable-ui/svelte API](/api/svelte)
 
 ### Browser-level capture coverage
 
@@ -51,7 +75,7 @@ pushes the last selected page area into CopilotKit readable context.
 
 ### 0.8 release path
 
-All workspace packages have been bumped to `0.8.1`.
+All workspace packages have been bumped to `0.8.2`.
 
 ## Recommended next step
 
@@ -63,7 +87,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.8.1** at both:
+The current published docs track **v0.8.2** at both:
 
 - `/docs/`
-- `/docs/v0.8.1/`
+- `/docs/v0.8.2/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.8.1**.
+> Current npm release: **v0.8.2**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,16 +59,17 @@ features:
   </video>
 </div>
 
-## Latest in v0.8.1
+## Latest in v0.8.2
 
 - `useAskableRegionCapture()` for React region and circle context selection
+- `useAskableRegionCapture()` for Vue and `createAskableRegionCaptureStore()` for Svelte
 - starter app region/circle buttons wired into CopilotKit readable context
 - full browser e2e coverage for core region and circle packet capture
 - continued support for Context packets, MCP tools/resources, and framework wrappers
 
 Start here:
 
-- [What’s New in v0.8.1](/guide/whats-new)
+- [What’s New in v0.8.2](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.8.1",
-    "slug": "v0.8.1"
+    "label": "v0.8.2",
+    "slug": "v0.8.2"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.8.1`) is built on every deploy and published to both:
+The current release (`v0.8.2`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.8.1/` (version-specific URL)
+- `/docs/v0.8.2/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- add Vue useAskableRegionCapture composable for region/circle Context packet capture
- add Svelte createAskableRegionCaptureStore with active/last packet/selection stores
- document the new adapter APIs and bump workspace release metadata to 0.8.2

## Validation
- npm test
- npm run build
- npm run build --prefix site/docs
- node scripts/check-example-askable-versions.mjs
- npm audit --json
- npm run test:e2e
- npm pack ./packages/vue --dry-run --json
- npm pack ./packages/svelte --dry-run --json

Note: Vercel preview may fail until 0.8.2 packages are published, matching the existing unpublished-version PR behavior.