### PR TITLE
ci(release): skip duplicate release dispatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,19 @@ jobs:
           script: |
             const tag = process.env.RELEASE_TAG;
             const isPrerelease = process.env.IS_PRERELEASE === 'true';
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              core.notice(`Release ${tag} already exists; skipping.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -46,17 +46,19 @@ jobs:
             echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
-            CHANGED=$(git diff HEAD~1 HEAD --name-only -- 'packages/core/package.json' | head -1)
-            if [ -z "$CHANGED" ]; then
+            VERSION=$(node -p "require('./packages/core/package.json').version")
+            PREVIOUS_VERSION=$(git show HEAD~1:packages/core/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+            if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then
+              echo "Version is still $VERSION; skipping release dispatch."
               echo "changed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            VERSION=$(node -p "require('./packages/core/package.json').version")
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Push git tag
+        id: tag
         if: steps.version.outputs.changed == 'true'
         env:
           TAG_VERSION: ${{ steps.version.outputs.version }}
@@ -64,11 +66,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           TAG="v${TAG_VERSION}"
-          git tag "$TAG" 2>&1 || echo "::warning::Tag $TAG already exists locally"
-          git push origin "$TAG" 2>&1 || echo "::warning::Failed to push tag $TAG (may already exist)"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists; skipping release dispatch."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Trigger publish workflow
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.changed == 'true' && steps.tag.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_VERSION: ${{ steps.version.outputs.version }}
@@ -78,7 +86,7 @@ jobs:
             --ref "v${TAG_VERSION}"
 
       - name: Trigger GitHub Release
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.changed == 'true' && steps.tag.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
- Compare the package version value before auto-tagging so dependency-only package.json edits do not dispatch release workflows.
- Skip publish and GitHub Release dispatches when the tag already exists remotely.
- Make GitHub Release creation idempotent when a release for the tag already exists.

## Validation
- Parsed updated workflow YAML with Ruby.
- Ran the tag resolver logic locally against the current main commit and confirmed it emits changed=false for version 0.8.3.
- Ran git diff --check.