### PR TITLE
docs(context): point spec links to standard repo

### DIFF
--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -7,7 +7,7 @@ exports a JSON Schema, and includes helpers for constructing and identifying
 packets. Capture runtimes such as `@askable-ui/core`, browser extensions, and
 MCP bridges can all emit the same packet format.
 
-The open specification lives at https://github.com/askable-ui/context.
+The open specification lives at https://github.com/askable-ui/context-standard.
 
 ```ts
 import { createWebContextPacket } from '@askable-ui/context';

--- a/site/docs/api/context.md
+++ b/site/docs/api/context.md
@@ -2,7 +2,7 @@
 
 Shared packet types and schema for structured Context packets.
 
-The open specification lives at [askable-ui/context](https://github.com/askable-ui/context).
+The open specification lives at [askable-ui/context-standard](https://github.com/askable-ui/context-standard).
 
 ```bash
 npm install @askable-ui/context

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -4,7 +4,7 @@ Prompt strings are useful for simple chat integrations. Context packets are
 for agents, MCP bridges, browser extensions, and tools that need structured
 context instead of prose.
 
-The open specification lives at [askable-ui/context](https://github.com/askable-ui/context).
+The open specification lives at [askable-ui/context-standard](https://github.com/askable-ui/context-standard).
 
 ```ts
 const packet = ctx.toContextPacket({


### PR DESCRIPTION
## Summary
- Update Context spec links to the renamed askable-ui/context-standard repository.
- Keep the npm package name and imports as @askable-ui/context.

## Validation
- npm run build --prefix site/docs
- git diff --check