### PR TITLE
test/docs: audit round 2 — tests, edge cases, JSDoc, and AGENTS.md

### DIFF
--- a/.github/workflows/publish_preview.yml
+++ b/.github/workflows/publish_preview.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build context
+        run: npm run build -w packages/context
+
       - name: Build core
         run: npm run build -w packages/core
 
@@ -48,4 +51,4 @@ jobs:
         run: npm run build --workspaces --if-present
 
       - name: Publish preview packages
-        run: npx pkg-pr-new publish ./packages/core ./packages/react ./packages/vue ./packages/svelte ./packages/react-native ./packages/create-askable-app
+        run: npx pkg-pr-new publish ./packages/context ./packages/core ./packages/mcp ./packages/react ./packages/vue ./packages/svelte ./packages/react-native ./packages/create-askable-app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,6 +373,213 @@ Do not ship `<AskableInspector>` or `{ inspector: true }` in production builds.
 
 ---
 
+## App-owned context sources
+
+Attach non-DOM data (tables, lists, API responses, documents) so the AI always has the right data — not just what's visible in the DOM.
+
+### Registering a collection source
+
+```ts
+import { createAskableCollectionSource } from '@askable-ui/core';
+
+const accountsSource = createAskableCollectionSource({
+  describe: 'Accounts matching active filters',
+  getState: () => ({ filter: activeFilter, sort: currentSort, page: currentPage }),
+  getItems: () => allAccounts,           // all logical items (e.g. beyond current page)
+  getVisibleItems: () => visibleRows,    // items rendered on screen
+  getSummary: () => ({ total: allAccounts.length, filtered: visibleRows.length }),
+  maxItems: 50,
+  sanitizeItem: (account) => {
+    const { internalId: _, rawSql: __, ...safe } = account;
+    return safe;                         // strip PII / internal keys before sending
+  },
+});
+
+ctx.registerSource('accounts', accountsSource);
+```
+
+`sanitizeItem` runs per item, async-safe. Rejected items are silently dropped so one bad row never crashes the whole source.
+
+### Registering a generic source
+
+```ts
+import { createAskableSource } from '@askable-ui/core';
+
+ctx.registerSource('current-doc', createAskableSource({
+  kind: 'document',
+  describe: 'Currently open editor document',
+  state: () => ({ filename: editor.filename, isDirty: editor.isDirty }),
+  data: ({ mode }) => mode === 'summary'
+    ? { wordCount: editor.wordCount, language: editor.language }
+    : { content: editor.getText() },
+}));
+```
+
+### React: `useAskableSource`
+
+```tsx
+import { useAskableSource } from '@askable-ui/react';
+
+function AccountsTable({ rows }) {
+  const { handle } = useAskableSource('accounts', {
+    getSummary: () => ({ total: rows.length }),
+    getItems: () => rows,
+    sanitizeItem: ({ internalId: _, ...safe }) => safe,
+  });
+
+  useEffect(() => {
+    handle?.notifyChanged(); // tell context the data updated
+  }, [rows, handle]);
+}
+```
+
+### Vue 3: `useAskableSource`
+
+```vue
+<script setup>
+import { useAskableSource } from '@askable-ui/vue';
+import { computed } from 'vue';
+
+const props = defineProps(['rows']);
+useAskableSource('accounts', {
+  getItems: () => props.rows,
+  enabled: computed(() => props.rows.length > 0),
+});
+</script>
+```
+
+### Controlling source resolution
+
+```ts
+// Include specific sources in prompt output
+const prompt = await ctx.toPromptContextAsync({
+  sources: ['accounts', { id: 'current-doc', mode: 'summary', timeoutMs: 1500 }],
+  sourceMode: 'summary',   // default mode for sources listed by string ID
+  sourceErrorMode: 'omit', // 'include' (default), 'omit', or 'throw'
+});
+```
+
+`sourceErrorMode`:
+- `'include'` *(default)* — failed source appears with an error note; context is still emitted
+- `'omit'` — failed source is silently dropped; healthy sources still appear
+- `'throw'` — any failure rejects the whole promise
+
+---
+
+## Streaming context with `subscribeAsync`
+
+Use `subscribeAsync` for live multi-turn agent transports — every time focus changes, the subscriber fires with fresh context including async source data.
+
+```ts
+const unsubscribe = ctx.subscribeAsync(async (context, focus) => {
+  // context is the fully resolved prompt string (sources included)
+  await myStreamingLLM.updateSystemPrompt(context);
+}, {
+  sources: 'all',
+  sourceMode: 'summary',
+  sourceErrorMode: 'omit',
+  debounce: 300,        // ms to wait after the last focus change before firing
+  emitInitial: true,    // fire immediately on subscribe (before the first user interaction)
+});
+
+// Stop listening
+unsubscribe();
+```
+
+For one-shot async serialization without subscribing:
+
+```ts
+const prompt = await ctx.toPromptContextAsync({
+  sources: ['accounts'],
+  history: 3,
+  sourceMode: 'summary',
+});
+```
+
+---
+
+## Packaging context for agent requests
+
+`toAgentRequest` bundles the current context, focus, and an optional `WebContextPacket` into a single typed object — ready to send over HTTP, WebSocket, or any agent transport.
+
+```ts
+const request = await ctx.toAgentRequest('Which accounts need follow-up?', {
+  requestId: crypto.randomUUID(),
+  sources: ['accounts'],
+  excludeKeys: ['internalId'],   // strip keys before they reach the packet
+  packet: true,                  // include a full WebContextPacket
+  metadata: { route: '/accounts', userId: session.userId },
+});
+
+// request.context  — prompt-ready string
+// request.focus    — serialized focus (null if nothing focused)
+// request.packet   — full WebContextPacket (undefined if packet:false)
+// request.metadata — your app-level metadata passed through verbatim
+// request.timestamp — Unix ms epoch
+
+await fetch('/api/agent', {
+  method: 'POST',
+  body: JSON.stringify(request),
+});
+```
+
+Pass an existing `WebContextPacket` (from a region capture, etc.) instead of `packet: true`:
+
+```ts
+const request = await ctx.toAgentRequest('Explain this selection', {
+  packet: capturedPacket,
+});
+```
+
+---
+
+## MCP integration (`@askable-ui/mcp`)
+
+Connect Askable context to any MCP-compatible LLM client (Claude Desktop, Cursor, custom agents) using `@askable-ui/mcp`.
+
+```bash
+npm install @askable-ui/mcp
+```
+
+### Wiring the MCP server
+
+```ts
+import { createAskableMcpServer, createAskableMcpContextProvider } from '@askable-ui/mcp';
+import { createAskableContext } from '@askable-ui/core';
+
+const ctx = createAskableContext();
+ctx.observe(document.body);
+
+// Optional: register sources
+ctx.registerSource('accounts', accountsSource);
+
+const provider = createAskableMcpContextProvider(ctx, {
+  source: { app: 'my-dashboard', version: '1.0.0' },
+  sources: 'all',
+  sourceMode: 'summary',
+  privacy: { consent: 'explicit' },
+});
+
+const server = createAskableMcpServer({ provider });
+// Attach server to your MCP transport (SSE, stdio, etc.)
+```
+
+The server exposes three tools to connected agents:
+- `get_current_context` — returns the current `WebContextPacket` as JSON
+- `format_context_for_prompt` — returns a prompt-ready text rendering of the context
+- `get_context_schema` — returns the JSON Schema for `WebContextPacket`
+
+### When to use MCP vs direct API
+
+| Use case | Approach |
+|---|---|
+| React/Vue app with in-page AI sidebar | Direct API — `useAskable` + `toAgentRequest` |
+| Claude Desktop / Cursor plugin | MCP server |
+| Custom agent outside the browser | MCP server or `toAgentRequest` over HTTP |
+| Streaming context to a live agent transport | `subscribeAsync` |
+
+---
+
 ## Common mistakes
 
 **Over-annotating.** Only annotate elements whose data is directly useful to an AI answer. Annotating generic layout wrappers (`<header>`, `<nav>`, `<main>`) adds noise without value.

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -2003,4 +2003,195 @@ describe('createAskableContext', () => {
     Object.defineProperty(globalThis, 'window', { value: win, configurable: true });
     ctx.destroy();
   });
+
+  describe('toAgentRequest() edge cases', () => {
+    it('returns valid request with null focus when nothing is focused', async () => {
+      const ctx = createAskableContext();
+      const request = await ctx.toAgentRequest('What can I do?');
+      expect(request.question).toBe('What can I do?');
+      expect(request.focus).toBeNull();
+      expect(request.context).toContain('No UI element');
+      ctx.destroy();
+    });
+
+    it('returns packet without target when packet:true and no focus', async () => {
+      const ctx = createAskableContext();
+      const request = await ctx.toAgentRequest('Describe the page', { packet: true });
+      expect(request.packet).toBeDefined();
+      expect(request.packet?.target).toBeUndefined();
+      ctx.destroy();
+    });
+
+    it('preserves requestId verbatim', async () => {
+      const ctx = createAskableContext();
+      const request = await ctx.toAgentRequest('Test', { requestId: 'custom-req-456' });
+      expect(request.requestId).toBe('custom-req-456');
+      ctx.destroy();
+    });
+
+    it('timestamp is a Unix millisecond epoch close to Date.now()', async () => {
+      const ctx = createAskableContext();
+      const before = Date.now();
+      const request = await ctx.toAgentRequest('Test');
+      const after = Date.now();
+      expect(request.timestamp).toBeGreaterThanOrEqual(before);
+      expect(request.timestamp).toBeLessThanOrEqual(after);
+      ctx.destroy();
+    });
+
+    it('excludeKeys filters nested metadata keys in focus meta', async () => {
+      const el = makeEl({ widget: 'table', secret: 'sensitive' }, 'Table');
+      const ctx = createAskableContext();
+      ctx.observe(document);
+      el.click();
+
+      const request = await ctx.toAgentRequest('Describe this', { excludeKeys: ['secret'] });
+      expect(request.focus?.meta).toEqual({ widget: 'table' });
+      expect(request.context).not.toContain('sensitive');
+
+      ctx.destroy();
+      cleanup(el);
+    });
+
+    it('returns context without sources section when no sources registered', async () => {
+      const ctx = createAskableContext();
+      ctx.push({ widget: 'empty' }, 'Empty panel');
+      const request = await ctx.toAgentRequest('What is here?', { sources: 'all' });
+      expect(request.context).not.toContain('Context sources');
+      ctx.destroy();
+    });
+  });
+
+  describe('toViewportContext() edge cases', () => {
+    it('returns fallback string when no elements are visible', () => {
+      const originalIO = globalThis.IntersectionObserver;
+      globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+      const ctx = createAskableContext({ viewport: true });
+      ctx.observe(document);
+      expect((ctx as any).toViewportContext()).toBe('No annotated UI elements are currently visible.');
+
+      ctx.destroy();
+      globalThis.IntersectionObserver = originalIO;
+    });
+
+    it('returns empty JSON array when no elements visible and format is json', () => {
+      const originalIO = globalThis.IntersectionObserver;
+      globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+      const ctx = createAskableContext({ viewport: true });
+      ctx.observe(document);
+      expect((ctx as any).toViewportContext({ format: 'json' })).toBe('[]');
+
+      ctx.destroy();
+      globalThis.IntersectionObserver = originalIO;
+    });
+
+    it('returns a JSON array of visible elements when format is json', () => {
+      const originalIO = globalThis.IntersectionObserver;
+      globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+      const el = makeEl({ widget: 'chart' }, 'Revenue chart');
+      const ctx = createAskableContext({ viewport: true });
+      ctx.observe(document);
+
+      const observer = MockIntersectionObserver.instances[0];
+      observer.trigger([{ target: el, isIntersecting: true }]);
+
+      const result = (ctx as any).toViewportContext({ format: 'json' });
+      const parsed = JSON.parse(result);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0]).toMatchObject({ meta: { widget: 'chart' } });
+
+      ctx.destroy();
+      cleanup(el);
+      globalThis.IntersectionObserver = originalIO;
+    });
+
+    it('filters visible elements by scope', () => {
+      const originalIO = globalThis.IntersectionObserver;
+      globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+      const inScope = makeEl({ widget: 'table' }, 'Table');
+      inScope.setAttribute('data-askable-scope', 'dashboard');
+      const outScope = makeEl({ widget: 'nav' }, 'Nav');
+      outScope.setAttribute('data-askable-scope', 'header');
+      const ctx = createAskableContext({ viewport: true });
+      ctx.observe(document);
+
+      const observer = MockIntersectionObserver.instances[0];
+      observer.trigger([
+        { target: inScope, isIntersecting: true },
+        { target: outScope, isIntersecting: true },
+      ]);
+
+      const result = (ctx as any).toViewportContext({ scope: 'dashboard' });
+      expect(result).toContain('table');
+      expect(result).not.toContain('nav');
+
+      ctx.destroy();
+      cleanup(inScope);
+      cleanup(outScope);
+      globalThis.IntersectionObserver = originalIO;
+    });
+
+    it('removes elements that become non-intersecting', () => {
+      const originalIO = globalThis.IntersectionObserver;
+      globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+      const el = makeEl({ widget: 'table' }, 'Table');
+      const ctx = createAskableContext({ viewport: true });
+      ctx.observe(document);
+
+      const observer = MockIntersectionObserver.instances[0];
+      observer.trigger([{ target: el, isIntersecting: true }]);
+      expect((ctx as any).getVisibleElements()).toHaveLength(1);
+
+      observer.trigger([{ target: el, isIntersecting: false }]);
+      expect((ctx as any).getVisibleElements()).toHaveLength(0);
+      expect((ctx as any).toViewportContext()).toBe('No annotated UI elements are currently visible.');
+
+      ctx.destroy();
+      cleanup(el);
+      globalThis.IntersectionObserver = originalIO;
+    });
+  });
+
+  describe('source timeout edge cases', () => {
+    it('times out slow sources after positive timeoutMs', async () => {
+      vi.useFakeTimers();
+      const ctx = createAskableContext();
+      ctx.registerSource('slow', {
+        resolve: () => new Promise<{ data: string }>((resolve) => {
+          setTimeout(() => resolve({ data: 'late' }), 500);
+        }),
+      });
+
+      const promptPromise = ctx.toPromptContextAsync({
+        sources: [{ id: 'slow', timeoutMs: 100 }],
+      });
+      await vi.runAllTimersAsync();
+      const prompt = await promptPromise;
+
+      expect(prompt).toContain('slow');
+      expect(prompt).toContain('Context source unavailable.');
+      ctx.destroy();
+    });
+
+    it('rejects immediately when the source request signal is already aborted', async () => {
+      const ctx = createAskableContext();
+      const controller = new AbortController();
+      controller.abort();
+
+      ctx.registerSource('fast', {
+        resolve: (_req) => ({ data: 'ok' }),
+      });
+
+      await expect(
+        (ctx as any).resolveSource('fast', { mode: 'summary', signal: controller.signal }),
+      ).rejects.toThrow('aborted');
+
+      ctx.destroy();
+    });
+  });
 });

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -323,6 +323,92 @@ describe('createAskableContext', () => {
     ctx.destroy();
   });
 
+  it('omits a failing source in subscribeAsync when sourceErrorMode is omit', async () => {
+    const ctx = createAskableContext();
+    ctx.registerSource('healthy', {
+      resolve: () => ({ rows: 5 }),
+    });
+    ctx.registerSource('broken', {
+      resolve: () => { throw new Error('db error'); },
+    });
+
+    let received = '';
+    const done = new Promise<void>((resolve) => {
+      ctx.subscribeAsync((context) => {
+        received = context;
+        resolve();
+      }, {
+        sources: ['healthy', 'broken'],
+        sourceErrorMode: 'omit',
+      });
+    });
+
+    ctx.push({ widget: 'table' }, 'Table');
+    await done;
+
+    expect(received).toContain('healthy');
+    expect(received).toContain('"rows":5');
+    expect(received).not.toContain('broken');
+    expect(received).not.toContain('db error');
+
+    ctx.destroy();
+  });
+
+  it('includes error text for a failing source when sourceErrorMode is include', async () => {
+    const ctx = createAskableContext();
+    ctx.registerSource('broken', {
+      resolve: () => { throw new Error('db unavailable'); },
+    });
+
+    let received = '';
+    const done = new Promise<void>((resolve) => {
+      ctx.subscribeAsync((context) => {
+        received = context;
+        resolve();
+      }, {
+        sources: ['broken'],
+        sourceErrorMode: 'include',
+      });
+    });
+
+    ctx.push({ widget: 'table' }, 'Table');
+    await done;
+
+    expect(received).toContain('broken');
+    expect(received).toContain('Context source unavailable.');
+
+    ctx.destroy();
+  });
+
+  it('emits context with healthy sources when one of two fails under sourceErrorMode omit', async () => {
+    const ctx = createAskableContext();
+    ctx.registerSource('good', {
+      resolve: () => ({ value: 42 }),
+    });
+    ctx.registerSource('bad', {
+      resolve: () => { throw new Error('fail'); },
+    });
+
+    let received = '';
+    const done = new Promise<void>((resolve) => {
+      ctx.subscribeAsync((context) => {
+        received = context;
+        resolve();
+      }, {
+        sources: ['good', 'bad'],
+        sourceErrorMode: 'omit',
+      });
+    });
+
+    ctx.push({ widget: 'x' }, 'X');
+    await done;
+
+    expect(received).toContain('"value":42');
+    expect(received).not.toContain('bad');
+
+    ctx.destroy();
+  });
+
   it('packages a user question with source-backed context for agent requests', async () => {
     const ctx = createAskableContext();
     ctx.push({ widget: 'accounts-table', debug: 'internal' }, 'Accounts');

--- a/packages/core/src/__tests__/sources.test.ts
+++ b/packages/core/src/__tests__/sources.test.ts
@@ -203,4 +203,19 @@ describe('source helpers', () => {
 
     ctx.destroy();
   });
+
+  it('returns undefined data when resolve returns undefined for an unsupported mode', async () => {
+    const ctx = createAskableContext();
+    ctx.registerSource('chart', createAskableSource({
+      data: ({ mode }) => mode === 'summary' ? { total: 5 } : undefined,
+    }));
+
+    const resultSummary = await ctx.resolveSource('chart', { mode: 'summary' });
+    expect(resultSummary.data).toEqual({ total: 5 });
+
+    const resultOther = await ctx.resolveSource('chart', { mode: 'all' });
+    expect(resultOther.data).toBeUndefined();
+
+    ctx.destroy();
+  });
 });

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -93,6 +93,25 @@ export const ASKABLE_REGION_CAPTURE_THEME: AskableRegionCaptureTheme = {
   lassoGlowRadius: 8,
 };
 
+/**
+ * Attaches a pointer-driven region-capture overlay to the document. The user drags
+ * (region), draws (circle), or traces (lasso) a shape; on release, an Askable context
+ * packet is emitted to `onCapture` with the selection geometry and the current context.
+ *
+ * Call `handle.start()` to mount the overlay and `handle.destroy()` to clean up.
+ * With `once: false` (default is `true`) the overlay persists after each capture.
+ *
+ * @example
+ * ```ts
+ * const capture = createAskableRegionCapture(ctx, {
+ *   shape: 'lasso',
+ *   intent: 'explain this region',
+ *   onCapture: (packet, selection) => sendToAI(packet),
+ *   onCancel: () => console.log('cancelled'),
+ * });
+ * capture.start(); // mounts overlay
+ * ```
+ */
 export function createAskableRegionCapture(
   ctx: AskableContext,
   options: AskableRegionCaptureOptions = {},

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -48,6 +48,25 @@ type LastInteraction = {
 
 const DEFAULT_DEBOUNCE = 120;
 
+/**
+ * Listens for text selection changes in the document and emits an Askable context packet
+ * each time the user selects text. Use `captureNow()` to programmatically snapshot the
+ * current selection without waiting for a `selectionchange` event.
+ *
+ * Call `handle.start()` to begin listening and `handle.destroy()` to clean up.
+ * Set `enabled: false` to pause without destroying.
+ *
+ * @example
+ * ```ts
+ * const capture = createAskableTextSelectionCapture(ctx, {
+ *   onCapture: (packet) => sendToAI(packet),
+ *   debounce: 200,
+ * });
+ * capture.start();
+ * // later:
+ * const snapshot = capture.captureNow(); // captures current selection
+ * ```
+ */
 export function createAskableTextSelectionCapture(
   ctx: AskableContext,
   options: AskableTextSelectionCaptureOptions = {},

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -56,6 +56,24 @@ export interface AskableCreateCollectionSourceOptions<TItem = unknown, TState = 
   sanitize?: (source: AskableResolvedContextSource) => AskableResolvedContextSource | Promise<AskableResolvedContextSource>;
 }
 
+/**
+ * Creates a generic app-owned context source that exposes arbitrary data to AI context.
+ * Use this for document, canvas, chart, or any non-collection data that doesn't need
+ * built-in item pagination modes.
+ *
+ * @example
+ * ```ts
+ * const editorSource = createAskableSource({
+ *   kind: 'document',
+ *   describe: 'Currently open editor document',
+ *   state: () => ({ filename: editor.filename, isDirty: editor.isDirty }),
+ *   data: ({ mode }) => mode === 'summary'
+ *     ? { wordCount: editor.wordCount }
+ *     : { content: editor.getText() },
+ * });
+ * ctx.registerSource('editor', editorSource);
+ * ```
+ */
 export function createAskableSource<TData = unknown, TState = unknown>(
   options: AskableCreateSourceOptions<TData, TState>,
 ): AskableContextSource {
@@ -74,6 +92,28 @@ export function createAskableSource<TData = unknown, TState = unknown>(
   };
 }
 
+/**
+ * Creates a collection source that understands list-oriented modes (summary, visible,
+ * selected, all) and handles item capping, async sanitization, and state tracking.
+ * Prefer this over `createAskableSource` for tables, lists, feeds, and other iterable data.
+ *
+ * @example
+ * ```ts
+ * const accountsSource = createAskableCollectionSource({
+ *   describe: 'Accounts matching active filters',
+ *   getState: () => ({ filter: activeFilter, sort: currentSort }),
+ *   getItems: () => allAccounts,
+ *   getVisibleItems: () => visibleRows,
+ *   getSummary: () => ({ total: allAccounts.length, filtered: visibleRows.length }),
+ *   maxItems: 50,
+ *   sanitizeItem: (account) => {
+ *     const { internalId: _, ...safe } = account;
+ *     return safe;
+ *   },
+ * });
+ * ctx.registerSource('accounts', accountsSource);
+ * ```
+ */
 export function createAskableCollectionSource<TItem = unknown, TState = unknown>(
   options: AskableCreateCollectionSourceOptions<TItem, TState>,
 ): AskableContextSource {

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -2,9 +2,24 @@ import { describe, expect, it, vi } from 'vitest';
 import { createWebContextPacket } from '@askable-ui/context';
 import {
   createAskableMcpContextProvider,
+  createAskableMcpServer,
   defaultPromptFormatter,
+  type AskableMcpContextProvider,
   type AskableMcpSourceContext,
 } from '../index.js';
+
+type McpToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getToolHandler(provider: AskableMcpContextProvider, toolName: string): McpToolHandler {
+  const server = createAskableMcpServer({ provider });
+  const tools = (server as unknown as { _registeredTools: Record<string, { handler: McpToolHandler }> })._registeredTools;
+  const tool = tools[toolName];
+  if (!tool) throw new Error(`Tool ${toolName} not registered`);
+  return tool.handler;
+}
 
 describe('createAskableMcpContextProvider', () => {
   it('adapts an Askable context to an MCP context provider', async () => {
@@ -141,6 +156,68 @@ describe('createAskableMcpContextProvider', () => {
       includeText: false,
       maxTokens: 50,
     });
+  });
+});
+
+describe('createAskableMcpServer', () => {
+  it('returns isError when get_current_context provider throws', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockRejectedValue(new Error('provider crashed')),
+    };
+    const handler = getToolHandler(provider, 'get_current_context');
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('provider crashed');
+  });
+
+  it('returns isError when format_context_for_prompt provider throws', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockRejectedValue(new Error('context unavailable')),
+    };
+    const handler = getToolHandler(provider, 'format_context_for_prompt');
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('context unavailable');
+  });
+
+  it('returns isError when formatContextForPrompt throws after getContext succeeds', async () => {
+    const packet = createWebContextPacket({ capture: { mode: 'element-focus' } });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+      formatContextForPrompt: vi.fn().mockRejectedValue(new Error('format failed')),
+    };
+    const handler = getToolHandler(provider, 'format_context_for_prompt');
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('format failed');
+  });
+
+  it('passes recognized context options to the provider', async () => {
+    const packet = createWebContextPacket({ capture: { mode: 'element-focus' } });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const handler = getToolHandler(provider, 'get_current_context');
+    await handler({ intent: 'test intent', history: 3 });
+    expect(provider.getContext).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'test intent', history: 3 }),
+    );
+  });
+
+  it('uses defaultPromptFormatter when provider has no formatContextForPrompt', async () => {
+    const packet = createWebContextPacket({
+      source: { url: 'https://example.com' },
+      capture: { mode: 'element-focus', intent: 'test' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const handler = getToolHandler(provider, 'format_context_for_prompt');
+    const result = await handler({});
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('Context mode: element-focus');
+    expect(result.content[0].text).toContain('User intent: test');
+    expect(result.content[0].text).toContain('URL: https://example.com');
   });
 });
 

--- a/packages/react-native/src/__tests__/useAskable.test.tsx
+++ b/packages/react-native/src/__tests__/useAskable.test.tsx
@@ -345,4 +345,185 @@ describe('useAskable (React Native)', () => {
 
     expect(seenCtx!.getFocus()).toBeNull();
   });
+
+  it('retains context when clearOnBlur is false and active becomes false', () => {
+    let seenCtx: AskableContext | null = null;
+    let onScroll: ((event: { nativeEvent: { contentOffset?: { y?: number }; layoutMeasurement?: { height?: number } } }) => void) | null = null;
+    let measureItem: ((key: string, item: { id: string; title: string }, layout: { y: number; height: number }) => void) | null = null;
+    let setActive!: (val: boolean) => void;
+
+    function Consumer() {
+      const [active, _setActive] = React.useState(true);
+      setActive = _setActive;
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      const tracker = useAskableScrollView({
+        ctx,
+        active,
+        clearOnBlur: false,
+        getMeta: (item) => ({ id: item.id }),
+        getText: (item) => item.title,
+      });
+      onScroll = tracker.onScroll;
+      measureItem = tracker.measureItem;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      measureItem!('a', { id: 'a', title: 'Item A' }, { y: 0, height: 100 });
+      onScroll!({ nativeEvent: { contentOffset: { y: 0 }, layoutMeasurement: { height: 100 } } });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({ meta: { id: 'a' } });
+
+    act(() => {
+      setActive(false);
+    });
+
+    // clearOnBlur: false — context should be retained
+    expect(seenCtx!.getFocus()).toMatchObject({ meta: { id: 'a' } });
+  });
+
+  it('clears context when active becomes false and clearOnBlur is true (default)', () => {
+    let seenCtx: AskableContext | null = null;
+    let onScroll: ((event: { nativeEvent: { contentOffset?: { y?: number }; layoutMeasurement?: { height?: number } } }) => void) | null = null;
+    let measureItem: ((key: string, item: { id: string; title: string }, layout: { y: number; height: number }) => void) | null = null;
+    let setActive!: (val: boolean) => void;
+
+    function Consumer() {
+      const [active, _setActive] = React.useState(true);
+      setActive = _setActive;
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      const tracker = useAskableScrollView({
+        ctx,
+        active,
+        getMeta: (item) => ({ id: item.id }),
+        getText: (item) => item.title,
+      });
+      onScroll = tracker.onScroll;
+      measureItem = tracker.measureItem;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      measureItem!('a', { id: 'a', title: 'Item A' }, { y: 0, height: 100 });
+      onScroll!({ nativeEvent: { contentOffset: { y: 0 }, layoutMeasurement: { height: 100 } } });
+    });
+
+    expect(seenCtx!.getFocus()).toMatchObject({ meta: { id: 'a' } });
+
+    act(() => {
+      setActive(false);
+    });
+
+    expect(seenCtx!.getFocus()).toBeNull();
+  });
+
+  it('only the first visible item wins with multiple items in viewport', () => {
+    let seenCtx: AskableContext | null = null;
+    let onScroll: ((event: { nativeEvent: { contentOffset?: { y?: number }; layoutMeasurement?: { height?: number } } }) => void) | null = null;
+    let measureItem: ((key: string, item: { id: string; title: string }, layout: { y: number; height: number }) => void) | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      const tracker = useAskableScrollView({
+        ctx,
+        getMeta: (item) => ({ id: item.id }),
+        getText: (item) => item.title,
+      });
+      onScroll = tracker.onScroll;
+      measureItem = tracker.measureItem;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      measureItem!('a', { id: 'a', title: 'First' }, { y: 0, height: 100 });
+      measureItem!('b', { id: 'b', title: 'Second' }, { y: 100, height: 100 });
+      measureItem!('c', { id: 'c', title: 'Third' }, { y: 200, height: 100 });
+      // viewport shows all three
+      onScroll!({ nativeEvent: { contentOffset: { y: 0 }, layoutMeasurement: { height: 400 } } });
+    });
+
+    // default selectVisible picks topmost — item 'a'
+    expect(seenCtx!.getFocus()).toMatchObject({ meta: { id: 'a' } });
+  });
+
+  it('custom selectVisible picks a different item from the visible list', () => {
+    let seenCtx: AskableContext | null = null;
+    let onScroll: ((event: { nativeEvent: { contentOffset?: { y?: number }; layoutMeasurement?: { height?: number } } }) => void) | null = null;
+    let measureItem: ((key: string, item: { id: string; title: string }, layout: { y: number; height: number }) => void) | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      const tracker = useAskableScrollView({
+        ctx,
+        getMeta: (item) => ({ id: item.id }),
+        getText: (item) => item.title,
+        selectVisible: (items) => items[items.length - 1] ?? null, // pick last
+      });
+      onScroll = tracker.onScroll;
+      measureItem = tracker.measureItem;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    act(() => {
+      measureItem!('a', { id: 'a', title: 'First' }, { y: 0, height: 100 });
+      measureItem!('b', { id: 'b', title: 'Second' }, { y: 100, height: 100 });
+      onScroll!({ nativeEvent: { contentOffset: { y: 0 }, layoutMeasurement: { height: 300 } } });
+    });
+
+    // custom selectVisible picks last — item 'b'
+    expect(seenCtx!.getFocus()).toMatchObject({ meta: { id: 'b' } });
+  });
+
+  it('does not crash when layout has no width or height', () => {
+    let seenCtx: AskableContext | null = null;
+    let onScroll: ((event: { nativeEvent: { contentOffset?: { y?: number }; layoutMeasurement?: { height?: number } } }) => void) | null = null;
+    let measureItem: ((key: string, item: { id: string }, layout: Record<string, never>) => void) | null = null;
+
+    function Consumer() {
+      const { ctx } = useAskable();
+      seenCtx = ctx;
+      const tracker = useAskableScrollView({
+        ctx,
+        getMeta: (item) => ({ id: item.id }),
+      });
+      onScroll = tracker.onScroll as typeof onScroll;
+      measureItem = tracker.measureItem as typeof measureItem;
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(<Consumer />);
+    });
+
+    expect(() => {
+      act(() => {
+        measureItem!('a', { id: 'a' }, {});
+        onScroll!({ nativeEvent: {} });
+      });
+    }).not.toThrow();
+
+    // No crash; focus may or may not be set, but the context is intact
+    expect(seenCtx).not.toBeNull();
+  });
 });

--- a/packages/react/src/__tests__/AskableInspector.test.tsx
+++ b/packages/react/src/__tests__/AskableInspector.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
+import { useState } from 'react';
 import { AskableInspector } from '../AskableInspector';
 import { useAskable } from '../useAskable';
+import { createAskableContext } from '@askable-ui/core';
 
 function ClickOnlyConsumer() {
   const { focus } = useAskable({ events: ['click'] });
@@ -40,5 +42,68 @@ describe('AskableInspector', () => {
     expect(screen.getByTestId('click-only-focus').textContent).toContain('inspector-click-only');
 
     view.unmount();
+  });
+
+  it('recreates the inspector when position prop changes', async () => {
+    function PositionToggle() {
+      const [position, setPosition] = useState<'bottom-right' | 'bottom-left'>('bottom-right');
+      return (
+        <>
+          <button data-testid="toggle" onClick={() => setPosition('bottom-left')}>Toggle</button>
+          <AskableInspector position={position} />
+        </>
+      );
+    }
+
+    const view = render(<PositionToggle />);
+    const panelBefore = document.getElementById('askable-inspector');
+    expect(panelBefore).not.toBeNull();
+
+    act(() => {
+      screen.getByTestId('toggle').click();
+    });
+
+    await waitFor(() => {
+      const panel = document.getElementById('askable-inspector');
+      expect(panel).not.toBeNull();
+    });
+
+    view.unmount();
+    expect(document.getElementById('askable-inspector')).toBeNull();
+  });
+
+  it('destroys the inspector exactly once on unmount after multiple prop changes', async () => {
+    function PropChanger() {
+      const [highlight, setHighlight] = useState(true);
+      return (
+        <>
+          <button data-testid="toggle" onClick={() => setHighlight((h) => !h)}>Toggle</button>
+          <AskableInspector highlight={highlight} />
+        </>
+      );
+    }
+
+    const view = render(<PropChanger />);
+
+    act(() => { screen.getByTestId('toggle').click(); });
+    act(() => { screen.getByTestId('toggle').click(); });
+    act(() => { screen.getByTestId('toggle').click(); });
+
+    view.unmount();
+    expect(document.getElementById('askable-inspector')).toBeNull();
+  });
+
+  it('reuses the provided ctx instead of creating a new one', () => {
+    const ctx = createAskableContext();
+    ctx.push({ widget: 'external' }, 'External element');
+
+    const view = render(<AskableInspector ctx={ctx} />);
+
+    const panel = document.getElementById('askable-inspector');
+    expect(panel).not.toBeNull();
+    expect(panel?.textContent).toContain('external');
+
+    view.unmount();
+    ctx.destroy();
   });
 });

--- a/packages/react/src/__tests__/useAskableTextSelectionCapture.test.tsx
+++ b/packages/react/src/__tests__/useAskableTextSelectionCapture.test.tsx
@@ -26,6 +26,30 @@ afterEach(() => {
 });
 
 describe('useAskableTextSelectionCapture', () => {
+  it('fires onCapture via selectionchange event when started', async () => {
+    const captured: unknown[] = [];
+
+    function Consumer() {
+      const capture = useAskableTextSelectionCapture({
+        debounce: 0,
+        onCapture: (packet) => { captured.push(packet); },
+      });
+
+      return (
+        <button type="button" onClick={() => capture.start()}>Start</button>
+      );
+    }
+
+    render(<Consumer />);
+    act(() => { fireEvent.click(screen.getByText('Start')); });
+
+    selectText('React selectionchange fires');
+    act(() => { document.dispatchEvent(new Event('selectionchange')); });
+
+    await waitFor(() => expect(captured.length).toBe(1));
+    expect((captured[0] as { target?: { text?: string } }).target?.text).toBe('React selectionchange fires');
+  });
+
   it('captures the current browser selection', async () => {
     function Consumer() {
       const capture = useAskableTextSelectionCapture({

--- a/packages/svelte/src/__tests__/store.test.ts
+++ b/packages/svelte/src/__tests__/store.test.ts
@@ -161,6 +161,42 @@ describe('createAskableTextSelectionCaptureStore', () => {
     document.querySelectorAll('#svelte-selection').forEach((el) => el.remove());
   });
 
+  it('fires onCapture via selectionchange event when started', () => {
+    const captured: unknown[] = [];
+    const capture = createAskableTextSelectionCaptureStore({
+      debounce: 0,
+      onCapture: (packet) => { captured.push(packet); },
+    });
+
+    capture.start();
+    selectText('Selectionchange Svelte');
+    document.dispatchEvent(new Event('selectionchange'));
+
+    expect(captured.length).toBe(1);
+    expect((captured[0] as { target?: { text?: string } }).target?.text).toBe('Selectionchange Svelte');
+
+    capture.destroy();
+  });
+
+  it('stops listening after cancel()', () => {
+    const captured: unknown[] = [];
+    const capture = createAskableTextSelectionCaptureStore({
+      debounce: 0,
+      onCapture: (packet) => { captured.push(packet); },
+    });
+
+    capture.start();
+    capture.cancel();
+    expect(get(capture.active)).toBe(false);
+
+    selectText('Should not capture');
+    document.dispatchEvent(new Event('selectionchange'));
+
+    expect(captured.length).toBe(0);
+
+    capture.destroy();
+  });
+
   it('captures the current browser selection', () => {
     const capture = createAskableTextSelectionCaptureStore({
       source: { app: 'svelte-test' },
@@ -432,6 +468,19 @@ describe('createAskableRegionCaptureStore', () => {
 
     expect(get(capture.active)).toBe(false);
     expect(document.getElementById('askable-region-capture')).toBeNull();
+
+    capture.destroy();
+  });
+
+  it('fires onCancel when cancel is called', () => {
+    const onCancel = vi.fn();
+    const capture = createAskableRegionCaptureStore({ onCancel });
+
+    capture.start();
+    capture.cancel();
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(get(capture.active)).toBe(false);
 
     capture.destroy();
   });

--- a/packages/vue/src/__tests__/useAskableTextSelectionCapture.test.ts
+++ b/packages/vue/src/__tests__/useAskableTextSelectionCapture.test.ts
@@ -35,6 +35,62 @@ afterEach(() => {
 });
 
 describe('useAskableTextSelectionCapture (Vue)', () => {
+  it('fires onCapture via selectionchange event when started', async () => {
+    const captured: unknown[] = [];
+    const Consumer = defineComponent({
+      name: 'SelectionChangeConsumer',
+      setup() {
+        const capture = useAskableTextSelectionCapture({
+          debounce: 0,
+          onCapture: (packet) => { captured.push(packet); },
+        });
+        capture.start();
+        return {};
+      },
+      template: '<div />',
+    });
+
+    const wrapper = track(mount(Consumer, { attachTo: document.body }));
+    await flushAll();
+
+    selectText('Selectionchange fires');
+    document.dispatchEvent(new Event('selectionchange'));
+    await flushAll();
+
+    expect(captured.length).toBe(1);
+    expect((captured[0] as { target?: { text?: string } }).target?.text).toBe('Selectionchange fires');
+
+    wrapper.unmount();
+  });
+
+  it('stops listening after cancel()', async () => {
+    const captured: unknown[] = [];
+    const Consumer = defineComponent({
+      name: 'CancelConsumer',
+      setup() {
+        const capture = useAskableTextSelectionCapture({
+          debounce: 0,
+          onCapture: (packet) => { captured.push(packet); },
+        });
+        capture.start();
+        capture.cancel();
+        return {};
+      },
+      template: '<div />',
+    });
+
+    const wrapper = track(mount(Consumer, { attachTo: document.body }));
+    await flushAll();
+
+    selectText('Should not be captured');
+    document.dispatchEvent(new Event('selectionchange'));
+    await flushAll();
+
+    expect(captured.length).toBe(0);
+
+    wrapper.unmount();
+  });
+
   it('captures the current browser selection', async () => {
     const Consumer = defineComponent({
       name: 'TextSelectionCaptureConsumer',


### PR DESCRIPTION
## Summary

Full audit pass covering test gaps, documentation gaps, and CI fix identified in round 2.

### CI fix
- **#290** — Add `packages/context` and `packages/mcp` to `pkg-pr-new publish` in `publish_preview.yml`. Adds a `Build context` step before `Build core` so the dependency is available.

### New tests

**Core (`packages/core`)**
- **#287** — MCP server: `get_current_context` and `format_context_for_prompt` return `isError:true` on provider throw; `defaultPromptFormatter` fallback; recognized args forwarded correctly
- **#286** — `toAgentRequest` edge cases: no focus, `packet:true` with no target, `requestId` preservation, timestamp epoch range, `excludeKeys` on nested meta, no sources registered
- **#291** — `toViewportContext` edge cases: no-elements fallback, empty JSON array, JSON format, scope filtering, elements becoming non-intersecting
- **#284** — Source timeout with positive `timeoutMs` via fake timers; `AbortSignal` already-aborted path
- **#278/#285** — `sourceErrorMode: 'omit'` and `'include'` in `subscribeAsync`; multi-source partial failure; `resolve()` returning `undefined` for unsupported mode

**React (`packages/react`)**
- **#295** — `AskableInspector` runtime option changes: position prop recreates inspector, multiple highlight changes don't leave stale instances, unmount after changes destroys exactly once, `ctx` prop reuses context
- **#292** — `useAskableTextSelectionCapture`: selectionchange event triggers `onCapture` when started

**Vue (`packages/vue`)**
- **#292** — `useAskableTextSelectionCapture`: selectionchange event triggers `onCapture`, `cancel()` stops listener

**React Native (`packages/react-native`)**
- **#294** — `useAskableScrollView` edge cases: `clearOnBlur:false` retains context on deactivate, default `clearOnBlur:true` clears on deactivate, multiple visible items pick topmost, custom `selectVisible`, missing layout fields don't crash

**Svelte (`packages/svelte`)**
- **#293** — `createAskableTextSelectionCaptureStore`: selectionchange fires `onCapture`, `cancel()` stops listener; `createAskableRegionCaptureStore`: `onCancel` fires when cancelled

### Documentation
- **#289** — JSDoc added to `createAskableSource`, `createAskableCollectionSource`, `createAskableRegionCapture`, `createAskableTextSelectionCapture` — description + `@example` on each
- **#288** — `AGENTS.md` new sections: Sources API (`createAskableSource`, `createAskableCollectionSource`, framework `useAskableSource`), `subscribeAsync` streaming pattern, `toAgentRequest` agent transport packaging, MCP integration with `createAskableMcpServer`

## Test plan

- [ ] All packages pass `npm test --workspaces` (206 core / 10 mcp / 56 react / 19 react-native / 38 svelte / 41 vue)
- [ ] Preview publish workflow includes `context` and `mcp` packages
- [ ] JSDoc renders correctly on hover in IDE for all four documented functions
- [ ] AGENTS.md sources, subscribeAsync, toAgentRequest, and MCP sections are accurate

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_