### PR TITLE
chore(release): bump 0.8.3

### DIFF
--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.8.2",
+    "@askable-ui/react": "^0.8.3",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.2",
-    "@askable-ui/react-native": "^0.8.2",
+    "@askable-ui/core": "^0.8.3",
+    "@askable-ui/react-native": "^0.8.3",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "workspaces": [
         "packages/*"
       ],
@@ -4919,7 +4919,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.2",
@@ -4928,10 +4928,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.8.2"
+        "@askable-ui/context": "^0.8.3"
       },
       "devDependencies": {
         "jsdom": "^29.0.1",
@@ -4941,7 +4941,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4949,10 +4949,10 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.8.2",
+        "@askable-ui/context": "^0.8.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -4963,10 +4963,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.2"
+        "@askable-ui/core": "^0.8.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4986,10 +4986,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.2"
+        "@askable-ui/core": "^0.8.3"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -5104,10 +5104,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.2"
+        "@askable-ui/core": "^0.8.3"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -5144,10 +5144,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.2"
+        "@askable-ui/core": "^0.8.3"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.8.2"
+    "@askable-ui/context": "^0.8.3"
   },
   "devDependencies": {
     "jsdom": "^29.0.1",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.8.2';
+const ASKABLE_VERSION = '0.8.3';
 const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "MCP bridge for exposing Context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,7 +36,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.8.2",
+    "@askable-ui/context": "^0.8.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.2"
+    "@askable-ui/core": "^0.8.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.2"
+    "@askable-ui/core": "^0.8.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.2"
+    "@askable-ui/core": "^0.8.3"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.2"
+    "@askable-ui/core": "^0.8.3"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.8.2`
-- Versioned current docs URL: `/docs/v0.8.2/`
+- Latest stable: `v0.8.3`
+- Versioned current docs URL: `/docs/v0.8.3/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.8.2/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.8.3/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.8.2**.
+> Current npm release: **v0.8.3**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,6 +1,6 @@
-# What’s New in v0.8.2
+# What’s New in v0.8.3
 
-askable-ui v0.8.2 expands explicit region and circle capture across the web
+askable-ui v0.8.3 expands explicit region and circle capture across the web
 framework adapters for "send this part of the page" agent workflows.
 
 ## Highlights
@@ -75,7 +75,7 @@ pushes the last selected page area into CopilotKit readable context.
 
 ### 0.8 release path
 
-All workspace packages have been bumped to `0.8.2`.
+All workspace packages have been bumped to `0.8.3`.
 
 ## Recommended next step
 
@@ -87,7 +87,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.8.2** at both:
+The current published docs track **v0.8.3** at both:
 
 - `/docs/`
-- `/docs/v0.8.2/`
+- `/docs/v0.8.3/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.8.2**.
+> Current npm release: **v0.8.3**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,7 +59,7 @@ features:
   </video>
 </div>
 
-## Latest in v0.8.2
+## Latest in v0.8.3
 
 - `useAskableRegionCapture()` for React region and circle context selection
 - `useAskableRegionCapture()` for Vue and `createAskableRegionCaptureStore()` for Svelte
@@ -69,7 +69,7 @@ features:
 
 Start here:
 
-- [What’s New in v0.8.2](/guide/whats-new)
+- [What’s New in v0.8.3](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.8.2",
-    "slug": "v0.8.2"
+    "label": "v0.8.3",
+    "slug": "v0.8.3"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.8.2`) is built on every deploy and published to both:
+The current release (`v0.8.3`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.8.2/` (version-specific URL)
+- `/docs/v0.8.3/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- bump workspace packages and docs from 0.8.2 to 0.8.3
- keep example dependency ranges aligned with the release version
- prepare a corrective publish after the 0.8.2 artifacts were kept off latest

## Validation
- npm test
- npm run build
- npm run build --prefix site/docs
- node scripts/check-example-askable-versions.mjs
- npm audit --json
- npm pack dry-run for all publishable packages, verifying dist output is present where required

Note: Vercel preview may fail until 0.8.3 packages are published, matching the existing unpublished-version PR behavior.