### PR TITLE
feat(core): add lasso context capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it
 - **Conversation history** — `ctx.toHistoryContext(n)` for multi-turn context
 - **Viewport awareness** — `ctx.getVisibleElements()` / `ctx.toViewportContext()` for on-screen context
 - **Structured Context packets** — `ctx.toContextPacket()` for agent/MCP-ready page context
-- **Explicit capture tools** — region, circle, and highlighted text capture for user-selected context
+- **Explicit capture tools** — region, circle, lasso, and highlighted text capture for user-selected context
 - **Redaction hooks** — strip sensitive fields before data reaches serialization
 - **Inspector panel** — `<AskableInspector />` or `useAskable({ inspector: true })` for a live dev overlay
 - **Agent templates** — reusable `AGENTS.md` guidance and copy-paste prompts for coding-agent-driven adoption

--- a/e2e/observer.spec.ts
+++ b/e2e/observer.spec.ts
@@ -245,6 +245,44 @@ test.describe('region capture', () => {
       },
     });
   });
+
+  test('dragging a lasso emits point path metadata', async ({ harness }) => {
+    const page = await harness(
+      `<div id="target" data-askable='{"widget":"chart"}' style="width:240px;height:120px">Chart</div>`,
+      `
+      window.capturedPacket = null;
+      window.regionCapture = AskableCore.createAskableRegionCapture(window.ctx, {
+        shape: 'lasso',
+        onCapture: (packet) => { window.capturedPacket = packet; },
+      });
+      window.regionCapture.start();
+      `,
+    );
+
+    await page.mouse.move(20, 30);
+    await page.mouse.down();
+    await page.mouse.move(45, 60);
+    await page.mouse.move(100, 50);
+    await page.mouse.up();
+
+    const packet = await page.evaluate(() => (window as any).capturedPacket);
+    expect(packet.capture).toMatchObject({
+      mode: 'lasso',
+      gesture: 'lasso',
+    });
+    expect(packet.target).toMatchObject({
+      bounds: { x: 20, y: 30, width: 80, height: 30 },
+      metadata: {
+        shape: 'lasso',
+        pointCount: 3,
+        points: [
+          { x: 20, y: 30 },
+          { x: 45, y: 60 },
+          { x: 100, y: 50 },
+        ],
+      },
+    });
+  });
 });
 
 test.describe('text selection capture', () => {

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.10.0",
+    "@askable-ui/react": "^0.11.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.10.0",
-    "@askable-ui/react-native": "^0.10.0",
+    "@askable-ui/core": "^0.11.0",
+    "@askable-ui/react-native": "^0.11.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "workspaces": [
         "packages/*"
       ],
@@ -4844,7 +4844,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -4867,10 +4867,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.10.0"
+        "@askable-ui/context": "^0.11.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -4894,7 +4894,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4902,11 +4902,11 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.10.0",
-        "@askable-ui/core": "^0.10.0",
+        "@askable-ui/context": "^0.11.0",
+        "@askable-ui/core": "^0.11.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -4931,10 +4931,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.10.0"
+        "@askable-ui/core": "^0.11.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4954,10 +4954,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.10.0"
+        "@askable-ui/core": "^0.11.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.15",
@@ -5129,10 +5129,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.10.0"
+        "@askable-ui/core": "^0.11.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",
@@ -5163,10 +5163,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.10.0"
+        "@askable-ui/core": "^0.11.0"
       },
       "devDependencies": {
         "@askable-ui/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,10 +42,10 @@ const formPrompt = ctx.toPromptContext({ scope: 'form-helper' });
 ctx.destroy();
 ```
 
-## Region and Circle Capture
+## Region, Circle, and Lasso Capture
 
-Use `createAskableRegionCapture()` when the user should draw a page region and
-send it as structured context.
+Use `createAskableRegionCapture()` when the user should draw a page region,
+circle an area, or lasso a freehand shape and send it as structured context.
 
 ```ts
 import { createAskableContext, createAskableRegionCapture } from '@askable-ui/core';
@@ -54,7 +54,7 @@ const ctx = createAskableContext({ viewport: true });
 ctx.observe(document);
 
 const capture = createAskableRegionCapture(ctx, {
-  shape: 'circle',
+  shape: 'lasso',
   intent: 'explain this selected area',
   includeViewport: true,
   onCapture(packet) {
@@ -65,8 +65,9 @@ const capture = createAskableRegionCapture(ctx, {
 capture.start();
 ```
 
-The packet uses `capture.mode` of `region` or `circle`, marks consent as
-explicit, and includes the selected geometry in `target.bounds`.
+The packet uses `capture.mode` of `region`, `circle`, or `lasso`, marks consent
+as explicit, and includes the selected geometry in `target.bounds`. Lasso
+captures also include `target.metadata.points` for the freehand path.
 
 ## Text Selection Capture
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.10.0"
+    "@askable-ui/context": "^0.11.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/packages/core/src/__tests__/capture.test.ts
+++ b/packages/core/src/__tests__/capture.test.ts
@@ -105,6 +105,55 @@ describe('createAskableRegionCapture', () => {
     ctx.destroy();
   });
 
+  it('captures a lasso with point metadata', () => {
+    const ctx = createAskableContext();
+    const onCapture = vi.fn();
+    const capture = createAskableRegionCapture(ctx, {
+      shape: 'lasso',
+      onCapture,
+    });
+
+    capture.start();
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointermove', 30, 45));
+    overlay.dispatchEvent(pointerEvent('pointermove', 70, 35));
+    overlay.dispatchEvent(pointerEvent('pointerup', 80, 75));
+
+    const [packet, selection] = onCapture.mock.calls[0];
+    expect(selection).toMatchObject({
+      shape: 'lasso',
+      bounds: { x: 10, y: 20, width: 70, height: 55 },
+      points: [
+        { x: 10, y: 20 },
+        { x: 30, y: 45 },
+        { x: 70, y: 35 },
+        { x: 80, y: 75 },
+      ],
+    });
+    expect(packet.capture).toMatchObject({
+      mode: 'lasso',
+      gesture: 'lasso',
+    });
+    expect(packet.target).toMatchObject({
+      bounds: { x: 10, y: 20, width: 70, height: 55 },
+      metadata: {
+        shape: 'lasso',
+        pointCount: 4,
+        points: [
+          { x: 10, y: 20 },
+          { x: 30, y: 45 },
+          { x: 70, y: 35 },
+          { x: 80, y: 75 },
+        ],
+      },
+    });
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
   it('cancels selections smaller than the minimum size', () => {
     const ctx = createAskableContext();
     const onCapture = vi.fn();

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -9,13 +9,14 @@ import type {
   AskableContextPacketOptions,
 } from './types.js';
 
-export type AskableRegionCaptureShape = 'region' | 'circle';
+export type AskableRegionCaptureShape = 'region' | 'circle' | 'lasso';
 
 export interface AskableRegionCaptureSelection {
   shape: AskableRegionCaptureShape;
   bounds: WebContextRect;
   center?: { x: number; y: number };
   radius?: number;
+  points?: AskableRegionCapturePoint[];
   pointerType?: string;
   startedAt: string;
   endedAt: string;
@@ -28,7 +29,7 @@ export interface AskableRegionCaptureOptions extends Omit<AskableContextPacketOp
   minSize?: number;
   /** Remove the overlay after the first accepted capture. Defaults to true. */
   once?: boolean;
-  /** Called after a region/circle is accepted and serialized to a Context packet. */
+  /** Called after a region/circle/lasso is accepted and serialized to a Context packet. */
   onCapture?: (packet: WebContextPacket, selection: AskableRegionCaptureSelection) => void;
   /** Called when an active capture is cancelled. */
   onCancel?: () => void;
@@ -41,10 +42,12 @@ export interface AskableRegionCaptureHandle {
   isActive(): boolean;
 }
 
-interface Point {
+export interface AskableRegionCapturePoint {
   x: number;
   y: number;
 }
+
+type Point = AskableRegionCapturePoint;
 
 const OVERLAY_ID = 'askable-region-capture';
 const SELECTION_ATTR = 'data-askable-region-capture-selection';
@@ -64,7 +67,10 @@ export function createAskableRegionCapture(
 
   let overlay: HTMLDivElement | null = null;
   let selectionEl: HTMLDivElement | null = null;
+  let lassoSvg: SVGSVGElement | null = null;
+  let lassoPolyline: SVGPolylineElement | null = null;
   let startPoint: Point | null = null;
+  let lassoPoints: Point[] = [];
   let startedAt = '';
   let pointerType: string | undefined;
   let active = false;
@@ -82,7 +88,10 @@ export function createAskableRegionCapture(
     overlay?.remove();
     overlay = null;
     selectionEl = null;
+    lassoSvg = null;
+    lassoPolyline = null;
     startPoint = null;
+    lassoPoints = [];
     active = false;
   };
 
@@ -108,26 +117,54 @@ export function createAskableRegionCapture(
       'user-select:none',
     ].join(';');
 
-    selectionEl = document.createElement('div');
-    selectionEl.setAttribute(SELECTION_ATTR, shape);
-    selectionEl.style.cssText = [
-      'position:absolute',
-      'box-sizing:border-box',
-      'border:2px solid #2563eb',
-      'background:rgba(37,99,235,0.14)',
-      'box-shadow:0 0 0 9999px rgba(15,23,42,0.12)',
-      'pointer-events:none',
-      'display:none',
-    ].join(';');
-    if (shape === 'circle') selectionEl.style.borderRadius = '9999px';
+    if (shape === 'lasso') {
+      lassoSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      lassoSvg.setAttribute(SELECTION_ATTR, shape);
+      lassoSvg.style.cssText = [
+        'position:absolute',
+        'inset:0',
+        'width:100%',
+        'height:100%',
+        'pointer-events:none',
+        'display:none',
+      ].join(';');
 
-    overlay.appendChild(selectionEl);
+      lassoPolyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+      lassoPolyline.setAttribute('fill', 'rgba(37,99,235,0.14)');
+      lassoPolyline.setAttribute('stroke', '#2563eb');
+      lassoPolyline.setAttribute('stroke-width', '2');
+      lassoPolyline.setAttribute('stroke-linejoin', 'round');
+      lassoPolyline.setAttribute('stroke-linecap', 'round');
+      lassoSvg.appendChild(lassoPolyline);
+      overlay.appendChild(lassoSvg);
+    } else {
+      selectionEl = document.createElement('div');
+      selectionEl.setAttribute(SELECTION_ATTR, shape);
+      selectionEl.style.cssText = [
+        'position:absolute',
+        'box-sizing:border-box',
+        'border:2px solid #2563eb',
+        'background:rgba(37,99,235,0.14)',
+        'box-shadow:0 0 0 9999px rgba(15,23,42,0.12)',
+        'pointer-events:none',
+        'display:none',
+      ].join(';');
+      if (shape === 'circle') selectionEl.style.borderRadius = '9999px';
+      overlay.appendChild(selectionEl);
+    }
+
     overlay.addEventListener('pointerdown', onPointerDown);
     overlay.addEventListener('pointermove', onPointerMove);
     overlay.addEventListener('pointerup', onPointerUp);
     overlay.addEventListener('pointercancel', onPointerCancel);
     document.addEventListener('keydown', onKeyDown);
     document.body.appendChild(overlay);
+  };
+
+  const updateLasso = (points: Point[]) => {
+    if (!lassoSvg || !lassoPolyline) return;
+    lassoSvg.style.display = 'block';
+    lassoPolyline.setAttribute('points', points.map((point) => `${point.x},${point.y}`).join(' '));
   };
 
   const updateSelection = (bounds: WebContextRect) => {
@@ -144,23 +181,39 @@ export function createAskableRegionCapture(
     event.preventDefault();
     pointerType = event.pointerType || undefined;
     startPoint = pointFromEvent(event);
+    lassoPoints = [startPoint];
     startedAt = new Date().toISOString();
     active = true;
-    selectionEl!.style.display = 'none';
+    if (selectionEl) selectionEl.style.display = 'none';
+    if (lassoSvg) lassoSvg.style.display = 'none';
     overlay?.setPointerCapture?.(event.pointerId);
   }
 
   function onPointerMove(event: PointerEvent) {
     if (!startPoint || !active) return;
     event.preventDefault();
-    updateSelection(boundsForShape(shape, startPoint, pointFromEvent(event)));
+    const point = pointFromEvent(event);
+    if (shape === 'lasso') {
+      appendLassoPoint(lassoPoints, point);
+      updateLasso(lassoPoints);
+      return;
+    }
+    updateSelection(boundsForShape(shape, startPoint, point));
   }
 
   function onPointerUp(event: PointerEvent) {
     if (!startPoint || !active) return;
     event.preventDefault();
     const endPoint = pointFromEvent(event);
-    const selection = createSelection(shape, startPoint, endPoint, pointerType, startedAt);
+    if (shape === 'lasso') appendLassoPoint(lassoPoints, endPoint);
+    const selection = createSelection(
+      shape,
+      startPoint,
+      endPoint,
+      pointerType,
+      startedAt,
+      shape === 'lasso' ? lassoPoints : undefined,
+    );
 
     if (selection.bounds.width < minSize || selection.bounds.height < minSize) {
       cancel();
@@ -177,6 +230,7 @@ export function createAskableRegionCapture(
           shape: selection.shape,
           ...(selection.center ? { center: selection.center } : {}),
           ...(selection.radius !== undefined ? { radius: selection.radius } : {}),
+          ...(selection.points ? { points: selection.points, pointCount: selection.points.length } : {}),
           ...(selection.pointerType ? { pointerType: selection.pointerType } : {}),
         },
       },
@@ -199,8 +253,10 @@ export function createAskableRegionCapture(
     }
 
     startPoint = null;
+    lassoPoints = [];
     active = false;
     if (selectionEl) selectionEl.style.display = 'none';
+    if (lassoSvg) lassoSvg.style.display = 'none';
   }
 
   function onPointerCancel() {
@@ -248,14 +304,42 @@ function boundsForShape(shape: AskableRegionCaptureShape, start: Point, end: Poi
   };
 }
 
+function boundsForPoints(points: Point[]): WebContextRect {
+  const xs = points.map((point) => point.x);
+  const ys = points.map((point) => point.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+}
+
+function appendLassoPoint(points: Point[], point: Point): void {
+  const previous = points[points.length - 1];
+  if (!previous || distance(previous, point) >= 2) {
+    points.push(point);
+  }
+}
+
+function distance(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
 function createSelection(
   shape: AskableRegionCaptureShape,
   start: Point,
   end: Point,
   pointerType: string | undefined,
   startedAt: string,
+  points?: Point[],
 ): AskableRegionCaptureSelection {
-  const bounds = boundsForShape(shape, start, end);
+  const lassoPointsForSelection = points && points.length > 0 ? points : undefined;
+  const bounds = lassoPointsForSelection ? boundsForPoints(lassoPointsForSelection) : boundsForShape(shape, start, end);
   const endedAt = new Date().toISOString();
 
   if (shape === 'circle') {
@@ -277,6 +361,7 @@ function createSelection(
   return {
     shape,
     bounds,
+    ...(lassoPointsForSelection ? { points: lassoPointsForSelection } : {}),
     ...(pointerType ? { pointerType } : {}),
     startedAt,
     endedAt,
@@ -284,9 +369,11 @@ function createSelection(
 }
 
 function captureModeForShape(shape: AskableRegionCaptureShape): WebContextCaptureMode {
+  if (shape === 'lasso') return 'lasso';
   return shape === 'circle' ? 'circle' : 'region';
 }
 
 function gestureForShape(shape: AskableRegionCaptureShape): WebContextGesture {
+  if (shape === 'lasso') return 'lasso';
   return shape === 'circle' ? 'circle' : 'drag';
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export type {
 export type {
   AskableRegionCaptureHandle,
   AskableRegionCaptureOptions,
+  AskableRegionCapturePoint,
   AskableRegionCaptureSelection,
   AskableRegionCaptureShape,
 } from './capture.js';

--- a/packages/create-askable-app/README.md
+++ b/packages/create-askable-app/README.md
@@ -15,7 +15,7 @@ The generated app includes:
 
 - a small analytics dashboard annotated with `data-askable`
 - `useAskable()` pre-wired for hover + click focus tracking
-- region and circle capture buttons for explicit page-area context
+- region, circle, and lasso capture buttons for explicit page-area context
 - `useCopilotReadable()` pushing current and recent Askable context into CopilotKit
 - a local Express runtime wired to `@copilotkit/runtime`
 - a starter README and `.env.example`

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.10.0';
+const ASKABLE_VERSION = '0.11.0';
 const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/create-askable-app/template/src/App.tsx
+++ b/packages/create-askable-app/template/src/App.tsx
@@ -100,7 +100,7 @@ export default function App() {
 
   useCopilotReadable(
     {
-      description: 'The last explicit region or circle the user selected on the page.',
+      description: 'The last explicit region, circle, or lasso the user selected on the page.',
       value: regionContext,
     },
     [regionContext],
@@ -146,6 +146,13 @@ export default function App() {
               onClick={() => regionCapture.start({ shape: 'circle', intent: 'explain this circled area' })}
             >
               Circle area
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => regionCapture.start({ shape: 'lasso', intent: 'explain this lassoed area' })}
+            >
+              Lasso area
             </button>
             {regionCapture.active && (
               <button type="button" className="secondary" onClick={regionCapture.cancel}>

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MCP bridge for exposing Context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,8 +36,8 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.10.0",
-    "@askable-ui/core": "^0.10.0",
+    "@askable-ui/context": "^0.11.0",
+    "@askable-ui/core": "^0.11.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.10.0"
+    "@askable-ui/core": "^0.11.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.15",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -166,7 +166,7 @@ const { focus: focusOnly } = useAskable({ events: ['focus'] });
   - `ctx.toPromptContext(options?)` — full serialization options (format, maxTokens, excludeKeys, …)
   - `ctx.serializeFocus(options?)` — structured `AskableSerializedFocus` object
   - `ctx.toContextPacket()` — structured Context packet for agents and MCP bridges
-- `useAskableRegionCapture()` — explicit region/circle capture for visual page selection
+- `useAskableRegionCapture()` — explicit region/circle/lasso capture for visual page selection
 - `useAskableTextSelectionCapture()` — explicit highlighted text capture for page copy selection
 
 The hook manages a shared singleton context per `name + events + viewport` configuration. Multiple `useAskable()` consumers with the same shared configuration reuse one observer lifecycle, while differing configurations get isolated shared contexts of their own. Each shared context is automatically destroyed when its last consumer unmounts.
@@ -208,7 +208,7 @@ function RevenueCard({ data }) {
 }
 ```
 
-### Region and circle capture
+### Region, circle, and lasso capture
 
 Use `useAskableRegionCapture()` when a user should select an area of the page
 and send that geometry as structured context.
@@ -233,6 +233,9 @@ function RegionTools() {
       </button>
       <button onClick={() => capture.start({ shape: 'circle' })}>
         Circle area
+      </button>
+      <button onClick={() => capture.start({ shape: 'lasso' })}>
+        Lasso area
       </button>
       {capture.active && <button onClick={capture.cancel}>Cancel</button>}
     </>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.10.0"
+    "@askable-ui/core": "^0.11.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/react/src/__tests__/useAskableRegionCapture.test.tsx
+++ b/packages/react/src/__tests__/useAskableRegionCapture.test.tsx
@@ -116,6 +116,50 @@ describe('useAskableRegionCapture', () => {
     });
   });
 
+  it('supports lasso capture overrides at start time', async () => {
+    function Consumer() {
+      const capture = useAskableRegionCapture();
+
+      return (
+        <div>
+          <button type="button" onClick={() => capture.start({ shape: 'lasso' })}>
+            Lasso
+          </button>
+          <span data-testid="packet">{capture.lastPacket ? JSON.stringify(capture.lastPacket) : 'null'}</span>
+        </div>
+      );
+    }
+
+    render(<Consumer />);
+
+    act(() => {
+      fireEvent.click(screen.getByText('Lasso'));
+    });
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    act(() => {
+      overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+      overlay.dispatchEvent(pointerEvent('pointermove', 30, 45));
+      overlay.dispatchEvent(pointerEvent('pointermove', 70, 35));
+      overlay.dispatchEvent(pointerEvent('pointerup', 80, 75));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('packet').textContent).not.toBe('null');
+    });
+
+    const packet = JSON.parse(screen.getByTestId('packet').textContent!);
+    expect(packet.capture).toMatchObject({ mode: 'lasso', gesture: 'lasso' });
+    expect(packet.target).toMatchObject({
+      bounds: { x: 10, y: 20, width: 70, height: 55 },
+      metadata: {
+        shape: 'lasso',
+        pointCount: 4,
+      },
+    });
+    expect(packet.target.metadata.points).toHaveLength(4);
+  });
+
   it('cancels the active overlay from React state', async () => {
     function Consumer() {
       const capture = useAskableRegionCapture();

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -76,7 +76,7 @@ const { focus, promptContext, ctx, destroy } = createAskableStore({ events: ['cl
 
 ### `createAskableRegionCaptureStore(options?)`
 
-Starts an explicit region or circle selection overlay and exposes the captured Context packet as Svelte stores.
+Starts an explicit region, circle, or lasso selection overlay and exposes the captured Context packet as Svelte stores.
 
 ```svelte
 <script lang="ts">
@@ -95,6 +95,7 @@ Starts an explicit region or circle selection overlay and exposes the captured C
 
 <button on:click={() => capture.start()}>Select region</button>
 <button on:click={() => capture.start({ shape: 'circle' })}>Circle area</button>
+<button on:click={() => capture.start({ shape: 'lasso' })}>Lasso area</button>
 {#if $active}
   <button on:click={capture.cancel}>Cancel</button>
 {/if}

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.10.0"
+    "@askable-ui/core": "^0.11.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/svelte/src/__tests__/store.test.ts
+++ b/packages/svelte/src/__tests__/store.test.ts
@@ -251,6 +251,32 @@ describe('createAskableRegionCaptureStore', () => {
     capture.destroy();
   });
 
+  it('supports lasso capture overrides at start time', () => {
+    const capture = createAskableRegionCaptureStore();
+
+    capture.start({ shape: 'lasso' });
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointermove', 30, 45));
+    overlay.dispatchEvent(pointerEvent('pointermove', 70, 35));
+    overlay.dispatchEvent(pointerEvent('pointerup', 80, 75));
+
+    expect(get(capture.lastPacket)?.capture).toMatchObject({ mode: 'lasso', gesture: 'lasso' });
+    expect(get(capture.lastSelection)).toMatchObject({
+      shape: 'lasso',
+      bounds: { x: 10, y: 20, width: 70, height: 55 },
+      points: [
+        { x: 10, y: 20 },
+        { x: 30, y: 45 },
+        { x: 70, y: 35 },
+        { x: 80, y: 75 },
+      ],
+    });
+
+    capture.destroy();
+  });
+
   it('cancels active capture from store state', () => {
     const capture = createAskableRegionCaptureStore();
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -73,7 +73,7 @@ The composable manages a shared singleton context per `events` configuration. Mu
 
 ### `useAskableRegionCapture(options?)`
 
-Starts an explicit region or circle selection overlay and emits a structured Context packet through the same `AskableContext`.
+Starts an explicit region, circle, or lasso selection overlay and emits a structured Context packet through the same `AskableContext`.
 
 ```vue
 <script setup lang="ts">
@@ -94,6 +94,7 @@ const selectedContext = computed(() =>
 <template>
   <button @click="capture.start()">Select region</button>
   <button @click="capture.start({ shape: 'circle' })">Circle area</button>
+  <button @click="capture.start({ shape: 'lasso' })">Lasso area</button>
   <button v-if="capture.active.value" @click="capture.cancel()">Cancel</button>
   <pre v-if="selectedContext">{{ selectedContext }}</pre>
 </template>

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.10.0"
+    "@askable-ui/core": "^0.11.0"
   },
   "devDependencies": {
     "@askable-ui/core": "*",

--- a/packages/vue/src/__tests__/useAskableRegionCapture.test.ts
+++ b/packages/vue/src/__tests__/useAskableRegionCapture.test.ts
@@ -124,6 +124,49 @@ describe('useAskableRegionCapture (Vue)', () => {
     });
   });
 
+  it('supports lasso capture overrides at start time', async () => {
+    const Consumer = defineComponent({
+      name: 'LassoCaptureConsumer',
+      setup() {
+        const capture = useAskableRegionCapture();
+        const packet = computed(() => capture.lastPacket.value ? JSON.stringify(capture.lastPacket.value) : 'null');
+        return {
+          packet,
+          startLasso: () => capture.start({ shape: 'lasso' }),
+        };
+      },
+      template: `
+        <div>
+          <button type="button" @click="startLasso()">Lasso</button>
+          <span data-testid="packet">{{ packet }}</span>
+        </div>
+      `,
+    });
+
+    const wrapper = track(mount(Consumer, { attachTo: document.body }));
+    await flushAll();
+
+    await wrapper.find('button').trigger('click');
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointermove', 30, 45));
+    overlay.dispatchEvent(pointerEvent('pointermove', 70, 35));
+    overlay.dispatchEvent(pointerEvent('pointerup', 80, 75));
+    await flushAll();
+
+    const packet = JSON.parse(wrapper.find('[data-testid="packet"]').text());
+    expect(packet.capture).toMatchObject({ mode: 'lasso', gesture: 'lasso' });
+    expect(packet.target).toMatchObject({
+      bounds: { x: 10, y: 20, width: 70, height: 55 },
+      metadata: {
+        shape: 'lasso',
+        pointCount: 4,
+      },
+    });
+    expect(packet.target.metadata.points).toHaveLength(4);
+  });
+
   it('cancels active capture from Vue state', async () => {
     const Consumer = defineComponent({
       name: 'CancelCaptureConsumer',

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -392,8 +392,8 @@ ctx.destroy();
 
 ## `createAskableRegionCapture(ctx, options?)`
 
-Mounts a temporary browser overlay that lets the user drag a rectangle or circle,
-then emits a structured Context packet with explicit consent metadata.
+Mounts a temporary browser overlay that lets the user drag a rectangle, circle,
+or lasso, then emits a structured Context packet with explicit consent metadata.
 
 ```ts
 import { createAskableContext, createAskableRegionCapture } from '@askable-ui/core';
@@ -402,7 +402,7 @@ const ctx = createAskableContext({ viewport: true });
 ctx.observe(document);
 
 const capture = createAskableRegionCapture(ctx, {
-  shape: 'circle',
+  shape: 'lasso',
   intent: 'explain this selected area',
   includeViewport: true,
   onCapture: (packet, selection) => {
@@ -418,7 +418,7 @@ capture.start();
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `shape` | `'region' \| 'circle'` | `'region'` | Shape produced by the drag gesture |
+| `shape` | `'region' \| 'circle' \| 'lasso'` | `'region'` | Shape produced by the drag gesture |
 | `minSize` | `number` | `6` | Minimum accepted width/height in CSS pixels |
 | `once` | `boolean` | `true` | Remove the overlay after the first accepted capture |
 | `onCapture` | `(packet, selection) => void` | — | Called with the Context packet and selection geometry |

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -285,7 +285,7 @@ function PrivatePanel({ panelEl }: { panelEl: HTMLElement }) {
 
 ## `useAskableRegionCapture(options?)`
 
-React hook for explicit region and circle capture. It mounts a temporary browser
+React hook for explicit region, circle, and lasso capture. It mounts a temporary browser
 overlay, tracks active state, and stores the last captured Context packet.
 
 ```tsx
@@ -309,6 +309,9 @@ function DashboardCapture() {
       <button onClick={() => capture.start({ shape: 'circle' })}>
         Circle area
       </button>
+      <button onClick={() => capture.start({ shape: 'lasso' })}>
+        Lasso area
+      </button>
       {capture.active && <button onClick={capture.cancel}>Cancel</button>}
     </>
   );
@@ -319,7 +322,7 @@ function DashboardCapture() {
 
 | Option | Type | Description |
 |---|---|---|
-| `shape` | `'region' \| 'circle'` | Default shape for `start()` |
+| `shape` | `'region' \| 'circle' \| 'lasso'` | Default shape for `start()` |
 | `minSize` | `number` | Minimum accepted width/height in CSS pixels |
 | `once` | `boolean` | Remove the overlay after the first accepted capture |
 | `onCapture` | `(packet, selection) => void` | Called when the user completes a selection |
@@ -335,7 +338,7 @@ function DashboardCapture() {
 | `ctx` | `AskableContext` | Context used for packet serialization |
 | `active` | `boolean` | Whether the overlay is currently active |
 | `lastPacket` | `WebContextPacket \| null` | Last captured packet |
-| `lastSelection` | `AskableRegionCaptureSelection \| null` | Last captured geometry |
+| `lastSelection` | `AskableRegionCaptureSelection \| null` | Last captured geometry; lasso includes point path metadata |
 | `start(overrides?)` | `function` | Start capture, optionally overriding shape/intent/etc. |
 | `cancel()` | `function` | Cancel the active overlay |
 | `destroy()` | `function` | Remove the overlay without firing cancel |

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -147,7 +147,7 @@ Use the private default for isolated widgets. Pass a shared `ctx` when multiple 
 
 ## `createAskableRegionCaptureStore(options?)`
 
-Factory that starts an explicit region or circle selection overlay and exposes the captured Context packet as Svelte stores.
+Factory that starts an explicit region, circle, or lasso selection overlay and exposes the captured Context packet as Svelte stores.
 
 ```ts
 import { createAskableRegionCaptureStore } from '@askable-ui/svelte';
@@ -160,6 +160,7 @@ const capture = createAskableRegionCaptureStore({
 
 capture.start();
 capture.start({ shape: 'circle' });
+capture.start({ shape: 'lasso' });
 capture.cancel();
 ```
 
@@ -175,13 +176,13 @@ onDestroy(capture.destroy);
 
 | Option | Type | Description |
 |---|---|---|
-| `shape` | `'region' \| 'circle'` | Initial capture shape. Default: `'region'` |
+| `shape` | `'region' \| 'circle' \| 'lasso'` | Initial capture shape. Default: `'region'` |
 | `includeViewport` | `boolean` | Include viewport metadata in the emitted Context packet |
 | `source` | `WebContextSource` | App/page source metadata attached to the packet |
 | `intent` | `string` | User intent attached to the capture |
 | `ctx` | `AskableContext` | Optional context to share with other Svelte stores/components |
 | `events` | `AskableEvent[]` | Observation events for the underlying store context |
-| `onCapture` | `(packet, selection) => void` | Called after a region or circle is accepted |
+| `onCapture` | `(packet, selection) => void` | Called after a region, circle, or lasso is accepted |
 | `onCancel` | `() => void` | Called after active capture is cancelled |
 
 **Returns:**
@@ -190,7 +191,7 @@ onDestroy(capture.destroy);
 |---|---|---|
 | `active` | `Readable<boolean>` | Whether the overlay is active |
 | `lastPacket` | `Readable<WebContextPacket \| null>` | Last captured Context packet |
-| `lastSelection` | `Readable<AskableRegionCaptureSelection \| null>` | Last raw region/circle selection geometry |
+| `lastSelection` | `Readable<AskableRegionCaptureSelection \| null>` | Last raw region/circle/lasso selection geometry |
 | `start` | `(overrides?) => void` | Starts capture, optionally overriding options for one capture |
 | `cancel` | `() => void` | Cancels the active overlay |
 | `destroy` | `() => void` | Cancels capture and destroys the underlying store context |

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.10.0`
-- Versioned current docs URL: `/docs/v0.10.0/`
+- Latest stable: `v0.11.0`
+- Versioned current docs URL: `/docs/v0.11.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.10.0/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.11.0/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -142,7 +142,7 @@ const panel = useAskable({ ctx: panelCtx });
 
 ## `useAskableRegionCapture(options?)`
 
-Composable that starts an explicit region or circle selection overlay and emits a structured Context packet through the same `AskableContext`.
+Composable that starts an explicit region, circle, or lasso selection overlay and emits a structured Context packet through the same `AskableContext`.
 
 ```ts
 import { useAskableRegionCapture } from '@askable-ui/vue';
@@ -155,6 +155,7 @@ const capture = useAskableRegionCapture({
 
 capture.start();
 capture.start({ shape: 'circle' });
+capture.start({ shape: 'lasso' });
 capture.cancel();
 ```
 
@@ -162,14 +163,14 @@ capture.cancel();
 
 | Option | Type | Description |
 |---|---|---|
-| `shape` | `'region' \| 'circle'` | Initial capture shape. Default: `'region'` |
+| `shape` | `'region' \| 'circle' \| 'lasso'` | Initial capture shape. Default: `'region'` |
 | `includeViewport` | `boolean` | Include viewport metadata in the emitted Context packet |
 | `source` | `WebContextSource` | App/page source metadata attached to the packet |
 | `intent` | `string` | User intent attached to the capture |
 | `ctx` | `AskableContext` | Optional context to share with other Vue consumers |
 | `name` | `string` | Optional shared context name when `ctx` is not provided |
 | `events` | `AskableEvent[]` | Observation events for the underlying `useAskable()` context |
-| `onCapture` | `(packet, selection) => void` | Called after a region or circle is accepted |
+| `onCapture` | `(packet, selection) => void` | Called after a region, circle, or lasso is accepted |
 | `onCancel` | `() => void` | Called after active capture is cancelled |
 
 **Returns:**
@@ -178,7 +179,7 @@ capture.cancel();
 |---|---|---|
 | `active` | `Ref<boolean>` | Whether the overlay is active |
 | `lastPacket` | `ShallowRef<WebContextPacket \| null>` | Last captured Context packet |
-| `lastSelection` | `ShallowRef<AskableRegionCaptureSelection \| null>` | Last raw region/circle selection geometry |
+| `lastSelection` | `ShallowRef<AskableRegionCaptureSelection \| null>` | Last raw region/circle/lasso selection geometry |
 | `start` | `(overrides?) => void` | Starts capture, optionally overriding options for one capture |
 | `cancel` | `() => void` | Cancels the active overlay |
 | `destroy` | `() => void` | Cancels capture and removes overlay listeners |

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -103,10 +103,10 @@ ctx.toContextPacket({
 });
 ```
 
-## Region and circle capture
+## Region, circle, and lasso capture
 
 For "send this part of the page" interactions, `@askable-ui/core` can mount a
-temporary drag overlay and emit a packet with region geometry:
+temporary drag overlay and emit a packet with selected geometry:
 
 ```ts
 import { createAskableContext, createAskableRegionCapture } from '@askable-ui/core';
@@ -115,7 +115,7 @@ const ctx = createAskableContext({ viewport: true });
 ctx.observe(document);
 
 const capture = createAskableRegionCapture(ctx, {
-  shape: 'circle',
+  shape: 'lasso',
   intent: 'explain this selected chart segment',
   includeViewport: true,
   onCapture: (packet) => {
@@ -126,9 +126,10 @@ const capture = createAskableRegionCapture(ctx, {
 capture.start();
 ```
 
-The resulting packet uses `capture.mode` of `region` or `circle`, sets
-`privacy.consent` to `explicit`, and places the selected bounds on
-`target.bounds`.
+The resulting packet uses `capture.mode` of `region`, `circle`, or `lasso`,
+sets `privacy.consent` to `explicit`, and places the selected bounds on
+`target.bounds`. Lasso packets also include the freehand path in
+`target.metadata.points`.
 
 Framework apps can use wrapper APIs instead:
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.10.0**.
+> Current npm release: **v0.11.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/react.md
+++ b/site/docs/guide/react.md
@@ -131,7 +131,7 @@ function MetricCard({ data }) {
 
 See [Ask AI Button](/examples/ask-ai-button) for a full working example.
 
-## Region and circle capture
+## Region, circle, and lasso capture
 
 For visual "send this part of the page" flows, use
 `useAskableRegionCapture()` with the same context that powers the rest of your
@@ -158,6 +158,9 @@ function RegionTools() {
       <button onClick={() => capture.start({ shape: 'circle' })}>
         Circle area
       </button>
+      <button onClick={() => capture.start({ shape: 'lasso' })}>
+        Lasso area
+      </button>
       {capture.active && <button onClick={capture.cancel}>Cancel</button>}
     </div>
   );
@@ -165,7 +168,8 @@ function RegionTools() {
 ```
 
 Region packets use `capture.mode: 'region'`; circle packets use
-`capture.mode: 'circle'` and include center/radius metadata.
+`capture.mode: 'circle'` and include center/radius metadata. Lasso packets use
+`capture.mode: 'lasso'` and include freehand path points.
 
 ## Text selection capture
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,34 +1,36 @@
-# What’s New in v0.10.0
+# What’s New in v0.11.0
 
-askable-ui v0.10.0 adds first-class text selection capture, so highlighted page
-copy can be sent to agents as structured Context packets.
+askable-ui v0.11.0 adds lasso capture, so users can freehand-select irregular
+areas of the page and send the shape to agents as structured Context packets.
 
 ## Highlights
 
-### Highlighted text as Context packets
+### Freehand lasso Context packets
 
-`@askable-ui/core` now exports `createAskableTextSelectionCapture()` for
-capturing the current browser selection or listening to user selection changes.
-Packets use `capture.mode: 'text-selection'`, set explicit consent, and include
-the highlighted copy in `target.text`.
+`createAskableRegionCapture()` now accepts `shape: 'lasso'`. Lasso packets use
+`capture.mode: 'lasso'`, set explicit consent, include the selected bounds in
+`target.bounds`, and include the freehand point path in
+`target.metadata.points`.
 
 ```ts
-import { createAskableContext, createAskableTextSelectionCapture } from '@askable-ui/core';
+import { createAskableContext, createAskableRegionCapture } from '@askable-ui/core';
 
 const ctx = createAskableContext({ viewport: true });
 ctx.observe(document);
 
-const selection = createAskableTextSelectionCapture(ctx, {
+const capture = createAskableRegionCapture(ctx, {
+  shape: 'lasso',
   includeViewport: true,
-  intent: 'answer using the highlighted text',
+  intent: 'answer using this freehand-selected region',
   onCapture: (packet) => sendToAgent(packet),
 });
 
-selection.start();
+capture.start();
 ```
 
-Framework wrappers are available as `useAskableTextSelectionCapture()` for
-React and Vue, plus `createAskableTextSelectionCaptureStore()` for Svelte.
+Framework wrappers already expose the same `shape` override through
+`useAskableRegionCapture()` for React and Vue, plus
+`createAskableRegionCaptureStore()` for Svelte.
 
 Related docs:
 
@@ -36,12 +38,13 @@ Related docs:
 - [@askable-ui/core API](/api/core)
 - [@askable-ui/react API](/api/react)
 
-### Region, circle, and text capture together
+### Region, circle, lasso, and text capture together
 
-Askable now covers three explicit user selection patterns:
+Askable now covers four explicit user selection patterns:
 
 - draw a rectangle with `createAskableRegionCapture()`
 - circle something on screen with `shape: 'circle'`
+- lasso an irregular shape with `shape: 'lasso'`
 - highlight copy with `createAskableTextSelectionCapture()`
 
 All three produce the same versioned Context packet format for MCP bridges,
@@ -49,8 +52,8 @@ browser tools, and agent runtimes.
 
 ### Starter and docs version alignment
 
-`npm create @askable-ui/app` now scaffolds projects pinned to `^0.10.0`, and the
-versioned docs have been advanced to `/docs/v0.10.0/`.
+`npm create @askable-ui/app` now scaffolds projects pinned to `^0.11.0`, and the
+versioned docs have been advanced to `/docs/v0.11.0/`.
 
 ## Recommended next step
 
@@ -62,7 +65,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.10.0** at both:
+The current published docs track **v0.11.0** at both:
 
 - `/docs/`
-- `/docs/v0.10.0/`
+- `/docs/v0.11.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.10.0**.
+> Current npm release: **v0.11.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,16 +59,16 @@ features:
   </video>
 </div>
 
-## Latest in v0.10.0
+## Latest in v0.11.0
 
-- `createAskableTextSelectionCapture()` for sending highlighted page text as Context packets
-- React, Vue, and Svelte wrappers for text selection capture
-- starter app dependency pins advanced to `^0.10.0`
-- continued support for region/circle capture, MCP Context packets, and framework wrappers
+- lasso capture via `shape: 'lasso'` for freehand-selected page regions
+- point-path metadata on lasso Context packets
+- starter app dependency pins advanced to `^0.11.0`
+- continued support for region/circle/text capture, MCP Context packets, and framework wrappers
 
 Start here:
 
-- [What’s New in v0.10.0](/guide/whats-new)
+- [What’s New in v0.11.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.10.0",
-    "slug": "v0.10.0"
+    "label": "v0.11.0",
+    "slug": "v0.11.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.10.0`) is built on every deploy and published to both:
+The current release (`v0.11.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.10.0/` (version-specific URL)
+- `/docs/v0.11.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- add `shape: 'lasso'` support to visual context capture with bounds and freehand point metadata
- add core, React, Vue, Svelte, and browser e2e coverage for lasso capture
- update docs/starter copy and bump packages/docs to 0.11.0

## Verification
- npm ci
- npm test
- npm run build
- npm run build --prefix site/docs
- npm run test:e2e
- npm audit --audit-level=moderate
- node scripts/check-example-askable-versions.mjs
- npm ls @askable-ui/context @askable-ui/core @askable-ui/react @askable-ui/vue @askable-ui/svelte @askable-ui/mcp --workspaces --all
- npm pack --dry-run --json --workspaces
- git diff --check
