### PR TITLE
docs(demo): showcase interaction patterns

### DIFF
--- a/examples/analytics-dashboard-react/README.md
+++ b/examples/analytics-dashboard-react/README.md
@@ -2,6 +2,16 @@
 
 A runnable Next.js dashboard example showing how Askable can annotate complex product surfaces like metrics grids, charts, tables, and sidebars.
 
+The live demo now exposes the main interaction patterns:
+
+- click or hover annotated cards and charts for implicit focus context
+- draw a rectangular region over the dashboard
+- circle one object or anomaly
+- lasso an irregular page area
+- highlight text in a table or card and send it to the chat sidebar
+
+Each pattern feeds the same Askable context that the sidebar reads.
+
 - **Stable live URL:** [askable-mu.vercel.app](https://askable-mu.vercel.app/)
 - **Pull request previews:** surfaced automatically by Vercel on GitHub PRs for this project
 

--- a/examples/analytics-dashboard-react/components/askable-banner.tsx
+++ b/examples/analytics-dashboard-react/components/askable-banner.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import { MousePointer, MousePointerClick, Pointer, X, Info } from "lucide-react"
+import { AskableInteractionToolbar } from "@/components/askable-interaction-toolbar"
 import { Button } from "@/components/ui/button"
 
 interface AskableBannerProps {
@@ -15,8 +16,8 @@ export function AskableBanner({ className }: AskableBannerProps) {
 
   return (
     <div className={`border-b border-border bg-gradient-to-r from-chart-1/5 via-transparent to-chart-3/5 ${className}`}>
-      <div className="flex items-center justify-between gap-4 px-4 py-3">
-        <div className="flex flex-1 items-center gap-6">
+      <div className="flex flex-col gap-3 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-1 flex-col gap-3 xl:flex-row xl:items-center xl:gap-6">
           <div className="flex items-center gap-2">
             <Info className="h-4 w-4 text-chart-1" />
             <span className="text-sm font-medium text-foreground">askable-ui enabled</span>
@@ -43,10 +44,12 @@ export function AskableBanner({ className }: AskableBannerProps) {
             </div>
           </div>
 
-          <div className="hidden items-center gap-2 rounded-full bg-secondary/50 px-3 py-1 text-xs text-muted-foreground lg:flex">
+          <div className="hidden items-center gap-2 rounded-full bg-secondary/50 px-3 py-1 text-xs text-muted-foreground 2xl:flex">
             <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-green-500" />
-            <span>Selected elements appear in chat sidebar</span>
+            <span>Elements and explicit selections appear in chat sidebar</span>
           </div>
+
+          <AskableInteractionToolbar />
         </div>
 
         <Button

--- a/examples/analytics-dashboard-react/components/askable-interaction-toolbar.tsx
+++ b/examples/analytics-dashboard-react/components/askable-interaction-toolbar.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import { useState } from "react"
+import { CircleIcon, MousePointer, MousePointerClick, Pointer, X } from "lucide-react"
+import {
+  useAskable,
+  useAskableRegionCapture,
+  useAskableTextSelectionCapture,
+} from "@askable-ui/react"
+import { Button } from "@/components/ui/button"
+
+function round(value: number) {
+  return Math.round(value)
+}
+
+function boundsLabel(bounds: { x: number; y: number; width: number; height: number }) {
+  return `${round(bounds.width)}x${round(bounds.height)} at ${round(bounds.x)},${round(bounds.y)}`
+}
+
+export function AskableInteractionToolbar() {
+  const { ctx } = useAskable({ inspector: true })
+  const [status, setStatus] = useState("Use a tool to send explicit page context to the chat.")
+
+  const region = useAskableRegionCapture({
+    ctx,
+    includeViewport: true,
+    source: { app: "analytics-dashboard-demo" },
+    onCapture(packet, selection) {
+      const label = `${selection.shape} selection: ${boundsLabel(selection.bounds)}`
+      ctx.push(
+        {
+          capture: packet.capture.mode,
+          gesture: packet.capture.gesture ?? selection.shape,
+          shape: selection.shape,
+          bounds: selection.bounds,
+          ...(selection.radius ? { radius: round(selection.radius) } : {}),
+          ...(selection.points ? { points: selection.points.length } : {}),
+        },
+        label,
+      )
+      setStatus(label)
+    },
+    onCancel() {
+      setStatus("Selection cancelled.")
+    },
+  })
+
+  const text = useAskableTextSelectionCapture({
+    ctx,
+    source: { app: "analytics-dashboard-demo" },
+    onCapture(packet, selection) {
+      const label = `Highlighted text: ${selection.text}`
+      ctx.push(
+        {
+          capture: packet.capture.mode,
+          gesture: packet.capture.gesture ?? "programmatic",
+          length: selection.text.length,
+          ...(selection.bounds ? { bounds: selection.bounds } : {}),
+        },
+        label,
+      )
+      setStatus(`Sent ${selection.text.length} selected characters to chat context.`)
+    },
+  })
+
+  const active = region.active || text.active
+
+  function captureText() {
+    const packet = text.captureNow({
+      dedupe: false,
+      intent: "answer using this highlighted text",
+    })
+    if (!packet) {
+      setStatus("Highlight text on the page first, then send it as context.")
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-border bg-background/70 p-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => region.start({ shape: "region", intent: "answer using this selected page region" })}
+        >
+          <MousePointerClick className="h-3.5 w-3.5" />
+          Region
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => region.start({ shape: "circle", intent: "answer using this circled area" })}
+        >
+          <CircleIcon className="h-3.5 w-3.5" />
+          Circle
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => region.start({ shape: "lasso", intent: "answer using this lassoed area" })}
+        >
+          <Pointer className="h-3.5 w-3.5" />
+          Lasso
+        </Button>
+        <Button variant="outline" size="sm" onClick={captureText}>
+          <MousePointer className="h-3.5 w-3.5" />
+          Send text
+        </Button>
+        {active && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              region.cancel()
+              text.cancel()
+            }}
+          >
+            <X className="h-3.5 w-3.5" />
+            Cancel
+          </Button>
+        )}
+      </div>
+      <p className="text-xs leading-relaxed text-muted-foreground">{status}</p>
+    </div>
+  )
+}

--- a/examples/analytics-dashboard-react/components/dashboard/chat-sidebar.tsx
+++ b/examples/analytics-dashboard-react/components/dashboard/chat-sidebar.tsx
@@ -21,7 +21,7 @@ const initialMessages: Message[] = [
   {
     id: "1",
     role: "assistant",
-    content: "Hi! I am your AI assistant powered by askable-ui. Click on any element to give me context about what you&apos;re looking at, then ask me questions!",
+    content: "Hi! I am your AI assistant powered by askable-ui. Click an element, draw a region, circle or lasso an area, or send highlighted text to give me context.",
     timestamp: new Date(Date.now() - 60000),
   },
 ]
@@ -149,7 +149,7 @@ export function ChatSidebar() {
               </div>
               <div>
                 <span className="text-sm font-medium text-muted-foreground">No Element Selected</span>
-                <p className="text-xs text-muted-foreground/70">Click any card or metric to capture context</p>
+                <p className="text-xs text-muted-foreground/70">Click a card, draw a region, lasso an area, or send highlighted text</p>
               </div>
             </div>
           </div>

--- a/examples/analytics-dashboard-react/components/demos/analytics-demo.tsx
+++ b/examples/analytics-dashboard-react/components/demos/analytics-demo.tsx
@@ -79,7 +79,7 @@ export function AnalyticsDemo() {
         <div className="mb-6">
           <h1 className="text-2xl font-semibold text-foreground">Analytics Dashboard</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Click any metric or chart to give the AI context about what you&apos;re viewing
+            Click a metric, draw over a chart, circle an anomaly, lasso an irregular area, or send highlighted table text as AI context
           </p>
         </div>
 

--- a/examples/analytics-dashboard-react/package-lock.json
+++ b/examples/analytics-dashboard-react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-project",
       "version": "0.1.0",
       "dependencies": {
-        "@askable-ui/react": "^0.6.1",
+        "@askable-ui/react": "^0.11.0",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-alert-dialog": "1.1.15",
@@ -83,19 +83,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@askable-ui/core": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.6.1.tgz",
-      "integrity": "sha512-8L+lZQb2t2/qUsF0MWA0gh7autmtUgzvgHdtpLcBTP6mmJNjQ4cvwkj9Z/15FKBiVTWHKFi/NwzoGLFsGcIoIA==",
+    "node_modules/@askable-ui/context": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.11.0.tgz",
+      "integrity": "sha512-IC0THMXbESyACSxTmtSt10KC9KZFoDy5oBhm4vDAlZojjN797Hqot4GWO2DJEjaN8EkofU+aeLhS/2YMm34cug==",
       "license": "MIT"
     },
-    "node_modules/@askable-ui/react": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.6.1.tgz",
-      "integrity": "sha512-Yn2jWQDBg79kAoCeSgRjbQzxUiAQCwAvY65Tjv65ePTswxAG2YjkRFF9FNYvpvQvdHl3NXPShy7U0sxO9PXrkg==",
+    "node_modules/@askable-ui/core": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-d/JaH+ghlEI8k6hlK23rKqp0UcCOLSABAaysbWNjOzJnWoSC8uzhZYqQgYhgaQU3KGGx9OlKMYNUtq4tuWUcmg==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.6.1"
+        "@askable-ui/context": "^0.11.0"
+      }
+    },
+    "node_modules/@askable-ui/react": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.11.0.tgz",
+      "integrity": "sha512-Bnu/W3okP5WqY1coRdM/NzuN0wnh0yg7CWpUTvXTIGapi/AOiJXpb6LUxU2wef0dd/M56VhjCWtL5YCl28yMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@askable-ui/core": "^0.11.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",

--- a/examples/analytics-dashboard-react/pnpm-lock.yaml
+++ b/examples/analytics-dashboard-react/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@askable-ui/react':
-        specifier: ^0.6.1
-        version: 0.6.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.11.0
+        version: 0.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.72.1(react@19.2.6))
@@ -193,11 +193,14 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@askable-ui/core@0.6.1':
-    resolution: {integrity: sha512-8L+lZQb2t2/qUsF0MWA0gh7autmtUgzvgHdtpLcBTP6mmJNjQ4cvwkj9Z/15FKBiVTWHKFi/NwzoGLFsGcIoIA==}
+  '@askable-ui/context@0.11.0':
+    resolution: {integrity: sha512-IC0THMXbESyACSxTmtSt10KC9KZFoDy5oBhm4vDAlZojjN797Hqot4GWO2DJEjaN8EkofU+aeLhS/2YMm34cug==}
 
-  '@askable-ui/react@0.6.1':
-    resolution: {integrity: sha512-Yn2jWQDBg79kAoCeSgRjbQzxUiAQCwAvY65Tjv65ePTswxAG2YjkRFF9FNYvpvQvdHl3NXPShy7U0sxO9PXrkg==}
+  '@askable-ui/core@0.11.0':
+    resolution: {integrity: sha512-d/JaH+ghlEI8k6hlK23rKqp0UcCOLSABAaysbWNjOzJnWoSC8uzhZYqQgYhgaQU3KGGx9OlKMYNUtq4tuWUcmg==}
+
+  '@askable-ui/react@0.11.0':
+    resolution: {integrity: sha512-Bnu/W3okP5WqY1coRdM/NzuN0wnh0yg7CWpUTvXTIGapi/AOiJXpb6LUxU2wef0dd/M56VhjCWtL5YCl28yMeA==}
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
@@ -1771,11 +1774,15 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@askable-ui/core@0.6.1': {}
+  '@askable-ui/context@0.11.0': {}
 
-  '@askable-ui/react@0.6.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@askable-ui/core@0.11.0':
     dependencies:
-      '@askable-ui/core': 0.6.1
+      '@askable-ui/context': 0.11.0
+
+  '@askable-ui/react@0.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@askable-ui/core': 0.11.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 

--- a/packages/create-askable-app/README.md
+++ b/packages/create-askable-app/README.md
@@ -16,6 +16,7 @@ The generated app includes:
 - a small analytics dashboard annotated with `data-askable`
 - `useAskable()` pre-wired for hover + click focus tracking
 - region, circle, and lasso capture buttons for explicit page-area context
+- highlighted-text capture for "use this copy" prompts
 - `useCopilotReadable()` pushing current and recent Askable context into CopilotKit
 - a local Express runtime wired to `@copilotkit/runtime`
 - a starter README and `.env.example`

--- a/packages/create-askable-app/template/README.md
+++ b/packages/create-askable-app/template/README.md
@@ -36,9 +36,11 @@ If `OPENAI_API_KEY` is blank, the runtime still starts so the dashboard loads, b
 2. `useAskable()` observes the page and produces prompt-ready context like:
    - current focus
    - recent interaction history
-3. `useCopilotReadable()` forwards those Askable strings into CopilotKit.
-4. CopilotKit sends the chat request to the local runtime at `/api/copilotkit`.
-5. The runtime calls the LLM and answers with the current dashboard context already attached.
+3. `useAskableRegionCapture()` adds region, circle, and lasso tools for visual page selection.
+4. `useAskableTextSelectionCapture()` lets the user highlight text and send it as context.
+5. `useCopilotReadable()` forwards those Askable strings and packets into CopilotKit.
+6. CopilotKit sends the chat request to the local runtime at `/api/copilotkit`.
+7. The runtime calls the LLM and answers with the current dashboard context already attached.
 
 ## Starter structure
 

--- a/packages/create-askable-app/template/src/App.tsx
+++ b/packages/create-askable-app/template/src/App.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import { CopilotSidebar } from '@copilotkit/react-ui';
 import { useCopilotReadable } from '@copilotkit/react-core';
-import { useAskable, useAskableRegionCapture } from '@askable-ui/react';
+import { useAskable, useAskableRegionCapture, useAskableTextSelectionCapture } from '@askable-ui/react';
 
 type MetricCard = {
   id: string;
@@ -62,6 +62,7 @@ export default function App() {
   const { ctx, promptContext } = useAskable();
   const [selectedPanel, setSelectedPanel] = useState<string | null>(null);
   const [regionContext, setRegionContext] = useState('No page region captured yet.');
+  const [textContext, setTextContext] = useState('No highlighted text captured yet.');
   const panelRefs = useRef<Record<string, HTMLElement | null>>({});
   const regionCapture = useAskableRegionCapture({
     ctx,
@@ -73,6 +74,32 @@ export default function App() {
         target: packet.target,
         selection,
       }, null, 2));
+      ctx.push(
+        {
+          capture: packet.capture.mode,
+          shape: selection.shape,
+          bounds: selection.bounds,
+        },
+        `${selection.shape} selection on the dashboard`,
+      );
+    },
+  });
+  const textCapture = useAskableTextSelectionCapture({
+    ctx,
+    source: { app: 'askable-starter' },
+    onCapture(packet, selection) {
+      setTextContext(JSON.stringify({
+        capture: packet.capture,
+        target: packet.target,
+        selection,
+      }, null, 2));
+      ctx.push(
+        {
+          capture: packet.capture.mode,
+          length: selection.text.length,
+        },
+        selection.text,
+      );
     },
   });
 
@@ -104,6 +131,14 @@ export default function App() {
       value: regionContext,
     },
     [regionContext],
+  );
+
+  useCopilotReadable(
+    {
+      description: 'The last highlighted text selection the user sent as Askable context.',
+      value: textContext,
+    },
+    [textContext],
   );
 
   function focusPanel(id: string) {
@@ -153,6 +188,21 @@ export default function App() {
               onClick={() => regionCapture.start({ shape: 'lasso', intent: 'explain this lassoed area' })}
             >
               Lasso area
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => {
+                const packet = textCapture.captureNow({
+                  dedupe: false,
+                  intent: 'answer using this highlighted text',
+                });
+                if (!packet) {
+                  setTextContext('Highlight text in a card, chart note, or table row before sending it as context.');
+                }
+              }}
+            >
+              Send selected text
             </button>
             {regionCapture.active && (
               <button type="button" className="secondary" onClick={regionCapture.cancel}>
@@ -235,6 +285,8 @@ export default function App() {
             <pre>{recentContext}</pre>
             <h3>Selected page region</h3>
             <pre>{regionContext}</pre>
+            <h3>Highlighted text</h3>
+            <pre>{textContext}</pre>
           </article>
         </section>
 

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
           text: 'Introduction',
           items: [
             { text: 'What is askable-ui?', link: '/guide/' },
-            { text: 'What’s New in v0.7.0', link: '/guide/whats-new' },
+            { text: `What’s New in ${currentVersion.label}`, link: '/guide/whats-new' },
             { text: 'Getting Started', link: '/guide/getting-started' },
             { text: 'How It Works', link: '/guide/how-it-works' },
           ],

--- a/site/docs/examples/dashboard.md
+++ b/site/docs/examples/dashboard.md
@@ -8,8 +8,9 @@ The pattern:
 
 1. Annotate each dashboard widget with `data-askable` metadata
 2. Track active focus with `useAskable` / `useAskable()` / `createAskableStore()`
-3. Inject `promptContext` into every AI request
-4. Optionally inject `historyContext` for a conversation-aware assistant
+3. Add explicit tools for Ask AI buttons, region/circle/lasso capture, and highlighted text when the user needs more precise context than a single widget
+4. Inject `promptContext` into every AI request
+5. Optionally inject `historyContext` or structured Context packets for a conversation-aware assistant
 
 ::: code-group
 
@@ -17,7 +18,12 @@ The pattern:
 // components/Dashboard.tsx
 'use client';
 import { useRef, useState } from 'react';
-import { Askable, useAskable } from '@askable-ui/react';
+import {
+  Askable,
+  useAskable,
+  useAskableRegionCapture,
+  useAskableTextSelectionCapture,
+} from '@askable-ui/react';
 import { useChat } from 'ai/react';
 
 const widgets = [
@@ -30,6 +36,22 @@ export function Dashboard() {
   const { ctx, promptContext } = useAskable();
   const [chatOpen, setChatOpen] = useState(false);
   const refs = useRef<Record<string, HTMLElement | null>>({});
+  const region = useAskableRegionCapture({
+    ctx,
+    includeViewport: true,
+    onCapture(packet, selection) {
+      ctx.push(
+        { capture: packet.capture.mode, shape: selection.shape, bounds: selection.bounds },
+        `${selection.shape} selection on the dashboard`
+      );
+    },
+  });
+  const text = useAskableTextSelectionCapture({
+    ctx,
+    onCapture(packet, selection) {
+      ctx.push({ capture: packet.capture.mode, length: selection.text.length }, selection.text);
+    },
+  });
 
   // Include last 5 interactions so the AI can answer follow-up questions
   const historyContext = ctx.toHistoryContext(5);
@@ -63,6 +85,13 @@ export function Dashboard() {
             </button>
           </Askable>
         ))}
+      </div>
+
+      <div className="selection-tools">
+        <button onClick={() => region.start({ shape: 'region' })}>Select region</button>
+        <button onClick={() => region.start({ shape: 'circle' })}>Circle anomaly</button>
+        <button onClick={() => region.start({ shape: 'lasso' })}>Lasso area</button>
+        <button onClick={() => text.captureNow({ dedupe: false })}>Send selected text</button>
       </div>
 
       {chatOpen && (

--- a/site/docs/guide/how-it-works.md
+++ b/site/docs/guide/how-it-works.md
@@ -3,18 +3,18 @@
 ## The data flow
 
 ```
-  DOM element          AskableContext           Your AI handler
-  ─────────────        ──────────────           ────────────────
-  data-askable ──►  MutationObserver  ──►  ctx.toPromptContext()
-  attribute         tracks all matching       returns a string
-                    elements, listens         ready for your LLM
-                    for click/hover/focus
+  UI interaction          AskableContext           Your AI handler
+  ──────────────          ──────────────           ────────────────
+  data-askable       ─►   current focus       ─►   ctx.toPromptContext()
+  ctx.select()       ─►   history             ─►   ctx.toContextPacket()
+  ctx.push()         ─►   visible elements    ─►   MCP / agent bridge
+  region/text tools  ─►   Context packet
 ```
 
-1. You annotate elements with `data-askable` (once, at build time).
+1. You annotate elements with `data-askable` or push semantic metadata from app code.
 2. `ctx.observe()` starts a `MutationObserver` on the root you give it. As elements enter or leave the DOM, the observer attaches and detaches event listeners automatically.
-3. When a user interacts with an annotated element, the context is updated — no re-renders, no state management required.
-4. Your AI handler calls `ctx.toPromptContext()` at request time and gets a plain string to inject into the system message.
+3. When a user interacts with an annotated element, presses an Ask AI button, highlights text, draws a region, circles an area, or lassos an irregular shape, the context is updated or emitted as a Context packet.
+4. Your AI handler calls `ctx.toPromptContext()` for prompt-ready text or `ctx.toContextPacket()` for structured agent/MCP transport.
 
 ## The Observer
 
@@ -55,6 +55,21 @@ User is focused on: — metric: mrr, value: $128k — value "Monthly Recurring R
 - Meta key-value pairs follow, formatted as `key: value, ...`.
 - The element's trimmed `textContent` is appended as `value "..."` (label is configurable).
 - See [Prompt Serialization](/guide/serialization) for all options including JSON output and token budgets.
+
+## Explicit selection tools
+
+Some user intent is not tied to one DOM element. Askable includes explicit capture tools for those cases:
+
+| Tool | Best for | Packet mode |
+| --- | --- | --- |
+| `ctx.select(element)` | Ask AI buttons and known widgets | `element-focus` |
+| `ctx.push(meta, text)` | App events, command palettes, generated summaries | `semantic` |
+| `createAskableRegionCapture(ctx)` | Dragging a rectangular page area | `region` |
+| `createAskableRegionCapture(ctx, { shape: 'circle' })` | Circling one object or anomaly | `circle` |
+| `createAskableRegionCapture(ctx, { shape: 'lasso' })` | Freehand irregular selections | `lasso` |
+| `createAskableTextSelectionCapture(ctx)` | Browser-highlighted copy | `text-selection` |
+
+Region, circle, lasso, and text capture mark `privacy.consent` as `explicit` because the user intentionally selected the context.
 
 ## Singleton vs. scoped contexts
 

--- a/site/docs/guide/index.md
+++ b/site/docs/guide/index.md
@@ -31,7 +31,8 @@ The LLM now knows exactly what the user is looking at. The answer goes from *"re
 
 - **Annotate** — Add `data-askable` to any element. The value can be a JSON object or a plain string.
 - **Observe** — One `ctx.observe(document)` call covers the entire page. A `MutationObserver` automatically picks up dynamically rendered elements.
-- **Inject** — `ctx.toPromptContext()` returns a string ready for any LLM system prompt.
+- **Capture** — Use clicks, hover, keyboard focus, Ask AI buttons, region selection, circle selection, lasso selection, highlighted text, or app events to decide what context the user means.
+- **Inject** — `ctx.toPromptContext()` returns a string ready for any LLM system prompt. `ctx.toContextPacket()` returns a structured packet for MCP bridges, browser extensions, and agent runtimes.
 
 ## What it is not
 
@@ -40,8 +41,31 @@ askable-ui does **not**:
 - Replace your AI SDK or framework
 - Track clicks for analytics — it only maintains the most-recent focused element (plus optional history)
 
+## Interaction patterns
+
+Start simple with annotated elements:
+
+```html
+<button data-askable='{"action":"refund","order":"A-1029"}'>
+  Refund order
+</button>
+```
+
+Then add explicit user-marking tools where the UI needs more precision:
+
+```ts
+const region = createAskableRegionCapture(ctx, { shape: 'lasso' });
+region.start();
+
+const text = createAskableTextSelectionCapture(ctx);
+text.captureNow();
+```
+
+All of these feed the same `AskableContext`, so your chat surface can read one current context no matter whether the user clicked a card, pressed an Ask AI button, circled a chart anomaly, lassoed an area, or highlighted copy.
+
 ## Next steps
 
 - [Getting Started](/guide/getting-started) — install and wire up in 5 minutes
 - [How It Works](/guide/how-it-works) — internals and architecture
+- [Context Packets](/guide/context) — structured packets for agents and MCP
 - [API Reference](/api/core) — full method signatures and options

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -32,8 +32,8 @@ features:
     details: First-class hooks and components for React, React Native, Vue, and Svelte. Web bindings are reactive and SSR-safe; React Native ships a focused press-driven adapter on top of @askable-ui/core.
 
   - icon: 🎯
-    title: Precision control
-    details: Configure which events trigger updates, filter or reorder metadata keys, set token budgets, track multi-step focus history, and use select() for explicit "Ask AI" button patterns.
+    title: Multiple interaction patterns
+    details: Capture implicit focus, explicit Ask AI buttons, highlighted text, rectangular regions, circles, and freehand lasso selections as one structured context model.
 
   - icon: 🔌
     title: Works with agents and MCP
@@ -66,10 +66,27 @@ features:
 - starter app dependency pins advanced to `^0.11.0`
 - continued support for region/circle/text capture, MCP Context packets, and framework wrappers
 
+## Interaction patterns
+
+Askable can capture context at different levels of user intent:
+
+| Pattern | Use it when | API |
+| --- | --- | --- |
+| Element focus | The user clicks, hovers, or tabs into annotated UI | `data-askable`, `ctx.observe()` |
+| Ask AI button | A known widget should be selected before opening chat | `ctx.select(element)` |
+| App event | Your code already knows the semantic object | `ctx.push(meta, text)` |
+| Region | The user wants to mark a rectangular area | `createAskableRegionCapture()` |
+| Circle | The user wants to point at an anomaly or object | `shape: 'circle'` |
+| Lasso | The user wants to freehand-select an irregular area | `shape: 'lasso'` |
+| Highlighted text | The user wants to send selected copy | `createAskableTextSelectionCapture()` |
+
+Every pattern can produce a prompt string with `toPromptContext()` or a structured Context packet with `toContextPacket()`.
+
 Start here:
 
 - [What’s New in v0.11.0](/guide/whats-new)
 - [Context Packets](/guide/context)
+- [React interaction patterns](/guide/react#region-circle-and-lasso-capture)
 - [AI SDK integration patterns](/examples/ai-sdk)
 - [CopilotKit guide](/guide/copilotkit)
 


### PR DESCRIPTION
## Summary

- adds a live interaction toolbar to the analytics demo for region, circle, lasso, and selected-text context
- updates the starter app to forward region and selected-text captures into Askable and CopilotKit context
- refreshes docs, demo README, and npm/pnpm demo lockfiles for the 0.11.0 interaction patterns

## Validation

- npm test
- npm run build
- npm run build --prefix site/docs
- npm run build --prefix examples/analytics-dashboard-react
- npx tsc --noEmit --project examples/analytics-dashboard-react/tsconfig.json
- npm test -w @askable-ui/create-app
- npm run test:e2e (134 passed, 1 skipped)

## Notes

- npm run lint --prefix examples/analytics-dashboard-react is currently not runnable because the example does not declare eslint.
