### PR TITLE
feat(core): copy inspector prompt context

### DIFF
--- a/packages/core/src/__tests__/inspector.test.ts
+++ b/packages/core/src/__tests__/inspector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { createAskableContext } from '../index.js';
 import { createAskableInspector } from '../inspector.js';
 
@@ -316,6 +316,37 @@ describe('createAskableInspector', () => {
     expect(document.querySelector('[data-askable-inspector-tool="text"]')).not.toBeNull();
     expect(document.querySelector('[data-askable-inspector-tool="clear"]')).not.toBeNull();
 
+    inspector.destroy();
+    ctx.destroy();
+  });
+
+  it('copies the current prompt context from the inspector', async () => {
+    const el = attach(makeEl({ metric: 'revenue', value: '$128k' }, 'Revenue'));
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const ctx = createAskableContext();
+    ctx.observe(document);
+    const inspector = createAskableInspector(ctx);
+
+    el.click();
+    document
+      .querySelector('[data-askable-inspector-copy]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('revenue'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('$128k'));
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
     inspector.destroy();
     ctx.destroy();
   });

--- a/packages/core/src/inspector.ts
+++ b/packages/core/src/inspector.ts
@@ -168,6 +168,41 @@ function inspectorButtonStyle(active = false): string {
   ].join(';');
 }
 
+function copyButtonStyle(): string {
+  return [
+    'border:1px solid #30363d',
+    'background:#21262d',
+    'color:#c9d1d9',
+    'border-radius:6px',
+    'font:inherit',
+    'font-size:11px',
+    'line-height:1',
+    'padding:5px 7px',
+    'cursor:pointer',
+  ].join(';');
+}
+
+async function copyText(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.cssText = [
+    'position:fixed',
+    'top:-9999px',
+    'left:-9999px',
+    'opacity:0',
+  ].join(';');
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  textarea.remove();
+}
+
 /**
  * Mount a floating inspector panel that shows the current Askable focus,
  * parsed metadata, and prompt output in real time.
@@ -235,7 +270,10 @@ export function createAskableInspector(
   ].join(';');
   header.innerHTML = `
     <span style="color:#58a6ff;font-weight:700;font-size:11px;letter-spacing:.06em">✦ ASKABLE INSPECTOR</span>
-    <button id="askable-inspector-close" style="background:none;border:none;color:#8b949e;cursor:pointer;font-size:14px;line-height:1;padding:2px" title="Close">&times;</button>
+    <span style="display:flex;align-items:center;gap:6px">
+      <button id="askable-inspector-copy" data-askable-inspector-copy style="${copyButtonStyle()}" title="Copy prompt context">Copy</button>
+      <button id="askable-inspector-close" style="background:none;border:none;color:#8b949e;cursor:pointer;font-size:14px;line-height:1;padding:2px" title="Close">&times;</button>
+    </span>
   `;
   panel.appendChild(header);
 
@@ -256,6 +294,7 @@ export function createAskableInspector(
   document.body.appendChild(panel);
 
   let highlightedEl: HTMLElement | null = null;
+  let latestPromptContext = '';
 
   function clearHighlight() {
     if (highlightedEl) {
@@ -277,6 +316,7 @@ export function createAskableInspector(
 
   function update(focus: AskableFocus | null) {
     const promptContext = ctx.toPromptContext(promptOptions);
+    latestPromptContext = promptContext;
     body.innerHTML = buildPanelHTML(focus, promptContext, ctx.listSources());
     if (focus?.element?.isConnected) applyHighlight(focus.element);
     else clearHighlight();
@@ -441,6 +481,22 @@ export function createAskableInspector(
   renderTools();
   header.addEventListener('mousedown', onDragStart);
   panel.querySelector('#askable-inspector-close')?.addEventListener('click', destroy);
+  panel.querySelector('#askable-inspector-copy')?.addEventListener('click', async (event) => {
+    const button = event.currentTarget;
+    if (!(button instanceof HTMLButtonElement)) return;
+    try {
+      await copyText(latestPromptContext);
+      button.textContent = 'Copied';
+      window.setTimeout(() => {
+        if (!destroyed) button.textContent = 'Copy';
+      }, 1200);
+    } catch {
+      button.textContent = 'Failed';
+      window.setTimeout(() => {
+        if (!destroyed) button.textContent = 'Copy';
+      }, 1200);
+    }
+  });
 
   return { destroy };
 }

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -801,6 +801,7 @@ ctx.observe(document);
 
 const inspector = createAskableInspector(ctx);
 // Shows a draggable floating panel in the bottom-right corner with test tools.
+// Use Copy to copy the current prompt context exactly as the panel renders it.
 
 // Tear down when done:
 inspector.destroy();

--- a/site/docs/guide/inspector.md
+++ b/site/docs/guide/inspector.md
@@ -6,6 +6,9 @@ The panel also shows registered context sources, so you can confirm that
 app-owned sources such as tables, documents, charts, or MCP bridges are mounted
 and refreshing while you test interactions.
 
+Use the `Copy` action in the header to copy the exact prompt context currently
+shown in the panel.
+
 ## What it shows
 
 The panel updates in real time whenever the focused element changes:


### PR DESCRIPTION
## Summary
- add a Copy action to the inspector header for the rendered prompt context
- show temporary copied/failed state after clipboard writes
- document the inspector copy workflow

## Verification
- npm test -w @askable-ui/core -- inspector.test.ts
- npm test -w @askable-ui/core
- npm run build
- npm run build:versioned --prefix site/docs
- git diff --check