### PR TITLE
feat(core): add text selection context capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it
 - **Conversation history** — `ctx.toHistoryContext(n)` for multi-turn context
 - **Viewport awareness** — `ctx.getVisibleElements()` / `ctx.toViewportContext()` for on-screen context
 - **Structured Context packets** — `ctx.toContextPacket()` for agent/MCP-ready page context
+- **Explicit capture tools** — region, circle, and highlighted text capture for user-selected context
 - **Redaction hooks** — strip sensitive fields before data reaches serialization
 - **Inspector panel** — `<AskableInspector />` or `useAskable({ inspector: true })` for a live dev overlay
 - **Agent templates** — reusable `AGENTS.md` guidance and copy-paste prompts for coding-agent-driven adoption

--- a/e2e/observer.spec.ts
+++ b/e2e/observer.spec.ts
@@ -247,6 +247,60 @@ test.describe('region capture', () => {
   });
 });
 
+test.describe('text selection capture', () => {
+  test('capturing highlighted text emits a structured Context packet', async ({ harness }) => {
+    const page = await harness(
+      `<p id="copy" data-askable-id="summary-copy">Revenue increased 18% this quarter.</p>`,
+      `
+      window.capturedPacket = null;
+      window.selectionCapture = AskableCore.createAskableTextSelectionCapture(window.ctx, {
+        source: { app: 'e2e' },
+        intent: 'explain selected text',
+        onCapture: (packet) => { window.capturedPacket = packet; },
+      });
+      `,
+    );
+
+    await page.evaluate(() => {
+      const el = document.getElementById('copy')!;
+      const node = el.firstChild!;
+      const range = document.createRange();
+      range.setStart(node, 0);
+      range.setEnd(node, 'Revenue increased'.length);
+      const selection = document.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+      (window as any).selectionCapture.captureNow();
+    });
+
+    const packet = await page.evaluate(() => (window as any).capturedPacket);
+    expect(packet).toMatchObject({
+      protocol: 'askable.context',
+      source: { app: 'e2e' },
+      capture: {
+        mode: 'text-selection',
+        gesture: 'programmatic',
+        intent: 'explain selected text',
+      },
+      target: {
+        text: 'Revenue increased',
+        selector: '#copy',
+        metadata: {
+          kind: 'text-selection',
+          length: 'Revenue increased'.length,
+        },
+      },
+      privacy: {
+        consent: 'explicit',
+      },
+      provenance: {
+        producer: '@askable-ui/core',
+        method: 'dom',
+      },
+    });
+  });
+});
+
 test.describe('nested elements — deepest strategy (default)', () => {
   test('clicking nested inner element wins', async ({ harness }) => {
     const page = await harness(`

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.9.0",
+    "@askable-ui/react": "^0.10.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.9.0",
-    "@askable-ui/react-native": "^0.9.0",
+    "@askable-ui/core": "^0.10.0",
+    "@askable-ui/react-native": "^0.10.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "workspaces": [
         "packages/*"
       ],
@@ -4844,7 +4844,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -4867,10 +4867,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.9.0"
+        "@askable-ui/context": "^0.10.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -4894,7 +4894,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4902,11 +4902,11 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.9.0",
-        "@askable-ui/core": "^0.9.0",
+        "@askable-ui/context": "^0.10.0",
+        "@askable-ui/core": "^0.10.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -4931,10 +4931,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.9.0"
+        "@askable-ui/core": "^0.10.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4954,10 +4954,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.9.0"
+        "@askable-ui/core": "^0.10.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.15",
@@ -5129,10 +5129,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.9.0"
+        "@askable-ui/core": "^0.10.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -5163,10 +5163,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.9.0"
+        "@askable-ui/core": "^0.10.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -68,6 +68,32 @@ capture.start();
 The packet uses `capture.mode` of `region` or `circle`, marks consent as
 explicit, and includes the selected geometry in `target.bounds`.
 
+## Text Selection Capture
+
+Use `createAskableTextSelectionCapture()` when the user should highlight page
+text and send that exact selected range as structured context.
+
+```ts
+import { createAskableContext, createAskableTextSelectionCapture } from '@askable-ui/core';
+
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
+
+const selection = createAskableTextSelectionCapture(ctx, {
+  intent: 'answer using this selected text',
+  includeViewport: true,
+  onCapture(packet) {
+    sendToAgent(packet);
+  },
+});
+
+selection.start();
+```
+
+The packet uses `capture.mode` of `text-selection`, marks consent as explicit,
+and includes the highlighted copy in `target.text`. Call `captureNow()` for
+button-driven flows where selection should be read on demand.
+
 ## API Reference
 
 ### `createAskableContext(): AskableContext`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.9.0"
+    "@askable-ui/context": "^0.10.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createAskableContext, createAskableTextSelectionCapture } from '../index.js';
+
+function selectText(
+  text: string,
+  bounds = { x: 12, y: 20, width: 80, height: 18 },
+): HTMLElement {
+  const el = document.createElement('p');
+  el.id = 'selected-copy';
+  el.textContent = text;
+  document.body.appendChild(el);
+
+  const node = el.firstChild!;
+  const range = document.createRange();
+  range.setStart(node, 0);
+  range.setEnd(node, text.length);
+  Object.defineProperty(range, 'getBoundingClientRect', {
+    value: () => bounds,
+  });
+
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return el;
+}
+
+function pointerEvent(type: string): PointerEvent {
+  const event = new MouseEvent(type, { bubbles: true });
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+  return event as PointerEvent;
+}
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+  document.body.innerHTML = '';
+  vi.useRealTimers();
+});
+
+describe('createAskableTextSelectionCapture', () => {
+  it('captures selected text as a Context packet', () => {
+    const ctx = createAskableContext();
+    const onCapture = vi.fn();
+    const capture = createAskableTextSelectionCapture(ctx, {
+      source: { app: 'reader' },
+      intent: 'explain selected text',
+      onCapture,
+    });
+
+    selectText('Gross margin improved by 12%.');
+
+    const packet = capture.captureNow();
+
+    expect(onCapture).toHaveBeenCalledTimes(1);
+    expect(packet).toMatchObject({
+      protocol: 'askable.context',
+      source: { app: 'reader' },
+      capture: {
+        mode: 'text-selection',
+        gesture: 'programmatic',
+        intent: 'explain selected text',
+      },
+      target: {
+        text: 'Gross margin improved by 12%.',
+        selector: '#selected-copy',
+        bounds: { x: 12, y: 20, width: 80, height: 18 },
+        metadata: {
+          kind: 'text-selection',
+          length: 29,
+        },
+      },
+      privacy: { consent: 'explicit' },
+      provenance: {
+        producer: '@askable-ui/core',
+        method: 'dom',
+      },
+    });
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
+  it('ignores selections outside the configured root', () => {
+    const root = document.createElement('section');
+    const outside = selectText('Outside selection');
+    document.body.appendChild(root);
+
+    const ctx = createAskableContext();
+    const capture = createAskableTextSelectionCapture(ctx, { root });
+
+    expect(outside.parentElement).toBe(document.body);
+    expect(capture.captureNow()).toBeNull();
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
+  it('captures debounced selectionchange events with pointer metadata', () => {
+    vi.useFakeTimers();
+    const ctx = createAskableContext();
+    const onCapture = vi.fn();
+    const capture = createAskableTextSelectionCapture(ctx, {
+      debounce: 20,
+      onCapture,
+    });
+
+    capture.start();
+    selectText('Drag selected text');
+    document.dispatchEvent(pointerEvent('pointerup'));
+    vi.advanceTimersByTime(20);
+
+    const [packet, selection] = onCapture.mock.calls[0];
+    expect(selection).toMatchObject({
+      text: 'Drag selected text',
+      pointerType: 'mouse',
+    });
+    expect(packet).toMatchObject({
+      capture: {
+        mode: 'text-selection',
+        gesture: 'drag',
+      },
+      target: {
+        metadata: {
+          pointerType: 'mouse',
+        },
+      },
+    });
+
+    capture.destroy();
+    ctx.destroy();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export { createAskableInspector } from './inspector.js';
 export { createAskableRegionCapture } from './capture.js';
+export { createAskableTextSelectionCapture } from './selection.js';
 export { a11yTextExtractor } from './a11y.js';
 export {
   WEB_CONTEXT_PROTOCOL,
@@ -16,6 +17,7 @@ export type {
   WebContextPacket,
   WebContextPrivacy,
   WebContextProvenance,
+  WebContextRect,
   WebContextSource,
   WebContextSurrounding,
   WebContextTarget,
@@ -31,6 +33,11 @@ export type {
   AskableRegionCaptureSelection,
   AskableRegionCaptureShape,
 } from './capture.js';
+export type {
+  AskableTextSelectionCaptureHandle,
+  AskableTextSelectionCaptureOptions,
+  AskableTextSelectionCaptureSelection,
+} from './selection.js';
 export type {
   AskableContext,
   AskableContextOptions,

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -1,0 +1,275 @@
+import type {
+  WebContextGesture,
+  WebContextPacket,
+  WebContextRect,
+} from '@askable-ui/context';
+import type {
+  AskableContext,
+  AskableContextPacketOptions,
+} from './types.js';
+
+export interface AskableTextSelectionCaptureSelection {
+  text: string;
+  bounds?: WebContextRect;
+  selector?: string;
+  pointerType?: string;
+  capturedAt: string;
+}
+
+export interface AskableTextSelectionCaptureOptions extends Omit<AskableContextPacketOptions, 'mode' | 'gesture' | 'target'> {
+  /** Root to observe for selections. Defaults to document. */
+  root?: Document | HTMLElement;
+  /** Minimum selected text length before a selection is accepted. Defaults to 1. */
+  minLength?: number;
+  /** Debounce delay for browser selectionchange events. Defaults to 120ms. */
+  debounce?: number;
+  /** Remove listeners after the first accepted capture. Defaults to false. */
+  once?: boolean;
+  /** Ignore duplicate selections with the same text and bounds. Defaults to true. */
+  dedupe?: boolean;
+  /** Called after selected text is serialized to a Context packet. */
+  onCapture?: (packet: WebContextPacket, selection: AskableTextSelectionCaptureSelection) => void;
+  /** Called when active selection capture is cancelled. */
+  onCancel?: () => void;
+}
+
+export interface AskableTextSelectionCaptureHandle {
+  start(): void;
+  captureNow(overrides?: Partial<AskableTextSelectionCaptureOptions>): WebContextPacket | null;
+  cancel(): void;
+  destroy(): void;
+  isActive(): boolean;
+}
+
+type LastInteraction = {
+  gesture: WebContextGesture;
+  pointerType?: string;
+};
+
+const DEFAULT_DEBOUNCE = 120;
+
+export function createAskableTextSelectionCapture(
+  ctx: AskableContext,
+  options: AskableTextSelectionCaptureOptions = {},
+): AskableTextSelectionCaptureHandle {
+  const doc = resolveDocument(options.root);
+  if (!doc) {
+    return {
+      start: () => undefined,
+      captureNow: () => null,
+      cancel: () => undefined,
+      destroy: () => undefined,
+      isActive: () => false,
+    };
+  }
+
+  const ownerDocument = doc;
+  const root = options.root ?? ownerDocument;
+  const minLength = options.minLength ?? 1;
+  const debounce = options.debounce ?? DEFAULT_DEBOUNCE;
+  const once = options.once ?? false;
+  const dedupe = options.dedupe ?? true;
+  let active = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastInteraction: LastInteraction = { gesture: 'programmatic' };
+  let lastSignature = '';
+
+  const clearTimer = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const capture = (overrides?: Partial<AskableTextSelectionCaptureOptions>): WebContextPacket | null => {
+    const currentOptions = { ...options, ...overrides };
+    const currentRoot = currentOptions.root ?? root;
+    const currentMinLength = currentOptions.minLength ?? minLength;
+    const currentDedupe = currentOptions.dedupe ?? dedupe;
+    const currentOnce = currentOptions.once ?? once;
+    const selection = readSelection(ownerDocument, currentRoot, currentMinLength, lastInteraction.pointerType);
+    if (!selection) return null;
+
+    const signature = selectionSignature(selection);
+    if (currentDedupe && signature === lastSignature) return null;
+    lastSignature = signature;
+
+    const packet = ctx.toContextPacket({
+      ...currentOptions,
+      mode: 'text-selection',
+      gesture: lastInteraction.gesture,
+      target: {
+        text: selection.text,
+        ...(selection.bounds ? { bounds: selection.bounds } : {}),
+        ...(selection.selector ? { selector: selection.selector } : {}),
+        metadata: {
+          kind: 'text-selection',
+          length: selection.text.length,
+          ...(selection.pointerType ? { pointerType: selection.pointerType } : {}),
+        },
+      },
+      privacy: {
+        consent: 'explicit',
+        ...currentOptions.privacy,
+      },
+      provenance: {
+        producer: '@askable-ui/core',
+        method: 'dom',
+        ...currentOptions.provenance,
+      },
+    });
+
+    currentOptions.onCapture?.(packet, selection);
+    if (currentOnce) destroy();
+    return packet;
+  };
+
+  const scheduleCapture = () => {
+    if (!active) return;
+    clearTimer();
+    if (debounce <= 0) {
+      capture();
+      return;
+    }
+    timer = setTimeout(() => {
+      timer = null;
+      capture();
+    }, debounce);
+  };
+
+  function onSelectionChange() {
+    scheduleCapture();
+  }
+
+  function onPointerUp(event: PointerEvent) {
+    lastInteraction = {
+      gesture: 'drag',
+      pointerType: event.pointerType || undefined,
+    };
+    scheduleCapture();
+  }
+
+  function onKeyUp() {
+    lastInteraction = { gesture: 'keyboard' };
+    scheduleCapture();
+  }
+
+  function start() {
+    if (active) return;
+    active = true;
+    ownerDocument.addEventListener('selectionchange', onSelectionChange);
+    ownerDocument.addEventListener('pointerup', onPointerUp);
+    ownerDocument.addEventListener('keyup', onKeyUp);
+  }
+
+  function destroy() {
+    clearTimer();
+    ownerDocument.removeEventListener('selectionchange', onSelectionChange);
+    ownerDocument.removeEventListener('pointerup', onPointerUp);
+    ownerDocument.removeEventListener('keyup', onKeyUp);
+    active = false;
+  }
+
+  function cancel() {
+    const wasActive = active;
+    destroy();
+    if (wasActive) options.onCancel?.();
+  }
+
+  return {
+    start,
+    captureNow: capture,
+    cancel,
+    destroy,
+    isActive: () => active,
+  };
+}
+
+function resolveDocument(root?: Document | HTMLElement): Document | null {
+  if (typeof Document !== 'undefined' && root instanceof Document) return root;
+  if (root?.ownerDocument) return root.ownerDocument;
+  return typeof document !== 'undefined' ? document : null;
+}
+
+function readSelection(
+  doc: Document,
+  root: Document | HTMLElement,
+  minLength: number,
+  pointerType?: string,
+): AskableTextSelectionCaptureSelection | null {
+  const selection = doc.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
+
+  const text = selection.toString().trim();
+  if (text.length < minLength) return null;
+
+  const range = selection.getRangeAt(0);
+  if (!rangeInsideRoot(range, root)) return null;
+
+  const bounds = rangeBounds(range);
+  const selector = selectorForRange(range);
+  return {
+    text,
+    ...(bounds ? { bounds } : {}),
+    ...(selector ? { selector } : {}),
+    ...(pointerType ? { pointerType } : {}),
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+function rangeInsideRoot(range: Range, root: Document | HTMLElement): boolean {
+  if (typeof Document !== 'undefined' && root instanceof Document) return true;
+  const start = nodeToElement(range.startContainer);
+  const end = nodeToElement(range.endContainer);
+  return Boolean(start && end && root.contains(start) && root.contains(end));
+}
+
+function rangeBounds(range: Range): WebContextRect | undefined {
+  if (typeof range.getBoundingClientRect !== 'function') return undefined;
+  const rect = range.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return undefined;
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function selectorForRange(range: Range): string | undefined {
+  const element = nodeToElement(range.commonAncestorContainer);
+  if (!element) return undefined;
+  return selectorForElement(element);
+}
+
+function nodeToElement(node: Node): HTMLElement | null {
+  if (typeof HTMLElement !== 'undefined' && node instanceof HTMLElement) return node;
+  const parent = node.parentElement;
+  return typeof HTMLElement !== 'undefined' && parent instanceof HTMLElement ? parent : null;
+}
+
+function selectorForElement(element: HTMLElement): string | undefined {
+  if (element.id) return `#${escapeSelectorIdent(element.id)}`;
+  const askableId = element.getAttribute('data-askable-id')?.trim();
+  if (askableId) return `[data-askable-id="${escapeAttributeValue(askableId)}"]`;
+  const askable = element.closest<HTMLElement>('[data-askable-id]');
+  const closestId = askable?.getAttribute('data-askable-id')?.trim();
+  return closestId ? `[data-askable-id="${escapeAttributeValue(closestId)}"]` : undefined;
+}
+
+function escapeSelectorIdent(value: string): string {
+  const css = globalThis.CSS as { escape?: (value: string) => string } | undefined;
+  return css?.escape ? css.escape(value) : value.replace(/["'\\#.:,[\]>~+*()]/g, '\\$&');
+}
+
+function escapeAttributeValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function selectionSignature(selection: AskableTextSelectionCaptureSelection): string {
+  return JSON.stringify({
+    text: selection.text,
+    bounds: selection.bounds,
+    selector: selection.selector,
+  });
+}

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.9.0';
+const ASKABLE_VERSION = '0.10.0';
 const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "MCP bridge for exposing Context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,8 +36,8 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.9.0",
-    "@askable-ui/core": "^0.9.0",
+    "@askable-ui/context": "^0.10.0",
+    "@askable-ui/core": "^0.10.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.9.0"
+    "@askable-ui/core": "^0.10.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.15",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -167,6 +167,7 @@ const { focus: focusOnly } = useAskable({ events: ['focus'] });
   - `ctx.serializeFocus(options?)` — structured `AskableSerializedFocus` object
   - `ctx.toContextPacket()` — structured Context packet for agents and MCP bridges
 - `useAskableRegionCapture()` — explicit region/circle capture for visual page selection
+- `useAskableTextSelectionCapture()` — explicit highlighted text capture for page copy selection
 
 The hook manages a shared singleton context per `name + events + viewport` configuration. Multiple `useAskable()` consumers with the same shared configuration reuse one observer lifecycle, while differing configurations get isolated shared contexts of their own. Each shared context is automatically destroyed when its last consumer unmounts.
 
@@ -234,6 +235,33 @@ function RegionTools() {
         Circle area
       </button>
       {capture.active && <button onClick={capture.cancel}>Cancel</button>}
+    </>
+  );
+}
+```
+
+### Text selection capture
+
+Use `useAskableTextSelectionCapture()` when a user highlights text and sends
+that exact selection to an agent.
+
+```tsx
+import { useAskableTextSelectionCapture } from '@askable-ui/react';
+
+function SelectionTools() {
+  const selection = useAskableTextSelectionCapture({
+    includeViewport: true,
+    intent: 'answer using the highlighted text',
+    onCapture(packet) {
+      sendToAgent(packet);
+    },
+  });
+
+  return (
+    <>
+      <button onClick={() => selection.start()}>Watch selection</button>
+      <button onClick={() => selection.captureNow()}>Send selected text</button>
+      {selection.active && <button onClick={selection.cancel}>Cancel</button>}
     </>
   );
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.9.0"
+    "@askable-ui/core": "^0.10.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/react/src/__tests__/useAskableTextSelectionCapture.test.tsx
+++ b/packages/react/src/__tests__/useAskableTextSelectionCapture.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useAskableTextSelectionCapture } from '../useAskableTextSelectionCapture.js';
+
+function selectText(text: string): HTMLElement {
+  const el = document.createElement('p');
+  el.id = 'react-selection';
+  el.textContent = text;
+  document.body.appendChild(el);
+
+  const range = document.createRange();
+  range.setStart(el.firstChild!, 0);
+  range.setEnd(el.firstChild!, text.length);
+  Object.defineProperty(range, 'getBoundingClientRect', {
+    value: () => ({ x: 10, y: 15, width: 120, height: 20 }),
+  });
+
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return el;
+}
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+  document.querySelectorAll('#react-selection').forEach((el) => el.remove());
+});
+
+describe('useAskableTextSelectionCapture', () => {
+  it('captures the current browser selection', async () => {
+    function Consumer() {
+      const capture = useAskableTextSelectionCapture({
+        source: { app: 'react-test' },
+        intent: 'summarize selection',
+      });
+
+      return (
+        <div>
+          <button type="button" onClick={() => capture.captureNow()}>
+            Capture
+          </button>
+          <span data-testid="packet">{capture.lastPacket ? JSON.stringify(capture.lastPacket) : 'null'}</span>
+        </div>
+      );
+    }
+
+    render(<Consumer />);
+    selectText('Selected React copy');
+
+    act(() => {
+      fireEvent.click(screen.getByText('Capture'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('packet').textContent).not.toBe('null');
+    });
+
+    const packet = JSON.parse(screen.getByTestId('packet').textContent!);
+    expect(packet).toMatchObject({
+      source: { app: 'react-test' },
+      capture: {
+        mode: 'text-selection',
+        gesture: 'programmatic',
+        intent: 'summarize selection',
+      },
+      target: {
+        text: 'Selected React copy',
+        selector: '#react-selection',
+      },
+      privacy: { consent: 'explicit' },
+    });
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,9 +2,14 @@ export { Askable } from './Askable.js';
 export { AskableInspector } from './AskableInspector.js';
 export { useAskable } from './useAskable.js';
 export { useAskableRegionCapture } from './useAskableRegionCapture.js';
+export { useAskableTextSelectionCapture } from './useAskableTextSelectionCapture.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
 export type {
   UseAskableRegionCaptureOptions,
   UseAskableRegionCaptureResult,
 } from './useAskableRegionCapture.js';
+export type {
+  UseAskableTextSelectionCaptureOptions,
+  UseAskableTextSelectionCaptureResult,
+} from './useAskableTextSelectionCapture.js';
 export type { AskableInspectorProps } from './AskableInspector.js';

--- a/packages/react/src/useAskableTextSelectionCapture.ts
+++ b/packages/react/src/useAskableTextSelectionCapture.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createAskableTextSelectionCapture,
+  type AskableContext,
+  type AskableTextSelectionCaptureHandle,
+  type AskableTextSelectionCaptureOptions,
+  type AskableTextSelectionCaptureSelection,
+  type WebContextPacket,
+} from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export interface UseAskableTextSelectionCaptureOptions
+  extends AskableTextSelectionCaptureOptions,
+    Omit<UseAskableOptions, 'inspector'> {}
+
+export interface UseAskableTextSelectionCaptureResult {
+  ctx: AskableContext;
+  active: boolean;
+  lastPacket: WebContextPacket | null;
+  lastSelection: AskableTextSelectionCaptureSelection | null;
+  start: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => void;
+  captureNow: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => WebContextPacket | null;
+  cancel: () => void;
+  destroy: () => void;
+  isActive: () => boolean;
+}
+
+export function useAskableTextSelectionCapture(
+  options: UseAskableTextSelectionCaptureOptions = {},
+): UseAskableTextSelectionCaptureResult {
+  const { ctx } = useAskable(options);
+  const optionsRef = useRef(options);
+  const handleRef = useRef<AskableTextSelectionCaptureHandle | null>(null);
+  const [active, setActive] = useState(false);
+  const [lastPacket, setLastPacket] = useState<WebContextPacket | null>(null);
+  const [lastSelection, setLastSelection] = useState<AskableTextSelectionCaptureSelection | null>(null);
+
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
+  const destroy = useCallback(() => {
+    handleRef.current?.destroy();
+    handleRef.current = null;
+    setActive(false);
+  }, []);
+
+  const cancel = useCallback(() => {
+    handleRef.current?.cancel();
+    handleRef.current = null;
+    setActive(false);
+  }, []);
+
+  const ensureHandle = useCallback((overrides?: Partial<AskableTextSelectionCaptureOptions>) => {
+    const currentOptions = {
+      ...optionsRef.current,
+      ...overrides,
+    };
+
+    handleRef.current?.destroy();
+    const handle = createAskableTextSelectionCapture(ctx, {
+      ...currentOptions,
+      onCapture(packet, selection) {
+        setLastPacket(packet);
+        setLastSelection(selection);
+        if (currentOptions.once) {
+          handleRef.current = null;
+          setActive(false);
+        }
+        currentOptions.onCapture?.(packet, selection);
+      },
+      onCancel() {
+        handleRef.current = null;
+        setActive(false);
+        currentOptions.onCancel?.();
+      },
+    });
+
+    handleRef.current = handle;
+    return handle;
+  }, [ctx]);
+
+  const start = useCallback((overrides?: Partial<AskableTextSelectionCaptureOptions>) => {
+    const handle = ensureHandle(overrides);
+    handle.start();
+    setActive(true);
+  }, [ensureHandle]);
+
+  const captureNow = useCallback((overrides?: Partial<AskableTextSelectionCaptureOptions>) => {
+    const handle = handleRef.current ?? ensureHandle(overrides);
+    const packet = handle.captureNow(overrides);
+    if (packet && (optionsRef.current.once || overrides?.once)) {
+      handleRef.current = null;
+      setActive(false);
+    }
+    return packet;
+  }, [ensureHandle]);
+
+  const isActive = useCallback(() => handleRef.current?.isActive() ?? active, [active]);
+
+  useEffect(() => destroy, [destroy]);
+
+  return {
+    ctx,
+    active,
+    lastPacket,
+    lastSelection,
+    start,
+    captureNow,
+    cancel,
+    destroy,
+    isActive,
+  };
+}

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -106,6 +106,39 @@ Starts an explicit region or circle selection overlay and exposes the captured C
 
 The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
 
+### `createAskableTextSelectionCaptureStore(options?)`
+
+Captures highlighted browser text and exposes the captured Context packet as
+Svelte stores.
+
+```svelte
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { createAskableTextSelectionCaptureStore } from '@askable-ui/svelte';
+
+  const selection = createAskableTextSelectionCaptureStore({
+    includeViewport: true,
+    source: { app: 'analytics-dashboard' },
+    intent: 'answer using the highlighted text',
+  });
+  const { active, lastPacket } = selection;
+
+  onDestroy(selection.destroy);
+</script>
+
+<button on:click={() => selection.start()}>Watch selection</button>
+<button on:click={() => selection.captureNow()}>Send selected text</button>
+{#if $active}
+  <button on:click={selection.cancel}>Cancel</button>
+{/if}
+
+{#if $lastPacket}
+  <pre>{JSON.stringify($lastPacket, null, 2)}</pre>
+{/if}
+```
+
+The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `captureNow(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+
 ### "Ask AI" button pattern
 
 Use `ctx.select()` to set context explicitly when a user clicks a button:

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.9.0"
+    "@askable-ui/core": "^0.10.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/svelte/src/__tests__/store.test.ts
+++ b/packages/svelte/src/__tests__/store.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { get } from 'svelte/store';
-import { createAskableRegionCaptureStore, createAskableStore } from '../askable.js';
+import {
+  createAskableRegionCaptureStore,
+  createAskableStore,
+  createAskableTextSelectionCaptureStore,
+} from '../askable.js';
 
 function pointerEvent(type: string, x: number, y: number): PointerEvent {
   const event = new MouseEvent(type, {
@@ -14,6 +18,25 @@ function pointerEvent(type: string, x: number, y: number): PointerEvent {
   return event as PointerEvent;
 }
 
+function selectText(text: string, id = 'svelte-selection'): HTMLElement {
+  const el = document.createElement('p');
+  el.id = id;
+  el.textContent = text;
+  document.body.appendChild(el);
+
+  const range = document.createRange();
+  range.setStart(el.firstChild!, 0);
+  range.setEnd(el.firstChild!, text.length);
+  Object.defineProperty(range, 'getBoundingClientRect', {
+    value: () => ({ x: 10, y: 15, width: 120, height: 20 }),
+  });
+
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return el;
+}
+
 describe('createAskableStore', () => {
   const elements: HTMLElement[] = [];
 
@@ -21,6 +44,8 @@ describe('createAskableStore', () => {
     elements.forEach((el) => el.parentNode?.removeChild(el));
     elements.length = 0;
     document.getElementById('askable-region-capture')?.remove();
+    document.getSelection()?.removeAllRanges();
+    document.querySelectorAll('#svelte-selection').forEach((el) => el.remove());
   });
 
   function makeEl(meta: object | string, text = ''): HTMLElement {
@@ -126,6 +151,44 @@ describe('createAskableStore', () => {
 
     unsub();
     scopedCtx.destroy();
+  });
+});
+
+describe('createAskableTextSelectionCaptureStore', () => {
+  afterEach(() => {
+    document.getSelection()?.removeAllRanges();
+    document.querySelectorAll('#svelte-selection').forEach((el) => el.remove());
+  });
+
+  it('captures the current browser selection', () => {
+    const capture = createAskableTextSelectionCaptureStore({
+      source: { app: 'svelte-test' },
+      intent: 'summarize selection',
+    });
+
+    selectText('Selected Svelte copy');
+    const packet = capture.captureNow();
+
+    expect(packet).toMatchObject({
+      source: { app: 'svelte-test' },
+      capture: {
+        mode: 'text-selection',
+        gesture: 'programmatic',
+        intent: 'summarize selection',
+      },
+      target: {
+        text: 'Selected Svelte copy',
+        selector: '#svelte-selection',
+      },
+      privacy: { consent: 'explicit' },
+    });
+    expect(get(capture.lastPacket)).toEqual(packet);
+    expect(get(capture.lastSelection)).toMatchObject({
+      text: 'Selected Svelte copy',
+      selector: '#svelte-selection',
+    });
+
+    capture.destroy();
   });
 });
 

--- a/packages/svelte/src/askable.ts
+++ b/packages/svelte/src/askable.ts
@@ -1,5 +1,10 @@
 import { writable, derived, readonly } from 'svelte/store';
-import { createAskableContext, createAskableInspector, createAskableRegionCapture } from '@askable-ui/core';
+import {
+  createAskableContext,
+  createAskableInspector,
+  createAskableRegionCapture,
+  createAskableTextSelectionCapture,
+} from '@askable-ui/core';
 import type {
   AskableEvent,
   AskableFocus,
@@ -9,6 +14,9 @@ import type {
   AskableRegionCaptureHandle,
   AskableRegionCaptureOptions,
   AskableRegionCaptureSelection,
+  AskableTextSelectionCaptureHandle,
+  AskableTextSelectionCaptureOptions,
+  AskableTextSelectionCaptureSelection,
   WebContextPacket,
 } from '@askable-ui/core';
 
@@ -33,6 +41,20 @@ export interface AskableRegionCaptureStore {
   lastSelection: ReturnType<typeof readonly>;
   ctx: AskableContext;
   start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
+  cancel: () => void;
+  destroy: () => void;
+  isActive: () => boolean;
+}
+
+export interface AskableTextSelectionCaptureStoreOptions extends AskableStoreOptions, AskableTextSelectionCaptureOptions {}
+
+export interface AskableTextSelectionCaptureStore {
+  active: ReturnType<typeof readonly>;
+  lastPacket: ReturnType<typeof readonly>;
+  lastSelection: ReturnType<typeof readonly>;
+  ctx: AskableContext;
+  start: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => void;
+  captureNow: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => WebContextPacket | null;
   cancel: () => void;
   destroy: () => void;
   isActive: () => boolean;
@@ -143,6 +165,95 @@ export function createAskableRegionCaptureStore(
     lastSelection: readonly(_lastSelection),
     ctx: askable.ctx,
     start,
+    cancel,
+    destroy,
+    isActive,
+  };
+}
+
+export function createAskableTextSelectionCaptureStore(
+  options: AskableTextSelectionCaptureStoreOptions = {},
+): AskableTextSelectionCaptureStore {
+  const { ctx, name, events, inspector, ...selectionOptions } = options;
+  const askable = createAskableStore({ ctx, name, events, inspector });
+  const _active = writable(false);
+  const _lastPacket = writable<WebContextPacket | null>(null);
+  const _lastSelection = writable<AskableTextSelectionCaptureSelection | null>(null);
+  let handle: AskableTextSelectionCaptureHandle | null = null;
+
+  function destroyCapture() {
+    handle?.destroy();
+    handle = null;
+    _active.set(false);
+  }
+
+  function ensureHandle(overrides?: Partial<AskableTextSelectionCaptureOptions>) {
+    handle?.destroy();
+
+    const currentOptions = {
+      ...selectionOptions,
+      ...overrides,
+    };
+
+    handle = createAskableTextSelectionCapture(askable.ctx, {
+      ...currentOptions,
+      onCapture(packet, selection) {
+        _lastPacket.set(packet);
+        _lastSelection.set(selection);
+        if (currentOptions.once) {
+          handle = null;
+          _active.set(false);
+        }
+        currentOptions.onCapture?.(packet, selection);
+      },
+      onCancel() {
+        handle = null;
+        _active.set(false);
+        currentOptions.onCancel?.();
+      },
+    });
+
+    return handle;
+  }
+
+  function start(overrides?: Partial<AskableTextSelectionCaptureOptions>) {
+    const current = ensureHandle(overrides);
+    current.start();
+    _active.set(true);
+  }
+
+  function captureNow(overrides?: Partial<AskableTextSelectionCaptureOptions>) {
+    const current = handle ?? ensureHandle(overrides);
+    const packet = current.captureNow(overrides);
+    if (packet && (selectionOptions.once || overrides?.once)) {
+      handle = null;
+      _active.set(false);
+    }
+    return packet;
+  }
+
+  function cancel() {
+    handle?.cancel();
+    handle = null;
+    _active.set(false);
+  }
+
+  function destroy() {
+    destroyCapture();
+    askable.destroy();
+  }
+
+  function isActive() {
+    return handle?.isActive() ?? false;
+  }
+
+  return {
+    active: readonly(_active),
+    lastPacket: readonly(_lastPacket),
+    lastSelection: readonly(_lastSelection),
+    ctx: askable.ctx,
+    start,
+    captureNow,
     cancel,
     destroy,
     isActive,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,10 +1,16 @@
 // Svelte 4 — store-based API
-export { createAskableRegionCaptureStore, createAskableStore } from './askable.js';
+export {
+  createAskableRegionCaptureStore,
+  createAskableStore,
+  createAskableTextSelectionCaptureStore,
+} from './askable.js';
 export type {
   AskableRegionCaptureStore,
   AskableRegionCaptureStoreOptions,
   AskableStore,
   AskableStoreOptions,
+  AskableTextSelectionCaptureStore,
+  AskableTextSelectionCaptureStoreOptions,
 } from './askable.js';
 
 // Svelte 5 runes-based API:

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -101,6 +101,37 @@ const selectedContext = computed(() =>
 
 The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
 
+### `useAskableTextSelectionCapture(options?)`
+
+Captures highlighted browser text and emits a structured Context packet through
+the same `AskableContext`.
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useAskableTextSelectionCapture } from '@askable-ui/vue';
+
+const selection = useAskableTextSelectionCapture({
+  includeViewport: true,
+  source: { app: 'analytics-dashboard' },
+  intent: 'answer using the highlighted text',
+});
+
+const selectedContext = computed(() =>
+  selection.lastPacket.value ? JSON.stringify(selection.lastPacket.value, null, 2) : ''
+);
+</script>
+
+<template>
+  <button @click="selection.start()">Watch selection</button>
+  <button @click="selection.captureNow()">Send selected text</button>
+  <button v-if="selection.active.value" @click="selection.cancel()">Cancel</button>
+  <pre v-if="selectedContext">{{ selectedContext }}</pre>
+</template>
+```
+
+The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `captureNow(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+
 ### "Ask AI" button pattern
 
 Use `ctx.select()` to set context explicitly when a user clicks a button:

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.9.0"
+    "@askable-ui/core": "^0.10.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/src/__tests__/useAskableTextSelectionCapture.test.ts
+++ b/packages/vue/src/__tests__/useAskableTextSelectionCapture.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { computed, defineComponent, nextTick } from 'vue';
+import { useAskableTextSelectionCapture } from '../useAskableTextSelectionCapture.js';
+import { track } from './helpers.js';
+
+function selectText(text: string): HTMLElement {
+  const el = document.createElement('p');
+  el.id = 'vue-selection';
+  el.textContent = text;
+  document.body.appendChild(el);
+
+  const range = document.createRange();
+  range.setStart(el.firstChild!, 0);
+  range.setEnd(el.firstChild!, text.length);
+  Object.defineProperty(range, 'getBoundingClientRect', {
+    value: () => ({ x: 10, y: 15, width: 120, height: 20 }),
+  });
+
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return el;
+}
+
+async function flushAll() {
+  await flushPromises();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+  document.querySelectorAll('#vue-selection').forEach((el) => el.remove());
+});
+
+describe('useAskableTextSelectionCapture (Vue)', () => {
+  it('captures the current browser selection', async () => {
+    const Consumer = defineComponent({
+      name: 'TextSelectionCaptureConsumer',
+      setup() {
+        const capture = useAskableTextSelectionCapture({
+          source: { app: 'vue-test' },
+          intent: 'summarize selection',
+        });
+        const packet = computed(() => capture.lastPacket.value ? JSON.stringify(capture.lastPacket.value) : 'null');
+        return {
+          packet,
+          captureNow: capture.captureNow,
+        };
+      },
+      template: `
+        <div>
+          <button type="button" @click="captureNow()">Capture</button>
+          <span data-testid="packet">{{ packet }}</span>
+        </div>
+      `,
+    });
+
+    const wrapper = track(mount(Consumer, { attachTo: document.body }));
+    await flushAll();
+
+    selectText('Selected Vue copy');
+    await wrapper.find('button').trigger('click');
+    await flushAll();
+
+    const packet = JSON.parse(wrapper.find('[data-testid="packet"]').text());
+    expect(packet).toMatchObject({
+      source: { app: 'vue-test' },
+      capture: {
+        mode: 'text-selection',
+        gesture: 'programmatic',
+        intent: 'summarize selection',
+      },
+      target: {
+        text: 'Selected Vue copy',
+        selector: '#vue-selection',
+      },
+      privacy: { consent: 'explicit' },
+    });
+  });
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -2,8 +2,13 @@ export { Askable } from './Askable.js';
 export { AskableInspector } from './AskableInspector.js';
 export { useAskable } from './useAskable.js';
 export { useAskableRegionCapture } from './useAskableRegionCapture.js';
+export { useAskableTextSelectionCapture } from './useAskableTextSelectionCapture.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
 export type {
   UseAskableRegionCaptureOptions,
   UseAskableRegionCaptureResult,
 } from './useAskableRegionCapture.js';
+export type {
+  UseAskableTextSelectionCaptureOptions,
+  UseAskableTextSelectionCaptureResult,
+} from './useAskableTextSelectionCapture.js';

--- a/packages/vue/src/useAskableTextSelectionCapture.ts
+++ b/packages/vue/src/useAskableTextSelectionCapture.ts
@@ -1,0 +1,111 @@
+import { onUnmounted, ref, shallowRef } from 'vue';
+import {
+  createAskableTextSelectionCapture,
+  type AskableContext,
+  type AskableTextSelectionCaptureHandle,
+  type AskableTextSelectionCaptureOptions,
+  type AskableTextSelectionCaptureSelection,
+  type WebContextPacket,
+} from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export interface UseAskableTextSelectionCaptureOptions
+  extends AskableTextSelectionCaptureOptions,
+    Omit<UseAskableOptions, 'inspector'> {}
+
+export interface UseAskableTextSelectionCaptureResult {
+  ctx: AskableContext;
+  active: ReturnType<typeof ref<boolean>>;
+  lastPacket: ReturnType<typeof shallowRef<WebContextPacket | null>>;
+  lastSelection: ReturnType<typeof shallowRef<AskableTextSelectionCaptureSelection | null>>;
+  start: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => void;
+  captureNow: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => WebContextPacket | null;
+  cancel: () => void;
+  destroy: () => void;
+  isActive: () => boolean;
+}
+
+export function useAskableTextSelectionCapture(
+  options: UseAskableTextSelectionCaptureOptions = {},
+): UseAskableTextSelectionCaptureResult {
+  const { ctx } = useAskable(options);
+  const active = ref(false);
+  const lastPacket = shallowRef<WebContextPacket | null>(null);
+  const lastSelection = shallowRef<AskableTextSelectionCaptureSelection | null>(null);
+  let handle: AskableTextSelectionCaptureHandle | null = null;
+
+  function destroy() {
+    handle?.destroy();
+    handle = null;
+    active.value = false;
+  }
+
+  function cancel() {
+    handle?.cancel();
+    handle = null;
+    active.value = false;
+  }
+
+  function ensureHandle(overrides?: Partial<AskableTextSelectionCaptureOptions>) {
+    handle?.destroy();
+
+    const currentOptions = {
+      ...options,
+      ...overrides,
+    };
+
+    handle = createAskableTextSelectionCapture(ctx, {
+      ...currentOptions,
+      onCapture(packet, selection) {
+        lastPacket.value = packet;
+        lastSelection.value = selection;
+        if (currentOptions.once) {
+          handle = null;
+          active.value = false;
+        }
+        currentOptions.onCapture?.(packet, selection);
+      },
+      onCancel() {
+        handle = null;
+        active.value = false;
+        currentOptions.onCancel?.();
+      },
+    });
+
+    return handle;
+  }
+
+  function start(overrides?: Partial<AskableTextSelectionCaptureOptions>) {
+    const current = ensureHandle(overrides);
+    current.start();
+    active.value = true;
+  }
+
+  function captureNow(overrides?: Partial<AskableTextSelectionCaptureOptions>) {
+    const current = handle ?? ensureHandle(overrides);
+    const packet = current.captureNow(overrides);
+    if (packet && (options.once || overrides?.once)) {
+      handle = null;
+      active.value = false;
+    }
+    return packet;
+  }
+
+  function isActive() {
+    return handle?.isActive() ?? active.value;
+  }
+
+  onUnmounted(destroy);
+
+  return {
+    ctx,
+    active,
+    lastPacket,
+    lastSelection,
+    start,
+    captureNow,
+    cancel,
+    destroy,
+    isActive,
+  };
+}

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -430,6 +430,48 @@ capture.start();
 
 ---
 
+## `createAskableTextSelectionCapture(ctx, options?)`
+
+Listens for highlighted browser text or reads the current selection on demand,
+then emits a structured Context packet with explicit consent metadata.
+
+```ts
+import { createAskableContext, createAskableTextSelectionCapture } from '@askable-ui/core';
+
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
+
+const selection = createAskableTextSelectionCapture(ctx, {
+  intent: 'answer using this highlighted text',
+  includeViewport: true,
+  onCapture: (packet, selected) => {
+    sendToAgent(packet);
+    console.log(selected.text);
+  },
+});
+
+selection.start();
+selection.captureNow();
+```
+
+**Options (`AskableTextSelectionCaptureOptions`):**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `root` | `Document \| HTMLElement` | `document` | Selection root to accept |
+| `minLength` | `number` | `1` | Minimum selected text length |
+| `debounce` | `number` | `120` | Delay for `selectionchange` captures |
+| `once` | `boolean` | `false` | Stop listening after the first accepted capture |
+| `dedupe` | `boolean` | `true` | Ignore repeated captures of the same text/bounds |
+| `onCapture` | `(packet, selection) => void` | — | Called with the Context packet and selected text details |
+| `onCancel` | `() => void` | — | Called when active capture is cancelled |
+| _...most `AskableContextPacketOptions`_ | | | Passed through to `toContextPacket()` |
+
+**Returns:** `AskableTextSelectionCaptureHandle` — object with `start()`,
+`captureNow()`, `cancel()`, `destroy()`, and `isActive()` methods.
+
+---
+
 ## `createAskableInspector(ctx, options?)`
 
 Mount a floating inspector panel that shows the active focus, parsed metadata, and prompt output in real time. Designed for development and demos.

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -340,3 +340,39 @@ function DashboardCapture() {
 | `cancel()` | `function` | Cancel the active overlay |
 | `destroy()` | `function` | Remove the overlay without firing cancel |
 | `isActive()` | `function` | Read active state from the live capture handle |
+
+---
+
+## `useAskableTextSelectionCapture(options?)`
+
+React hook for highlighted text capture. It can listen to browser selection
+changes or capture the current selection on demand.
+
+```tsx
+import { useAskableTextSelectionCapture } from '@askable-ui/react';
+
+function TextSelectionCapture() {
+  const selection = useAskableTextSelectionCapture({
+    includeViewport: true,
+    intent: 'answer using this highlighted text',
+    onCapture(packet) {
+      sendToAgent(packet);
+    },
+  });
+
+  return (
+    <>
+      <button onClick={() => selection.start()}>Watch selection</button>
+      <button onClick={() => selection.captureNow()}>Send selected text</button>
+      {selection.active && <button onClick={selection.cancel}>Cancel</button>}
+    </>
+  );
+}
+```
+
+**Options:** `root`, `minLength`, `debounce`, `once`, `dedupe`, `onCapture`,
+`onCancel`, `ctx`, and packet options such as `includeViewport`, `source`,
+`intent`, `privacy`, and `provenance`.
+
+**Returns:** `ctx`, `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
+`captureNow(overrides?)`, `cancel()`, `destroy()`, and `isActive()`.

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -196,3 +196,32 @@ onDestroy(capture.destroy);
 | `destroy` | `() => void` | Cancels capture and destroys the underlying store context |
 | `isActive` | `() => boolean` | Reads the current overlay state |
 | `ctx` | `AskableContext` | Store context instance |
+
+---
+
+## `createAskableTextSelectionCaptureStore(options?)`
+
+Factory that captures highlighted browser text and exposes the captured Context
+packet as Svelte stores.
+
+```ts
+import { createAskableTextSelectionCaptureStore } from '@askable-ui/svelte';
+
+const selection = createAskableTextSelectionCaptureStore({
+  includeViewport: true,
+  source: { app: 'dashboard' },
+  intent: 'answer using this highlighted text',
+});
+
+selection.start();
+selection.captureNow();
+selection.cancel();
+```
+
+Always call `destroy()` in `onDestroy`.
+
+**Options:** `root`, `minLength`, `debounce`, `once`, `dedupe`, `source`,
+`intent`, `ctx`, `events`, `onCapture`, and `onCancel`.
+
+**Returns:** `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
+`captureNow(overrides?)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.9.0`
-- Versioned current docs URL: `/docs/v0.9.0/`
+- Latest stable: `v0.10.0`
+- Versioned current docs URL: `/docs/v0.10.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.9.0/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.10.0/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -184,3 +184,30 @@ capture.cancel();
 | `destroy` | `() => void` | Cancels capture and removes overlay listeners |
 | `isActive` | `() => boolean` | Reads the current overlay state |
 | `ctx` | `AskableContext` | Shared or provided context instance |
+
+---
+
+## `useAskableTextSelectionCapture(options?)`
+
+Composable that captures highlighted browser text and emits a structured
+Context packet through the same `AskableContext`.
+
+```ts
+import { useAskableTextSelectionCapture } from '@askable-ui/vue';
+
+const selection = useAskableTextSelectionCapture({
+  includeViewport: true,
+  source: { app: 'dashboard' },
+  intent: 'answer using this highlighted text',
+});
+
+selection.start();
+selection.captureNow();
+selection.cancel();
+```
+
+**Options:** `root`, `minLength`, `debounce`, `once`, `dedupe`, `source`,
+`intent`, `ctx`, `name`, `events`, `onCapture`, and `onCancel`.
+
+**Returns:** `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
+`captureNow(overrides?)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -17,7 +17,7 @@ const packet = ctx.toContextPacket({
 The packet describes:
 
 - where the context came from: URL, title, app, route, timestamp
-- how the context was captured: focused element, semantic push, viewport, region, lasso, circle, or custom capture
+- how the context was captured: focused element, selected text, semantic push, viewport, region, lasso, circle, or custom capture
 - what the user is pointing at: text, role, label, selector, bounds, metadata, optional screenshots
 - surrounding context: ancestors, visible items, and recent interactions
 - privacy and provenance: redaction state, consent state, producer, and capture method
@@ -156,6 +156,60 @@ const capture = useAskableRegionCapture({
 import { createAskableRegionCaptureStore } from '@askable-ui/svelte';
 
 const capture = createAskableRegionCaptureStore({
+  includeViewport: true,
+  onCapture: (packet) => sendToAgent(packet),
+});
+```
+
+## Text selection capture
+
+Use text selection capture when the user highlights copy in the page and wants
+that exact selected range sent to an agent:
+
+```ts
+import { createAskableContext, createAskableTextSelectionCapture } from '@askable-ui/core';
+
+const ctx = createAskableContext({ viewport: true });
+ctx.observe(document);
+
+const selection = createAskableTextSelectionCapture(ctx, {
+  intent: 'answer using the highlighted text',
+  includeViewport: true,
+  onCapture: (packet) => {
+    sendToAgent(packet);
+  },
+});
+
+selection.start();
+```
+
+The resulting packet uses `capture.mode` of `text-selection`, sets
+`privacy.consent` to `explicit`, and places the selected text on `target.text`.
+
+Framework wrappers expose the same behavior:
+
+```tsx
+import { useAskableTextSelectionCapture } from '@askable-ui/react';
+
+const selection = useAskableTextSelectionCapture({
+  includeViewport: true,
+  onCapture: (packet) => sendToAgent(packet),
+});
+```
+
+```ts
+import { useAskableTextSelectionCapture } from '@askable-ui/vue';
+
+const selection = useAskableTextSelectionCapture({
+  includeViewport: true,
+  onCapture: (packet) => sendToAgent(packet),
+});
+```
+
+```ts
+import { createAskableTextSelectionCaptureStore } from '@askable-ui/svelte';
+
+const selection = createAskableTextSelectionCaptureStore({
   includeViewport: true,
   onCapture: (packet) => sendToAgent(packet),
 });

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.9.0**.
+> Current npm release: **v0.10.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/react.md
+++ b/site/docs/guide/react.md
@@ -167,6 +167,35 @@ function RegionTools() {
 Region packets use `capture.mode: 'region'`; circle packets use
 `capture.mode: 'circle'` and include center/radius metadata.
 
+## Text selection capture
+
+For "send this highlighted copy" flows, use `useAskableTextSelectionCapture()`.
+
+```tsx
+import { useAskableTextSelectionCapture } from '@askable-ui/react';
+
+function TextSelectionTools() {
+  const selection = useAskableTextSelectionCapture({
+    includeViewport: true,
+    intent: 'answer using the highlighted text',
+    onCapture(packet) {
+      sendToAgent(packet);
+    },
+  });
+
+  return (
+    <div>
+      <button onClick={() => selection.start()}>Watch selection</button>
+      <button onClick={() => selection.captureNow()}>Send selected text</button>
+      {selection.active && <button onClick={selection.cancel}>Cancel</button>}
+    </div>
+  );
+}
+```
+
+Selection packets use `capture.mode: 'text-selection'` and include the
+highlighted text in `target.text`.
+
 ## History-aware context
 
 Feed multi-step interaction history into your LLM instead of just the current focus:

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,52 +1,56 @@
-# What’s New in v0.9.0
+# What’s New in v0.10.0
 
-askable-ui v0.9.0 makes the MCP bridge easier to wire into agent runtimes by
-adding a first-class provider for existing Askable contexts.
+askable-ui v0.10.0 adds first-class text selection capture, so highlighted page
+copy can be sent to agents as structured Context packets.
 
 ## Highlights
 
-### First-class MCP context provider
+### Highlighted text as Context packets
 
-`@askable-ui/mcp` now exports `createAskableMcpContextProvider()` so apps can
-publish the same context they already use in their UI directly through MCP
-tools and resources.
+`@askable-ui/core` now exports `createAskableTextSelectionCapture()` for
+capturing the current browser selection or listening to user selection changes.
+Packets use `capture.mode: 'text-selection'`, set explicit consent, and include
+the highlighted copy in `target.text`.
 
 ```ts
-import { createAskableContext } from '@askable-ui/core';
-import { createAskableMcpContextProvider, createAskableMcpServer } from '@askable-ui/mcp';
+import { createAskableContext, createAskableTextSelectionCapture } from '@askable-ui/core';
 
 const ctx = createAskableContext({ viewport: true });
 ctx.observe(document);
 
-const server = createAskableMcpServer({
-  provider: createAskableMcpContextProvider(ctx, {
-    history: 3,
-    includeViewport: true,
-    source: { app: 'analytics-dashboard' },
-  }),
+const selection = createAskableTextSelectionCapture(ctx, {
+  includeViewport: true,
+  intent: 'answer using the highlighted text',
+  onCapture: (packet) => sendToAgent(packet),
 });
+
+selection.start();
 ```
 
-The provider adapts `ctx.toContextPacket()` for structured packet tools and
-`ctx.toContext()` for prompt-ready text tools. Callers can request prompt
-shaping options such as `scope`, `preset`, `format`, `includeText`,
-`maxTextLength`, `maxTokens`, `history`, and `includeViewport`.
+Framework wrappers are available as `useAskableTextSelectionCapture()` for
+React and Vue, plus `createAskableTextSelectionCaptureStore()` for Svelte.
 
 Related docs:
 
 - [Context Packets](/guide/context)
-- [@askable-ui/mcp API](/api/mcp)
+- [@askable-ui/core API](/api/core)
+- [@askable-ui/react API](/api/react)
 
-### Expanded MCP prompt controls
+### Region, circle, and text capture together
 
-The MCP bridge now accepts the same common prompt controls as the core context
-serializer, so MCP clients can ask for compact, JSON, scoped, or text-limited
-context without each host app inventing its own tool contract.
+Askable now covers three explicit user selection patterns:
+
+- draw a rectangle with `createAskableRegionCapture()`
+- circle something on screen with `shape: 'circle'`
+- highlight copy with `createAskableTextSelectionCapture()`
+
+All three produce the same versioned Context packet format for MCP bridges,
+browser tools, and agent runtimes.
 
 ### Starter and docs version alignment
 
-`npm create @askable-ui/app` now scaffolds projects pinned to `^0.9.0`, and the
-versioned docs have been advanced to `/docs/v0.9.0/`.
+`npm create @askable-ui/app` now scaffolds projects pinned to `^0.10.0`, and the
+versioned docs have been advanced to `/docs/v0.10.0/`.
 
 ## Recommended next step
 
@@ -54,11 +58,11 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 1. [Getting Started](/guide/getting-started)
 2. [Context Packets](/guide/context)
-3. [@askable-ui/mcp API](/api/mcp)
+3. [@askable-ui/core API](/api/core)
 
 ## Version note
 
-The current published docs track **v0.9.0** at both:
+The current published docs track **v0.10.0** at both:
 
 - `/docs/`
-- `/docs/v0.9.0/`
+- `/docs/v0.10.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.9.0**.
+> Current npm release: **v0.10.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,16 +59,16 @@ features:
   </video>
 </div>
 
-## Latest in v0.9.0
+## Latest in v0.10.0
 
-- `createAskableMcpContextProvider()` for wiring existing Askable contexts into MCP servers
-- expanded MCP tool options for scoped, compact, JSON, and token-limited context
-- starter app dependency pins advanced to `^0.9.0`
-- continued support for region/circle capture, Context packets, and framework wrappers
+- `createAskableTextSelectionCapture()` for sending highlighted page text as Context packets
+- React, Vue, and Svelte wrappers for text selection capture
+- starter app dependency pins advanced to `^0.10.0`
+- continued support for region/circle capture, MCP Context packets, and framework wrappers
 
 Start here:
 
-- [What’s New in v0.9.0](/guide/whats-new)
+- [What’s New in v0.10.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.9.0",
-    "slug": "v0.9.0"
+    "label": "v0.10.0",
+    "slug": "v0.10.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.9.0`) is built on every deploy and published to both:
+The current release (`v0.10.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.9.0/` (version-specific URL)
+- `/docs/v0.10.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- add core text selection capture that emits structured Context packets with explicit consent
- add React, Vue, and Svelte wrapper APIs for selected-text capture
- document text selection capture and bump packages/docs to 0.10.0

## Verification
- npm ci
- npm test
- npm run build
- npm run build --prefix site/docs
- npm run test:e2e
- npm audit --audit-level=moderate
- node scripts/check-example-askable-versions.mjs
- npm ls @askable-ui/context @askable-ui/core @askable-ui/react @askable-ui/vue @askable-ui/svelte @askable-ui/mcp --workspaces --all
- npm pack --dry-run --json --workspaces
- git diff --check
