### PR TITLE
feat(site): add launch campaign assets

### DIFF
--- a/marketing/launch-campaign.md
+++ b/marketing/launch-campaign.md
@@ -1,0 +1,148 @@
+# Askable launch campaign
+
+## Positioning
+
+Askable makes application UI understandable to chat agents. Developers can mark elements, lasso regions, circle details, capture selected text, and include app-owned sources such as full tables or documents as explicit context.
+
+Primary message:
+
+> Stop asking users to describe the screen. Let them point, select, circle, or lasso the exact UI context the agent should use.
+
+One-line tagline options:
+
+- UI context your model can actually use.
+- Point at your app. Askable turns it into agent context.
+- Selection, lasso, and app state for AI chat.
+- The UI context layer for AI-native applications.
+
+## Launch assets
+
+- Website: `https://askable-ui.com`
+- GitHub: `https://github.com/askable-ui/askable`
+- Docs: `https://askable-ui.com/docs/`
+- Demo video page: `site/www/launch-video.html`
+- Existing social image: `site/www/social.png`
+- Existing demo GIF: `site/www/demo.gif`
+
+## Product Hunt draft
+
+Name:
+
+Askable UI
+
+Tagline:
+
+Turn UI selections, regions, and app state into AI-ready context.
+
+Short description:
+
+Askable UI is an open source context layer for AI-native apps. Add click, hover, text selection, circle, lasso, and app-owned data sources so chat agents know exactly what the user is pointing at.
+
+Maker comment:
+
+We built Askable UI because AI chat inside apps still depends on users explaining what is already on screen.
+
+The missing primitive is explicit UI context. A user should be able to click a row, highlight text, circle a chart point, or lasso a dashboard area and have the agent receive structured, consented context. For richer cases, the app can also register sources such as the full table, current document, filters, route, or selected objects.
+
+Askable UI gives developers that layer across React, Vue, Svelte, React Native, and plain JavaScript. It includes UI annotations, interaction capture, structured Context packets, prompt serialization, MCP support, and dev tooling for inspecting what will be sent.
+
+We are launching this as open source because this should become a normal interaction pattern for AI-native software, not a one-off widget in every app.
+
+I would love feedback from builders working on copilots, internal tools, dashboards, support tooling, and browser agents: what context do your users still have to explain manually today?
+
+Gallery shot ideas:
+
+- Hero: "Point, lasso, select. Your agent gets the context."
+- Interaction modes: click, hover, text selection, circle, lasso.
+- App-owned sources: visible selection plus full table/document context.
+- Protocol angle: structured Context packet from UI to chat/MCP.
+- Frameworks: React, Vue, Svelte, React Native, vanilla JS.
+
+Topics:
+
+- Artificial Intelligence
+- Developer Tools
+- Open Source
+- Productivity
+- SaaS
+
+## Launch sequence
+
+T-minus 14 days:
+
+- Publish the demo video page and record a 45-60 second launch video.
+- Make the README first screen explain the "point at UI -> context for agent" loop.
+- Add 3 short demos: dashboard lasso, text selection, app source/full table.
+- Build a list of 50 direct contacts: AI app builders, devtool founders, internal tooling teams, OSS maintainers, and MCP/browser-agent builders.
+- Ask 10 trusted builders for landing page and demo feedback before announcing.
+
+T-minus 7 days:
+
+- Schedule the Product Hunt launch from a personal maker account.
+- Prepare 5 gallery images and 1 video.
+- Prepare X, LinkedIn, Hacker News, Reddit, and Discord posts.
+- Prepare a launch blog post: "UI context is the missing primitive for AI-native apps."
+- Confirm npm package pages, GitHub README, docs, examples, and website all point to the same current version.
+
+Launch day:
+
+- Post at the start of the Product Hunt day.
+- Add the maker comment immediately.
+- Share the Product Hunt link through personal channels without asking for blind upvotes. Ask for feedback.
+- Reply to every useful comment quickly.
+- Post the demo video natively on X and LinkedIn, not only as a link.
+- Pin the GitHub repo announcement and link to docs.
+
+Post-launch:
+
+- Publish a launch recap with concrete learnings and roadmap.
+- Convert common Product Hunt questions into docs.
+- Open GitHub issues for repeated feature requests.
+- Turn the best demo into the website hero asset.
+
+## Social copy
+
+X short:
+
+AI chat in apps should not make users explain the screen.
+
+Askable UI lets users click, select text, circle, or lasso UI context, then sends structured context to the agent.
+
+Open source. React, Vue, Svelte, React Native, and vanilla JS.
+
+X technical:
+
+Most copilots know the user typed a question, but not what they are looking at.
+
+Askable UI adds:
+- UI annotations
+- click/hover focus
+- text selection
+- circle/lasso capture
+- app-owned context sources
+- structured packets for chat/MCP
+
+LinkedIn:
+
+We are launching Askable UI, an open source context layer for AI-native applications.
+
+The core idea is simple: users should not have to describe the UI they are already looking at. They should be able to click an object, highlight text, circle a chart point, or lasso part of the screen, and the chat agent should receive structured context with clear provenance.
+
+Askable UI gives product teams the building blocks for that interaction pattern across modern web stacks.
+
+Hacker News:
+
+Show HN: Askable UI - open source UI context for AI chat agents
+
+I built Askable UI to solve a problem I kept seeing in app copilots: the user asks about something on screen, but the model only sees the text prompt unless the app builds custom context plumbing.
+
+Askable lets developers mark UI, capture selected regions/text, and register app-owned sources so agents can receive structured context about what the user meant.
+
+## Submission notes
+
+Product Hunt currently requires a personal account to post a product. The product page should be scheduled from the maker account so comments, maker identity, and launch notifications are controlled by the founder.
+
+Reference links:
+
+- Product Hunt launch guide: https://www.producthunt.com/launch
+- Product Hunt help, how to post a product: https://help.producthunt.com/en/articles/479557-how-to-post-a-product

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -713,6 +713,7 @@
       <a href="#how" class="nav-link">How it works</a>
       <a href="#packages" class="nav-link">Packages</a>
       <a href="#integrations" class="nav-link">Integrations</a>
+      <a href="launch-video.html" class="nav-link">Launch video</a>
       <a href="https://askable-ui.com/docs/" target="_blank" rel="noopener noreferrer" class="nav-link">Docs</a>
       <a href="https://github.com/askable-ui/askable" target="_blank" rel="noopener noreferrer" class="nav-gh" aria-label="GitHub repository" title="GitHub repository">
         <svg class="github-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -746,6 +747,7 @@
             <span class="copy-icon" id="copy-icon">⎘ copy</span>
           </button>
           <a href="#demo" class="btn btn-primary">See it live</a>
+          <a href="launch-video.html" class="btn btn-secondary">Launch video</a>
           <a href="https://askable-ui.com/docs/" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">Documentation</a>
           <a href="https://github.com/askable-ui/askable" class="btn btn-secondary btn-icon" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository" title="GitHub repository">
             <svg class="github-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">

--- a/site/www/launch-video.html
+++ b/site/www/launch-video.html
@@ -1,0 +1,544 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Askable UI launch demo</title>
+  <meta name="description" content="A motion demo showing Askable UI interaction context for AI agents." />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    :root {
+      --bg: #f7f8fb;
+      --ink: #0d1117;
+      --muted: #626b7a;
+      --line: rgba(14, 23, 38, .11);
+      --blue: #2563eb;
+      --purple: #7c3aed;
+      --purple-soft: rgba(124, 58, 237, .14);
+      --green: #16a34a;
+      --panel: #ffffff;
+      --shadow: 0 28px 80px rgba(15, 23, 42, .14);
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      --font: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    html, body {
+      margin: 0;
+      min-height: 100%;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: var(--font);
+    }
+
+    body {
+      overflow: hidden;
+    }
+
+    .stage {
+      position: relative;
+      width: 100vw;
+      height: 100vh;
+      min-height: 720px;
+      padding: 42px;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      gap: 22px;
+      background:
+        radial-gradient(circle at 18% 18%, rgba(37, 99, 235, .10), transparent 28%),
+        radial-gradient(circle at 82% 22%, rgba(124, 58, 237, .12), transparent 30%),
+        linear-gradient(180deg, #ffffff 0%, #f5f7fb 100%);
+    }
+
+    .topbar,
+    .footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      position: relative;
+      z-index: 10;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-weight: 800;
+      letter-spacing: -.03em;
+      font-size: 22px;
+    }
+
+    .mark {
+      width: 38px;
+      height: 38px;
+      display: grid;
+      place-items: center;
+      border-radius: 12px;
+      background: #101317;
+      color: #fff;
+      box-shadow: 0 12px 30px rgba(16, 19, 23, .18);
+    }
+
+    .pill {
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, .76);
+      backdrop-filter: blur(14px);
+      border-radius: 999px;
+      padding: 9px 14px;
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 700;
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(440px, .78fr);
+      align-items: center;
+      gap: 38px;
+      position: relative;
+      z-index: 3;
+    }
+
+    .copy {
+      max-width: 760px;
+      padding-bottom: 18px;
+    }
+
+    .kicker {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      color: #3b2f83;
+      background: var(--purple-soft);
+      border: 1px solid rgba(124, 58, 237, .20);
+      font-size: 13px;
+      font-weight: 800;
+      margin-bottom: 24px;
+    }
+
+    h1 {
+      margin: 0;
+      max-width: 820px;
+      font-size: clamp(58px, 7.4vw, 114px);
+      line-height: .96;
+      letter-spacing: -.055em;
+      font-weight: 850;
+    }
+
+    h1 span {
+      color: var(--blue);
+    }
+
+    .subcopy {
+      margin: 24px 0 0;
+      max-width: 620px;
+      color: var(--muted);
+      font-size: 21px;
+      line-height: 1.5;
+      letter-spacing: -.015em;
+    }
+
+    .workflow {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 28px;
+    }
+
+    .workflow span {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 10px 14px;
+      background: #fff;
+      color: #202a3a;
+      font-size: 14px;
+      font-weight: 800;
+      box-shadow: 0 10px 28px rgba(15, 23, 42, .06);
+      opacity: 0;
+      animation: reveal-chip 18s linear infinite;
+    }
+
+    .workflow span:nth-child(2) { animation-delay: 1.6s; }
+    .workflow span:nth-child(3) { animation-delay: 3.2s; }
+    .workflow span:nth-child(4) { animation-delay: 4.8s; }
+
+    .product {
+      position: relative;
+      height: min(64vh, 620px);
+      min-height: 500px;
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      overflow: hidden;
+      background: var(--panel);
+      box-shadow: var(--shadow);
+    }
+
+    .appbar {
+      height: 58px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 18px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255, 255, 255, .92);
+    }
+
+    .dots {
+      display: flex;
+      gap: 7px;
+    }
+
+    .dots i {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      background: #d7dce5;
+    }
+
+    .app-title {
+      color: #647083;
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+
+    .dashboard {
+      height: calc(100% - 58px);
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      padding: 18px;
+      background:
+        linear-gradient(rgba(15, 23, 42, .04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(15, 23, 42, .04) 1px, transparent 1px),
+        #fbfcff;
+      background-size: 34px 34px;
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: rgba(255, 255, 255, .9);
+      padding: 16px;
+      box-shadow: 0 12px 30px rgba(15, 23, 42, .07);
+    }
+
+    .card h2 {
+      margin: 0 0 8px;
+      font-size: 13px;
+      color: #657084;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+    }
+
+    .metric {
+      font-size: 34px;
+      font-weight: 850;
+      letter-spacing: -.05em;
+      margin-bottom: 10px;
+    }
+
+    .bars {
+      display: grid;
+      gap: 8px;
+      margin-top: 14px;
+    }
+
+    .bar {
+      height: 10px;
+      border-radius: 999px;
+      background: #e5e9f2;
+      overflow: hidden;
+    }
+
+    .bar i {
+      display: block;
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, var(--blue), var(--purple));
+    }
+
+    .table {
+      grid-column: span 2;
+      display: grid;
+      gap: 8px;
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: 1.2fr .7fr .7fr .6fr;
+      align-items: center;
+      min-height: 42px;
+      gap: 12px;
+      border: 1px solid rgba(15, 23, 42, .08);
+      border-radius: 12px;
+      padding: 0 12px;
+      background: #fff;
+      color: #202a3a;
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .row small {
+      color: #7a8494;
+      font-weight: 700;
+    }
+
+    .context-panel {
+      position: absolute;
+      right: 18px;
+      bottom: 18px;
+      width: min(430px, calc(100% - 36px));
+      border: 1px solid rgba(15, 23, 42, .14);
+      border-radius: 18px;
+      background: rgba(13, 17, 23, .94);
+      color: #e6edf3;
+      padding: 14px;
+      font-family: var(--mono);
+      font-size: 12px;
+      line-height: 1.55;
+      box-shadow: 0 26px 80px rgba(15, 23, 42, .32);
+      transform: translateY(16px);
+      opacity: 0;
+      animation: context-in 18s linear infinite;
+    }
+
+    .context-panel strong {
+      display: block;
+      color: #a5d6ff;
+      font-family: var(--font);
+      font-size: 12px;
+      margin-bottom: 7px;
+      letter-spacing: .02em;
+    }
+
+    .context-panel code {
+      color: #d2a8ff;
+      white-space: pre-wrap;
+    }
+
+    .cursor {
+      position: absolute;
+      left: 110px;
+      top: 160px;
+      width: 38px;
+      height: 38px;
+      z-index: 9;
+      filter: drop-shadow(0 8px 14px rgba(37, 99, 235, .28));
+      animation: cursor-path 18s cubic-bezier(.65, 0, .28, 1) infinite;
+    }
+
+    .cursor svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    .trail {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      z-index: 7;
+    }
+
+    .trail path {
+      fill: none;
+      stroke: url(#lassoGradient);
+      stroke-width: 8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-dasharray: 640;
+      stroke-dashoffset: 640;
+      opacity: 0;
+      filter: drop-shadow(0 0 8px rgba(124, 58, 237, .28));
+      animation: draw-lasso 18s linear infinite;
+    }
+
+    .selected {
+      position: absolute;
+      left: 34px;
+      bottom: 158px;
+      width: calc(100% - 500px);
+      min-width: 340px;
+      height: 56px;
+      border-radius: 18px;
+      border: 2px solid rgba(124, 58, 237, .58);
+      background: rgba(124, 58, 237, .06);
+      opacity: 0;
+      animation: selection-in 18s linear infinite;
+      pointer-events: none;
+      z-index: 6;
+    }
+
+    .caption {
+      font-size: 15px;
+      color: var(--muted);
+      font-weight: 700;
+    }
+
+    .progress {
+      position: relative;
+      width: 360px;
+      height: 8px;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, .09);
+      overflow: hidden;
+    }
+
+    .progress i {
+      display: block;
+      width: 100%;
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, var(--blue), var(--purple));
+      transform-origin: left;
+      animation: progress 18s linear infinite;
+    }
+
+    @keyframes reveal-chip {
+      0%, 7% { opacity: 0; transform: translateY(8px); }
+      11%, 82% { opacity: 1; transform: translateY(0); }
+      88%, 100% { opacity: 0; transform: translateY(-6px); }
+    }
+
+    @keyframes cursor-path {
+      0%, 9% { transform: translate(0, 0); }
+      22% { transform: translate(230px, 150px); }
+      34% { transform: translate(64px, 390px); }
+      48% { transform: translate(440px, 412px); }
+      61% { transform: translate(374px, 294px); }
+      74% { transform: translate(530px, 360px); }
+      100% { transform: translate(0, 0); }
+    }
+
+    @keyframes draw-lasso {
+      0%, 27% { opacity: 0; stroke-dashoffset: 640; }
+      32% { opacity: 1; stroke-dashoffset: 560; }
+      50% { opacity: 1; stroke-dashoffset: 0; }
+      62% { opacity: .72; }
+      74%, 100% { opacity: 0; stroke-dashoffset: 0; }
+    }
+
+    @keyframes selection-in {
+      0%, 48% { opacity: 0; transform: scale(.99); }
+      55%, 78% { opacity: 1; transform: scale(1); }
+      88%, 100% { opacity: 0; transform: scale(1); }
+    }
+
+    @keyframes context-in {
+      0%, 55% { opacity: 0; transform: translateY(18px); }
+      63%, 88% { opacity: 1; transform: translateY(0); }
+      100% { opacity: 0; transform: translateY(10px); }
+    }
+
+    @keyframes progress {
+      from { transform: scaleX(0); }
+      to { transform: scaleX(1); }
+    }
+
+    @media (max-width: 980px) {
+      body { overflow: auto; }
+      .stage { min-height: 1100px; padding: 24px; }
+      .hero { grid-template-columns: 1fr; }
+      .product { min-height: 560px; }
+      .footer { align-items: flex-start; gap: 18px; flex-direction: column; }
+      .selected { width: calc(100% - 64px); }
+      .progress { width: min(360px, 100%); }
+    }
+  </style>
+</head>
+<body>
+  <main class="stage" aria-label="Askable UI launch video storyboard">
+    <header class="topbar">
+      <div class="brand">
+        <span class="mark">A</span>
+        <span>askable-ui</span>
+      </div>
+      <div class="pill">Open source UI context layer</div>
+    </header>
+
+    <section class="hero">
+      <div class="copy">
+        <div class="kicker">For AI-native apps</div>
+        <h1>Let users point at <span>context</span>.</h1>
+        <p class="subcopy">
+          Click, select text, circle, or lasso UI. Askable turns intent and app state into structured context your chat agent can use.
+        </p>
+        <div class="workflow" aria-label="Interaction workflow">
+          <span>1. User selects UI</span>
+          <span>2. App adds source context</span>
+          <span>3. Agent receives packet</span>
+          <span>4. Answer is grounded</span>
+        </div>
+      </div>
+
+      <div class="product">
+        <div class="appbar">
+          <div class="dots"><i></i><i></i><i></i></div>
+          <div class="app-title">Analytics dashboard</div>
+          <div class="pill">Ask AI</div>
+        </div>
+        <div class="dashboard">
+          <div class="card">
+            <h2>Revenue</h2>
+            <div class="metric">$128k</div>
+            <div class="bars">
+              <span class="bar"><i style="width: 78%"></i></span>
+              <span class="bar"><i style="width: 64%"></i></span>
+              <span class="bar"><i style="width: 88%"></i></span>
+            </div>
+          </div>
+          <div class="card">
+            <h2>Retention</h2>
+            <div class="metric">94.2%</div>
+            <div class="bars">
+              <span class="bar"><i style="width: 92%"></i></span>
+              <span class="bar"><i style="width: 58%"></i></span>
+              <span class="bar"><i style="width: 72%"></i></span>
+            </div>
+          </div>
+          <div class="card table">
+            <h2>Accounts</h2>
+            <div class="row"><span>Acme Corp</span><small>$8,400 MRR</small><small>Enterprise</small><small style="color: var(--green)">Healthy</small></div>
+            <div class="row"><span>Northstar</span><small>$5,100 MRR</small><small>Growth</small><small>Review</small></div>
+            <div class="row"><span>Helio Labs</span><small>$3,900 MRR</small><small>Pro</small><small>New</small></div>
+          </div>
+        </div>
+
+        <div class="selected" aria-hidden="true"></div>
+        <svg class="trail" viewBox="0 0 620 560" preserveAspectRatio="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="lassoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#2563eb" stop-opacity="0" />
+              <stop offset="45%" stop-color="#7c3aed" stop-opacity=".78" />
+              <stop offset="100%" stop-color="#a78bfa" stop-opacity=".92" />
+            </linearGradient>
+          </defs>
+          <path d="M78 388 C122 338 250 334 326 366 C404 398 482 378 490 426 C498 474 356 482 220 466 C92 452 42 430 78 388" />
+        </svg>
+        <div class="cursor" aria-hidden="true">
+          <svg viewBox="0 0 32 32" role="img">
+            <path d="M7 3.8 27.2 17 18.5 19.2 23.5 27.1 20.4 29 15.4 21.2 8.1 28.1 7 3.8Z" fill="#ffffff" stroke="#2563eb" stroke-width="2.4" stroke-linejoin="round" />
+          </svg>
+        </div>
+        <div class="context-panel">
+          <strong>Context sent to chat</strong>
+          <code>{
+  "capture": "lasso",
+  "selectedItems": ["Acme Corp"],
+  "sources": ["accounts:all"],
+  "intent": "explain this account"
+}</code>
+        </div>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <p class="caption">Record at 1440x900 or 1920x1080. The animation loops every 18 seconds.</p>
+      <div class="progress" aria-hidden="true"><i></i></div>
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Product Hunt and social launch campaign playbook
- add a self-contained HTML launch video/storyboard page for recording feature demos
- link the launch video from the marketing site navigation and hero

## Verification
- rendered http://127.0.0.1:4185/launch-video.html with Playwright at 1440x900 and 390x844
- captured early and context-packet animation states with no horizontal overflow
- git diff --check