### PR TITLE
feat(core): resolve multiple context sources

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -296,6 +296,16 @@ newer source with the same id.
 Use `ctx.hasSource(id)` and `ctx.listSources()` to drive source pickers,
 diagnostics, or chat controls without resolving source data. `listSources()`
 returns each source id, optional kind, registration time, and last update time.
+Use `ctx.resolveSources()` when a chat endpoint, MCP bridge, or debug surface
+needs structured source objects instead of prompt text. It resolves all
+registered sources by default, or a selected subset when `sources` is passed.
+
+```ts
+const sources = await ctx.resolveSources({
+  sources: [{ id: 'accounts', mode: 'all', maxItems: 20 }],
+  sourceErrorMode: 'include',
+});
+```
 
 #### `toHistoryContext(limit?: number, options?: AskablePromptContextOptions): string`
 

--- a/packages/core/src/__tests__/sources.test.ts
+++ b/packages/core/src/__tests__/sources.test.ts
@@ -127,4 +127,80 @@ describe('source helpers', () => {
 
     ctx.destroy();
   });
+
+  it('resolves multiple registered sources as structured data', async () => {
+    const ctx = createAskableContext();
+    ctx.registerSource('accounts', createAskableCollectionSource({
+      getItems: () => [
+        { id: 'a1', company: 'Acme Corp' },
+        { id: 'b2', company: 'Beta Labs' },
+      ],
+      getSummary: () => ({ count: 2 }),
+    }));
+    ctx.registerSource('document', createAskableSource({
+      kind: 'document',
+      data: ({ mode }) => ({ mode, title: 'Launch plan' }),
+    }));
+
+    await expect(ctx.resolveSources()).resolves.toMatchObject([
+      {
+        id: 'accounts',
+        kind: 'collection',
+        mode: 'summary',
+        data: { mode: 'summary', summary: { count: 2 } },
+      },
+      {
+        id: 'document',
+        kind: 'document',
+        mode: 'summary',
+        data: { mode: 'summary', title: 'Launch plan' },
+      },
+    ]);
+
+    await expect(ctx.resolveSources({
+      sources: [{ id: 'accounts', mode: 'all', maxItems: 1 }],
+    })).resolves.toMatchObject([
+      {
+        id: 'accounts',
+        data: {
+          mode: 'all',
+          items: [{ id: 'a1', company: 'Acme Corp' }],
+          totalCount: 2,
+          returnedCount: 1,
+          truncated: true,
+        },
+      },
+    ]);
+
+    ctx.destroy();
+  });
+
+  it('isolates source failures when resolving multiple sources', async () => {
+    const ctx = createAskableContext();
+    ctx.registerSource('broken', createAskableSource({
+      resolve: () => {
+        throw new Error('Sensitive backend error');
+      },
+    }));
+
+    await expect(ctx.resolveSources()).resolves.toEqual([
+      {
+        id: 'broken',
+        mode: 'summary',
+        error: {
+          message: 'Context source unavailable.',
+        },
+      },
+    ]);
+
+    await expect(ctx.resolveSources({
+      sourceErrorMode: 'omit',
+    })).resolves.toEqual([]);
+
+    await expect(ctx.resolveSources({
+      sourceErrorMode: 'throw',
+    })).rejects.toThrow('Sensitive backend error');
+
+    ctx.destroy();
+  });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -20,6 +20,7 @@ import type {
   AskableContextSourceMode,
   AskableContextSourceRequest,
   AskableContextSourceChange,
+  AskableResolveSourcesOptions,
   AskableEventHandler,
   AskableEventName,
   AskableFocus,
@@ -418,6 +419,13 @@ export class AskableContextImpl implements AskableContext {
       ...(data !== undefined ? { data } : {}),
     };
     return this.applySourceSanitizers(resolved, source);
+  }
+
+  async resolveSources(options?: AskableResolveSourcesOptions): Promise<AskableResolvedContextSource[]> {
+    return this.resolveIncludedSources({
+      ...options,
+      sources: options?.sources ?? 'all',
+    });
   }
 
   clear(): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,7 @@ export type {
   AskablePromptFormat,
   AskablePromptPreset,
   AskablePushOptions,
+  AskableResolveSourcesOptions,
   AskableResolvedContextSource,
   AskableSerializedFocus,
   AskableSerializedFocusSegment,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -262,6 +262,15 @@ export interface AskableAsyncContextOutputOptions extends AskableContextOutputOp
   sourceErrorMode?: AskableContextSourceErrorMode;
 }
 
+export interface AskableResolveSourcesOptions {
+  /** Sources to resolve. Defaults to "all" registered sources. */
+  sources?: 'all' | AskableContextSourceInclude[];
+  /** Default source mode when a source request omits `mode`. Defaults to "summary". */
+  sourceMode?: AskableContextSourceMode;
+  /** How source failures are handled. Defaults to "include". */
+  sourceErrorMode?: AskableContextSourceErrorMode;
+}
+
 /**
  * Options for creating an AskableContext.
  */
@@ -463,6 +472,8 @@ export interface AskableContext {
   notifySourceChanged(id?: string): void;
   /** Resolve one registered source on demand. */
   resolveSource(id: string, request?: Omit<AskableContextSourceRequest, 'id'>): Promise<AskableResolvedContextSource>;
+  /** Resolve multiple app-owned context sources as structured data. Defaults to all registered sources. */
+  resolveSources(options?: AskableResolveSourcesOptions): Promise<AskableResolvedContextSource[]>;
   /** Reset the current focus to null and emit a 'clear' event */
   clear(): void;
   /** Serialize current focus to structured prompt-ready data */

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -292,6 +292,10 @@ Use `ctx.hasSource(id)` and `ctx.listSources()` to drive source pickers,
 diagnostics, or chat controls without resolving source data. `listSources()`
 returns each source id, optional kind, registration time, and last update time.
 
+Use `ctx.resolveSources()` when an agent bridge, chat endpoint, or debug surface
+needs source data as structured objects instead of prompt text. It resolves all
+registered sources by default, or the requested subset when `sources` is passed.
+
 Async prompt methods isolate source failures by default. If a resolver throws or
 times out, Askable includes a safe `Context source unavailable.` marker and does
 not expose the original error message or stack trace. Use
@@ -306,6 +310,7 @@ ctx.listSources();
 ctx.unregisterSource('accounts');
 ctx.notifySourceChanged('accounts');
 await ctx.resolveSource('accounts', { mode: 'visible' });
+await ctx.resolveSources({ sources: [{ id: 'accounts', mode: 'all' }] });
 await ctx.toPromptContextAsync({ sources: 'all' });
 await ctx.toContextAsync({ history: 3, sources: ['accounts'] });
 ```


### PR DESCRIPTION
## Summary
- add ctx.resolveSources() for structured multi-source app context
- default to resolving all registered sources while supporting selected source requests
- reuse existing source failure modes and document the structured-source workflow

## Verification
- npm test -w @askable-ui/core -- sources.test.ts
- npm test -w @askable-ui/core
- npm run build
- npm run build:versioned --prefix site/docs
- git diff --check