### PR TITLE
feat(react-native): add source registration hook

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -8,6 +8,7 @@ React Native bindings for askable.
 - `useAskableScreen()` hook for screen/navigation-aware context updates
 - `useAskableVisibility()` hook for FlatList / SectionList visibility-driven context updates
 - `useAskableScrollView()` hook for raw `ScrollView` measurement-driven visibility tracking
+- `useAskableSource()` hook for app-owned mobile data that is not fully visible on screen
 - `<Askable ctx={...}>` wrapper that turns `onPress` / `onLongPress` into context updates
 - Runnable Expo example in [`examples/react-native-expo`](../../examples/react-native-expo)
 
@@ -31,6 +32,43 @@ export function RevenueCard() {
 ```
 
 `scope` is optional and lets you later read filtered context with `ctx.toPromptContext({ scope: 'analytics' })` or `ctx.toHistoryContext(5, { scope: 'analytics' })`.
+
+## App-owned sources
+
+Use `useAskableSource()` when the assistant needs data that is not fully
+represented by the current screen, such as full query results, offline records,
+navigation state, or a selected account loaded from your store.
+
+```tsx
+import { useAskable, useAskableSource } from '@askable-ui/react-native';
+
+const accounts = [
+  { id: 'a1', name: 'Acme Corp', status: 'healthy' },
+  { id: 'b2', name: 'Beta Labs', status: 'review' },
+];
+
+export function AccountsScreen() {
+  const { ctx } = useAskable();
+  const accountsSource = useAskableSource('accounts', {
+    kind: 'collection',
+    describe: 'Accounts loaded in the mobile store',
+    resolve: ({ mode }) => ({
+      mode,
+      items: accounts,
+      totalCount: accounts.length,
+    }),
+  }, { ctx });
+
+  async function askAboutAccounts() {
+    const context = await accountsSource.toPromptContext({
+      source: { mode: 'all', maxItems: 20 },
+    });
+    return context;
+  }
+
+  return null;
+}
+```
 
 ## Screen awareness
 

--- a/packages/react-native/src/__tests__/useAskableSource.test.tsx
+++ b/packages/react-native/src/__tests__/useAskableSource.test.tsx
@@ -1,0 +1,175 @@
+import React, { useMemo } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { createAskableContext } from '@askable-ui/core';
+import type { AskableContextSource, AskableResolvedContextSource } from '@askable-ui/core';
+import { useAskableSource } from '../useAskableSource.js';
+
+function waitForAsyncContext() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+describe('useAskableSource (React Native)', () => {
+  it('registers a source and unregisters it on unmount', async () => {
+    const ctx = createAskableContext();
+
+    function SourceConsumer() {
+      useAskableSource('accounts', {
+        kind: 'collection',
+        resolve: () => ({ count: 2 }),
+      }, { ctx });
+      return null;
+    }
+
+    let view: TestRenderer.ReactTestRenderer;
+    act(() => {
+      view = TestRenderer.create(<SourceConsumer />);
+    });
+
+    await expect(ctx.resolveSource('accounts')).resolves.toMatchObject({
+      id: 'accounts',
+      kind: 'collection',
+      data: { count: 2 },
+    });
+
+    act(() => {
+      view.unmount();
+    });
+
+    await expect(ctx.resolveSource('accounts')).rejects.toThrow('not registered');
+    ctx.destroy();
+  });
+
+  it('uses the latest source implementation without re-registering', async () => {
+    const ctx = createAskableContext();
+    const results: AskableResolvedContextSource[] = [];
+
+    function SourceConsumer({ count }: { count: number }) {
+      useAskableSource('accounts', {
+        resolve: () => ({ count }),
+      }, { ctx });
+      return null;
+    }
+
+    let view: TestRenderer.ReactTestRenderer;
+    act(() => {
+      view = TestRenderer.create(<SourceConsumer count={1} />);
+    });
+
+    results.push(await ctx.resolveSource('accounts'));
+
+    act(() => {
+      view.update(<SourceConsumer count={2} />);
+    });
+
+    results.push(await ctx.resolveSource('accounts'));
+
+    expect(results.map((source) => source.data)).toEqual([
+      { count: 1 },
+      { count: 2 },
+    ]);
+
+    act(() => {
+      view.unmount();
+    });
+    ctx.destroy();
+  });
+
+  it('returns helpers for resolving and serializing the registered source', async () => {
+    const ctx = createAskableContext();
+    const prompts: string[] = [];
+    const resolved: AskableResolvedContextSource[] = [];
+
+    function SourceConsumer() {
+      const source = useMemo<AskableContextSource>(() => ({
+        kind: 'document',
+        resolve: ({ mode }) => ({ mode, title: 'Mobile brief' }),
+      }), []);
+      const documentSource = useAskableSource('document', source, { ctx });
+
+      React.useEffect(() => {
+        documentSource.resolve({ mode: 'summary' }).then((value) => {
+          resolved.push(value);
+        });
+        documentSource.toPromptContext({
+          source: { mode: 'summary' },
+        }).then((prompt) => {
+          prompts.push(prompt);
+        });
+      }, [documentSource]);
+
+      return null;
+    }
+
+    await act(async () => {
+      TestRenderer.create(<SourceConsumer />);
+      await Promise.resolve();
+    });
+
+    expect(resolved[0]).toMatchObject({
+      id: 'document',
+      kind: 'document',
+      data: { mode: 'summary', title: 'Mobile brief' },
+    });
+    expect(prompts[0]).toContain('Mobile brief');
+
+    ctx.destroy();
+  });
+
+  it('notifies async subscribers when source data changes', async () => {
+    const ctx = createAskableContext();
+    const updates: string[] = [];
+    let count = 1;
+    let accounts: ReturnType<typeof useAskableSource> | undefined;
+
+    function SourceConsumer() {
+      accounts = useAskableSource('accounts', {
+        resolve: () => ({ count }),
+      }, { ctx });
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<SourceConsumer />);
+    });
+
+    const unsubscribe = ctx.subscribeAsync((context) => {
+      updates.push(context);
+    }, {
+      sources: ['accounts'],
+      emitInitial: true,
+    });
+
+    await waitForAsyncContext();
+    count = 2;
+
+    act(() => {
+      accounts!.notifyChanged();
+    });
+    await waitForAsyncContext();
+
+    expect(updates.at(-1)).toContain('count":2');
+
+    unsubscribe();
+    ctx.destroy();
+  });
+
+  it('does not register while disabled', async () => {
+    const ctx = createAskableContext();
+
+    function SourceConsumer() {
+      useAskableSource('accounts', {
+        resolve: () => ({ count: 1 }),
+      }, { ctx, enabled: false });
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<SourceConsumer />);
+    });
+
+    await expect(ctx.resolveSource('accounts')).rejects.toThrow('not registered');
+    ctx.destroy();
+  });
+});

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -2,10 +2,15 @@ export { Askable } from './Askable.js';
 export { useAskable } from './useAskable.js';
 export { useAskableScreen } from './useAskableScreen.js';
 export { useAskableScrollView } from './useAskableScrollView.js';
+export { useAskableSource } from './useAskableSource.js';
 export { useAskableVisibility } from './useAskableVisibility.js';
 export type { AskableProps } from './Askable.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
 export type { UseAskableScreenOptions } from './useAskableScreen.js';
+export type {
+  UseAskableSourceOptions,
+  UseAskableSourceResult,
+} from './useAskableSource.js';
 export type {
   AskableScrollLayout,
   AskableScrollNativeEvent,

--- a/packages/react-native/src/useAskableSource.ts
+++ b/packages/react-native/src/useAskableSource.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type {
+  AskableAsyncPromptContextOptions,
+  AskableContext,
+  AskableContextSource,
+  AskableContextSourceHandle,
+  AskableContextSourceRequest,
+  AskableResolvedContextSource,
+} from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export interface UseAskableSourceOptions extends UseAskableOptions {
+  /** Register the source while true. Defaults to true. */
+  enabled?: boolean;
+}
+
+export interface UseAskableSourceResult {
+  ctx: AskableContext;
+  sourceId: string;
+  resolve: (request?: Omit<AskableContextSourceRequest, 'id'>) => Promise<AskableResolvedContextSource>;
+  toPromptContext: (
+    options?: Omit<AskableAsyncPromptContextOptions, 'sources'>
+      & { source?: Omit<AskableContextSourceRequest, 'id'> },
+  ) => Promise<string>;
+  notifyChanged: () => void;
+  unregister: () => void;
+}
+
+export function useAskableSource(
+  id: string,
+  source: AskableContextSource,
+  options: UseAskableSourceOptions = {},
+): UseAskableSourceResult {
+  const { enabled = true, ...askableOptions } = options;
+  const { ctx } = useAskable(askableOptions);
+  const sourceRef = useRef(source);
+  const handleRef = useRef<AskableContextSourceHandle | null>(null);
+  sourceRef.current = source;
+
+  const sourceId = id.trim();
+
+  useEffect(() => {
+    if (!enabled || !sourceId) return undefined;
+
+    const proxy: AskableContextSource = {
+      get kind() {
+        return sourceRef.current.kind;
+      },
+      describe: () => {
+        const describe = sourceRef.current.describe;
+        if (typeof describe === 'function') return describe();
+        return describe ?? '';
+      },
+      getState: () => sourceRef.current.getState?.(),
+      resolve: (request) => sourceRef.current.resolve?.(request),
+      sanitize: (resolved) => sourceRef.current.sanitize?.(resolved) ?? resolved,
+    };
+
+    const handle = ctx.registerSource(sourceId, proxy);
+    handleRef.current = handle;
+
+    return () => {
+      handle.unregister();
+      if (handleRef.current === handle) handleRef.current = null;
+    };
+  }, [ctx, enabled, sourceId]);
+
+  const resolve = useCallback(
+    (request?: Omit<AskableContextSourceRequest, 'id'>) => ctx.resolveSource(sourceId, request),
+    [ctx, sourceId],
+  );
+
+  const toPromptContext = useCallback(
+    (promptOptions?: Omit<AskableAsyncPromptContextOptions, 'sources'>
+      & { source?: Omit<AskableContextSourceRequest, 'id'> }) => {
+      const { source: sourceRequest, ...rest } = promptOptions ?? {};
+      return ctx.toPromptContextAsync({
+        ...rest,
+        sources: [{ id: sourceId, ...sourceRequest }],
+      });
+    },
+    [ctx, sourceId],
+  );
+
+  const notifyChanged = useCallback(() => {
+    handleRef.current?.notifyChanged();
+  }, []);
+
+  const unregister = useCallback(() => {
+    handleRef.current?.unregister();
+    handleRef.current = null;
+  }, []);
+
+  return {
+    ctx,
+    sourceId,
+    resolve,
+    toPromptContext,
+    notifyChanged,
+    unregister,
+  };
+}


### PR DESCRIPTION
## Summary
- add useAskableSource() for React Native app-owned context sources
- export source hook types from the React Native package
- document mobile app-owned source usage

## Verification
- npm test -w @askable-ui/react-native
- npm run build -w @askable-ui/react-native
- git diff --check