### PR TITLE
feat(mcp): add askable context provider

### DIFF
--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.8.3",
+    "@askable-ui/react": "^0.9.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.3",
-    "@askable-ui/react-native": "^0.8.3",
+    "@askable-ui/core": "^0.9.0",
+    "@askable-ui/react-native": "^0.9.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "workspaces": [
         "packages/*"
       ],
@@ -4844,7 +4844,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -4867,10 +4867,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.8.3"
+        "@askable-ui/context": "^0.9.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -4894,7 +4894,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4902,10 +4902,11 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.8.3",
+        "@askable-ui/context": "^0.9.0",
+        "@askable-ui/core": "^0.9.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -4930,10 +4931,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.3"
+        "@askable-ui/core": "^0.9.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4953,10 +4954,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.3"
+        "@askable-ui/core": "^0.9.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.15",
@@ -5128,10 +5129,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.3"
+        "@askable-ui/core": "^0.9.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -5162,10 +5163,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.8.3"
+        "@askable-ui/core": "^0.9.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.8.3"
+    "@askable-ui/context": "^0.9.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.8.3';
+const ASKABLE_VERSION = '0.9.0';
 const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -7,14 +7,25 @@ that return the current packet, the packet schema, and a prompt-ready text
 rendering.
 
 ```ts
-import { createAskableMcpServer } from '@askable-ui/mcp';
+import { createAskableContext } from '@askable-ui/core';
+import { createAskableMcpContextProvider, createAskableMcpServer } from '@askable-ui/mcp';
+
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
 
 const server = createAskableMcpServer({
-  provider: {
-    getContext: () => ctx.toContextPacket({ history: 3, includeViewport: true }),
-  },
+  provider: createAskableMcpContextProvider(ctx, {
+    history: 3,
+    includeViewport: true,
+    source: { app: 'analytics-dashboard' },
+  }),
 });
 ```
+
+The built-in provider adapts `ctx.toContextPacket()` and `ctx.toContext()` to
+the MCP tools. Tool callers can request prompt shaping options such as `scope`,
+`preset`, `format`, `includeText`, `maxTextLength`, `maxTokens`, `history`, and
+`includeViewport`.
 
 Transports are intentionally left to the host app so the same server factory can
 be used with stdio, Streamable HTTP, or an embedded web runtime.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "MCP bridge for exposing Context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,7 +36,8 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.8.3",
+    "@askable-ui/context": "^0.9.0",
+    "@askable-ui/core": "^0.9.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWebContextPacket } from '@askable-ui/context';
+import {
+  createAskableMcpContextProvider,
+  defaultPromptFormatter,
+  type AskableMcpSourceContext,
+} from '../index.js';
+
+describe('createAskableMcpContextProvider', () => {
+  it('adapts an Askable context to an MCP context provider', async () => {
+    const packet = createWebContextPacket({
+      source: { app: 'test-app' },
+      capture: { mode: 'element-focus' },
+      privacy: { consent: 'explicit' },
+    });
+    const ctx = {
+      toContextPacket: vi.fn(() => packet),
+      toContext: vi.fn(() => 'Prompt context'),
+    } satisfies AskableMcpSourceContext;
+
+    const provider = createAskableMcpContextProvider(ctx, {
+      history: 2,
+      includeViewport: true,
+      source: { app: 'default-app' },
+      privacy: { consent: 'implicit' },
+      provenance: { producer: 'default-producer' },
+    });
+
+    await expect(Promise.resolve(provider.getContext({
+      intent: 'explain selected UI',
+      privacy: { consent: 'explicit', omitted: ['email'] },
+      provenance: { method: 'mcp' },
+    }))).resolves.toBe(packet);
+
+    expect(ctx.toContextPacket).toHaveBeenCalledWith({
+      history: 2,
+      includeViewport: true,
+      intent: 'explain selected UI',
+      source: { app: 'default-app' },
+      privacy: { consent: 'explicit', omitted: ['email'] },
+      provenance: { producer: 'default-producer', method: 'mcp' },
+    });
+  });
+
+  it('formats prompt text from the source context with prompt-safe options', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'element-focus' },
+    });
+    const ctx = {
+      toContextPacket: vi.fn(() => packet),
+      toContext: vi.fn(() => 'Scoped prompt context'),
+    } satisfies AskableMcpSourceContext;
+    const provider = createAskableMcpContextProvider(ctx, {
+      currentLabel: 'Current UI',
+      includeViewport: true,
+      source: { app: 'dashboard' },
+    });
+
+    await expect(Promise.resolve(provider.formatContextForPrompt?.(packet, {
+      history: 3,
+      intent: 'summarize this region',
+      scope: 'analytics',
+      includeText: false,
+      maxTokens: 50,
+    }))).resolves.toBe('Scoped prompt context');
+
+    expect(ctx.toContext).toHaveBeenCalledWith({
+      currentLabel: 'Current UI',
+      history: 3,
+      scope: 'analytics',
+      includeText: false,
+      maxTokens: 50,
+    });
+  });
+});
+
+describe('defaultPromptFormatter', () => {
+  it('renders the packet fields that are useful for prompts', () => {
+    const packet = createWebContextPacket({
+      source: {
+        url: 'https://example.com/dashboard',
+        title: 'Analytics',
+      },
+      capture: {
+        mode: 'region',
+        intent: 'explain the highlighted chart',
+      },
+      target: {
+        text: 'Revenue rose 12%',
+        metadata: { metric: 'revenue', delta: '+12%' },
+      },
+      surrounding: {
+        visible: [{ metadata: { metric: 'churn' }, text: 'Churn is 4.2%' }],
+        history: [{ metadata: { metric: 'pipeline' }, text: 'Pipeline is $8.1M' }],
+      },
+    });
+
+    expect(defaultPromptFormatter(packet)).toBe([
+      'Context mode: region',
+      'User intent: explain the highlighted chart',
+      'URL: https://example.com/dashboard',
+      'Title: Analytics',
+      'Target text: Revenue rose 12%',
+      'Target metadata: {"metric":"revenue","delta":"+12%"}',
+      'Visible context: [{"metadata":{"metric":"churn"},"text":"Churn is 4.2%"}]',
+      'Recent context: [{"metadata":{"metric":"pipeline"},"text":"Pipeline is $8.1M"}]',
+    ].join('\n'));
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,16 +2,25 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { webContextPacketSchema } from '@askable-ui/context';
 import type { WebContextPacket } from '@askable-ui/context';
+import type {
+  AskableContext,
+  AskableContextOutputOptions,
+  AskableContextPacketOptions,
+  AskablePromptFormat,
+  AskablePromptPreset,
+} from '@askable-ui/core';
 
-export interface AskableMcpContextOptions {
-  history?: number;
-  includeViewport?: boolean;
-  intent?: string;
+export interface AskableMcpContextOptions extends AskableContextPacketOptions {
+  currentLabel?: string;
+  historyLabel?: string;
 }
 
 export interface AskableMcpContextProvider {
   getContext(options?: AskableMcpContextOptions): WebContextPacket | Promise<WebContextPacket>;
-  formatContextForPrompt?(packet: WebContextPacket): string | Promise<string>;
+  formatContextForPrompt?(
+    packet: WebContextPacket,
+    options?: AskableMcpContextOptions,
+  ): string | Promise<string>;
 }
 
 export interface AskableMcpServerOptions {
@@ -20,11 +29,38 @@ export interface AskableMcpServerOptions {
   provider: AskableMcpContextProvider;
 }
 
+export type AskableMcpSourceContext = Pick<AskableContext, 'toContextPacket' | 'toContext'>;
+
+export interface CreateAskableMcpContextProviderOptions extends AskableMcpContextOptions {}
+
 const contextOptionsShape = {
+  scope: z.string().optional(),
+  preset: z.enum(['compact', 'verbose', 'json']).optional(),
+  format: z.enum(['natural', 'json']).optional(),
+  includeText: z.boolean().optional(),
+  maxTextLength: z.number().int().min(0).max(100_000).optional(),
+  maxTokens: z.number().int().min(1).max(100_000).optional(),
+  hierarchyDepth: z.number().int().min(0).max(50).optional(),
   history: z.number().int().min(0).max(50).optional(),
   includeViewport: z.boolean().optional(),
   intent: z.string().optional(),
+  currentLabel: z.string().optional(),
+  historyLabel: z.string().optional(),
 };
+
+export function createAskableMcpContextProvider(
+  ctx: AskableMcpSourceContext,
+  defaults: CreateAskableMcpContextProviderOptions = {},
+): AskableMcpContextProvider {
+  return {
+    getContext(options) {
+      return ctx.toContextPacket(mergeContextOptions(defaults, options));
+    },
+    formatContextForPrompt(_packet, options) {
+      return ctx.toContext(toPromptOptions(mergeContextOptions(defaults, options)));
+    },
+  };
+}
 
 export function createAskableMcpServer(options: AskableMcpServerOptions): McpServer {
   const server = new McpServer({
@@ -100,7 +136,7 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
     async (args) => {
       const packet = await options.provider.getContext(args);
       const text = options.provider.formatContextForPrompt
-        ? await options.provider.formatContextForPrompt(packet)
+        ? await options.provider.formatContextForPrompt(packet, args)
         : defaultPromptFormatter(packet);
 
       return {
@@ -130,4 +166,43 @@ export function defaultPromptFormatter(packet: WebContextPacket): string {
   ];
 
   return parts.filter((part): part is string => Boolean(part)).join('\n');
+}
+
+function mergeContextOptions(
+  defaults: AskableMcpContextOptions,
+  options?: AskableMcpContextOptions,
+): AskableMcpContextOptions {
+  return {
+    ...defaults,
+    ...options,
+    ...(defaults.source || options?.source
+      ? { source: { ...defaults.source, ...options?.source } }
+      : {}),
+    ...(defaults.privacy || options?.privacy
+      ? { privacy: { ...defaults.privacy, ...options?.privacy } }
+      : {}),
+    ...(defaults.provenance || options?.provenance
+      ? { provenance: { ...defaults.provenance, ...options?.provenance } }
+      : {}),
+  };
+}
+
+function toPromptOptions(options: AskableMcpContextOptions): AskableContextOutputOptions {
+  const {
+    includeViewport: _includeViewport,
+    intent: _intent,
+    mode: _mode,
+    gesture: _gesture,
+    target: _target,
+    source: _source,
+    privacy: _privacy,
+    provenance: _provenance,
+    ...promptOptions
+  } = options;
+
+  return {
+    ...promptOptions,
+    ...(promptOptions.preset ? { preset: promptOptions.preset as AskablePromptPreset } : {}),
+    ...(promptOptions.format ? { format: promptOptions.format as AskablePromptFormat } : {}),
+  };
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.3"
+    "@askable-ui/core": "^0.9.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.15",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.3"
+    "@askable-ui/core": "^0.9.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.3"
+    "@askable-ui/core": "^0.9.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.8.3"
+    "@askable-ui/core": "^0.9.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -7,14 +7,32 @@ npm install @askable-ui/mcp
 ```
 
 ```ts
-import { createAskableMcpServer } from '@askable-ui/mcp';
+import { createAskableContext } from '@askable-ui/core';
+import { createAskableMcpContextProvider, createAskableMcpServer } from '@askable-ui/mcp';
+
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
 
 const server = createAskableMcpServer({
-  provider: {
-    getContext: (options) => ctx.toContextPacket(options),
-  },
+  provider: createAskableMcpContextProvider(ctx, {
+    history: 3,
+    includeViewport: true,
+    source: { app: 'analytics-dashboard' },
+  }),
 });
 ```
+
+## `createAskableMcpContextProvider(ctx, defaults?)`
+
+Adapts an existing `AskableContext` to the MCP provider interface.
+
+| Option | Type | Description |
+|---|---|---|
+| `ctx` | `Pick<AskableContext, 'toContextPacket' \| 'toContext'>` | Source context to expose through MCP |
+| `defaults` | `AskableMcpContextOptions` | Default packet and prompt options applied to every tool call |
+
+Defaults and tool-call options are merged. Nested `source`, `privacy`, and
+`provenance` metadata are merged field-by-field.
 
 ## `createAskableMcpServer(options)`
 
@@ -23,9 +41,28 @@ Creates an MCP server with tools/resources for reading structured Context packet
 | Option | Type | Description |
 |---|---|---|
 | `provider.getContext` | `(options) => WebContextPacket \| Promise<WebContextPacket>` | Supplies the current packet |
-| `provider.formatContextForPrompt` | `(packet) => string \| Promise<string>` | Optional custom prompt formatter |
+| `provider.formatContextForPrompt` | `(packet, options) => string \| Promise<string>` | Optional custom prompt formatter |
 | `name` | `string` | MCP server name |
 | `version` | `string` | MCP server version |
+
+## Tool options
+
+`get_current_context` and `format_context_for_prompt` accept common context
+options:
+
+| Option | Description |
+|---|---|
+| `scope` | Filter context to a named UI scope |
+| `preset` | Use `compact`, `verbose`, or `json` prompt defaults |
+| `format` | Use `natural` or `json` prompt output |
+| `includeText` | Include or omit target text |
+| `maxTextLength` | Truncate extracted text |
+| `maxTokens` | Apply an approximate prompt budget |
+| `hierarchyDepth` | Limit included ancestor hierarchy |
+| `history` | Include recent interactions |
+| `includeViewport` | Include visible annotated elements in packets |
+| `intent` | Attach user intent to packets |
+| `currentLabel` / `historyLabel` | Customize prompt section labels |
 
 ## Registered MCP surface
 

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.8.3`
-- Versioned current docs URL: `/docs/v0.8.3/`
+- Latest stable: `v0.9.0`
+- Versioned current docs URL: `/docs/v0.9.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.8.3/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.9.0/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -52,16 +52,17 @@ route context before sending it to a model.
 
 ## MCP bridge
 
-`@askable-ui/mcp` exposes packets through MCP tools and resources. The host
-application provides a context provider:
+`@askable-ui/mcp` exposes packets through MCP tools and resources. The built-in
+provider adapts an existing `AskableContext`:
 
 ```ts
-import { createAskableMcpServer } from '@askable-ui/mcp';
+import { createAskableMcpContextProvider, createAskableMcpServer } from '@askable-ui/mcp';
 
 const server = createAskableMcpServer({
-  provider: {
-    getContext: (options) => ctx.toContextPacket(options),
-  },
+  provider: createAskableMcpContextProvider(ctx, {
+    history: 3,
+    includeViewport: true,
+  }),
 });
 ```
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.8.3**.
+> Current npm release: **v0.9.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,81 +1,52 @@
-# What’s New in v0.8.3
+# What’s New in v0.9.0
 
-askable-ui v0.8.3 expands explicit region and circle capture across the web
-framework adapters for "send this part of the page" agent workflows.
+askable-ui v0.9.0 makes the MCP bridge easier to wire into agent runtimes by
+adding a first-class provider for existing Askable contexts.
 
 ## Highlights
 
-### Framework region and circle capture
+### First-class MCP context provider
 
-React exports `useAskableRegionCapture()`:
-
-```tsx
-const { ctx } = useAskable({ viewport: true });
-const capture = useAskableRegionCapture({
-  ctx,
-  shape: 'circle',
-  intent: 'explain this selected area',
-  includeViewport: true,
-  onCapture: (packet) => sendToAgent(packet),
-});
-
-capture.start({ shape: 'circle' });
-```
-
-Vue now exports the matching composable:
+`@askable-ui/mcp` now exports `createAskableMcpContextProvider()` so apps can
+publish the same context they already use in their UI directly through MCP
+tools and resources.
 
 ```ts
-const capture = useAskableRegionCapture({
-  includeViewport: true,
-  source: { app: 'dashboard' },
-});
+import { createAskableContext } from '@askable-ui/core';
+import { createAskableMcpContextProvider, createAskableMcpServer } from '@askable-ui/mcp';
 
-capture.start();
-capture.start({ shape: 'circle' });
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
+
+const server = createAskableMcpServer({
+  provider: createAskableMcpContextProvider(ctx, {
+    history: 3,
+    includeViewport: true,
+    source: { app: 'analytics-dashboard' },
+  }),
+});
 ```
 
-Svelte now exports a store-based helper:
-
-```ts
-const capture = createAskableRegionCaptureStore({
-  intent: 'explain this selected area',
-});
-
-capture.start({ shape: 'circle' });
-```
-
-Each wrapper mounts a temporary drag overlay and emits a Context packet with
-`capture.mode` set to `region` or `circle`, explicit consent metadata, and the
-selected geometry in `target.bounds`. They also expose `active`, `lastPacket`,
-`lastSelection`, `cancel()`, and `destroy()` for framework-native UI state.
-
-Use it when you want to:
-
-- let a user circle part of a chart, table, or canvas
-- send a visible page region to an agent
-- combine manual selection geometry with viewport and focus context
-- build screenshot or browser-extension capture flows on top of the same packet shape
+The provider adapts `ctx.toContextPacket()` for structured packet tools and
+`ctx.toContext()` for prompt-ready text tools. Callers can request prompt
+shaping options such as `scope`, `preset`, `format`, `includeText`,
+`maxTextLength`, `maxTokens`, `history`, and `includeViewport`.
 
 Related docs:
 
 - [Context Packets](/guide/context)
-- [@askable-ui/react API](/api/react)
-- [@askable-ui/vue API](/api/vue)
-- [@askable-ui/svelte API](/api/svelte)
+- [@askable-ui/mcp API](/api/mcp)
 
-### Browser-level capture coverage
+### Expanded MCP prompt controls
 
-The core capture path now has Playwright coverage that exercises real pointer
-drag selection in Chromium, Firefox, and WebKit through the bundled browser API.
+The MCP bridge now accepts the same common prompt controls as the core context
+serializer, so MCP clients can ask for compact, JSON, scoped, or text-limited
+context without each host app inventing its own tool contract.
 
-### Starter app capture controls
+### Starter and docs version alignment
 
-`npm create @askable-ui/app` now scaffolds region and circle capture buttons and
-pushes the last selected page area into CopilotKit readable context.
-
-### 0.8 release path
-
-All workspace packages have been bumped to `0.8.3`.
+`npm create @askable-ui/app` now scaffolds projects pinned to `^0.9.0`, and the
+versioned docs have been advanced to `/docs/v0.9.0/`.
 
 ## Recommended next step
 
@@ -87,7 +58,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.8.3** at both:
+The current published docs track **v0.9.0** at both:
 
 - `/docs/`
-- `/docs/v0.8.3/`
+- `/docs/v0.9.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.8.3**.
+> Current npm release: **v0.9.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,17 +59,16 @@ features:
   </video>
 </div>
 
-## Latest in v0.8.3
+## Latest in v0.9.0
 
-- `useAskableRegionCapture()` for React region and circle context selection
-- `useAskableRegionCapture()` for Vue and `createAskableRegionCaptureStore()` for Svelte
-- starter app region/circle buttons wired into CopilotKit readable context
-- full browser e2e coverage for core region and circle packet capture
-- continued support for Context packets, MCP tools/resources, and framework wrappers
+- `createAskableMcpContextProvider()` for wiring existing Askable contexts into MCP servers
+- expanded MCP tool options for scoped, compact, JSON, and token-limited context
+- starter app dependency pins advanced to `^0.9.0`
+- continued support for region/circle capture, Context packets, and framework wrappers
 
 Start here:
 
-- [What’s New in v0.8.3](/guide/whats-new)
+- [What’s New in v0.9.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.8.3",
-    "slug": "v0.8.3"
+    "label": "v0.9.0",
+    "slug": "v0.9.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.8.3`) is built on every deploy and published to both:
+The current release (`v0.9.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.8.3/` (version-specific URL)
+- `/docs/v0.9.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- Add createAskableMcpContextProvider() to adapt an existing AskableContext directly into the MCP provider interface.
- Expand MCP tool options for scoped, preset, JSON, text-limited, history, viewport, and intent-aware context calls.
- Add MCP package tests for provider option merging and prompt formatting.
- Bump workspace packages, examples, starter scaffold, and docs to 0.9.0.

## Validation
- npm ci
- npm test
- npm run build
- npm audit --audit-level=moderate
- node scripts/check-example-askable-versions.mjs
- npm run build --prefix site/docs
- npm run test:e2e
- npm ls @askable-ui/context @askable-ui/core @askable-ui/mcp --workspaces --all
- npm pack --dry-run --json --workspaces
- git diff --check