### PR TITLE
feat(core): add page snapshot source

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -252,7 +252,11 @@ tables, virtualized lists, documents, maps, charts, calendars, canvases, file
 trees, or custom product state.
 
 ```ts
-import { createAskableCollectionSource, createAskableSource } from '@askable-ui/core';
+import {
+  createAskableCollectionSource,
+  createAskablePageSource,
+  createAskableSource,
+} from '@askable-ui/core';
 
 const accountsSource = ctx.registerSource('accounts', createAskableCollectionSource({
   describe: 'Customer accounts matching the active filters',
@@ -281,6 +285,12 @@ ctx.registerSource('active-chart', createAskableSource({
   data: ({ mode }) => chart.export({ mode }),
 }));
 
+ctx.registerSource('page', createAskablePageSource({
+  includeLinks: true,
+  maxTextLength: 6000,
+  sanitizeText: redactPageText,
+}));
+
 const prompt = await ctx.toPromptContextAsync({
   sources: [{ id: 'accounts', mode: 'all', maxItems: 20, timeoutMs: 750 }],
   sourceErrorMode: 'include',
@@ -297,9 +307,11 @@ maps, canvases, and product state. Its `modes` map is a concise way to expose
 named slices such as `summary`, `selected`, `all`, or app-defined modes, while
 `data` remains the fallback for modes you do not list. Use
 `createAskableCollectionSource()` when a list, grid, table, board, or search
-result has more data than the DOM currently renders. Failed or timed-out
-sources are represented with a safe unavailable marker by default; use
-`sourceErrorMode: 'omit'` or `'throw'` for stricter runtimes.
+result has more data than the DOM currently renders. Use
+`createAskablePageSource()` when an extension, fallback bridge, or unannotated
+page still needs selected text, headings, optional links, and full-page text.
+Failed or timed-out sources are represented with a safe unavailable marker by
+default; use `sourceErrorMode: 'omit'` or `'throw'` for stricter runtimes.
 
 Call `handle.notifyChanged()` or `ctx.notifySourceChanged('accounts')` when
 filters, pagination, query data, or selected records change without a DOM focus

--- a/packages/core/src/__tests__/page-source.test.ts
+++ b/packages/core/src/__tests__/page-source.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createAskableContext,
+  createAskablePageSource,
+} from '../index.js';
+
+function setPage(html: string, title = 'Askable test page') {
+  document.title = title;
+  document.body.innerHTML = html;
+  document.getSelection()?.removeAllRanges();
+}
+
+function selectElement(selector: string) {
+  const target = document.querySelector(selector);
+  if (!target) throw new Error(`Missing test selector: ${selector}`);
+  const range = document.createRange();
+  range.selectNodeContents(target);
+  const selection = document.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+describe('createAskablePageSource', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.title = '';
+    document.getSelection()?.removeAllRanges();
+  });
+
+  it('resolves page summary context without Askable annotations', async () => {
+    setPage(`
+      <main>
+        <h1>Revenue dashboard</h1>
+        <h2>Pipeline risk</h2>
+        <p id="selected">Acme Corp renewal is at risk.</p>
+        <a href="/accounts/acme">Acme account</a>
+      </main>
+    `);
+    selectElement('#selected');
+    const ctx = createAskableContext();
+    ctx.registerSource('page', createAskablePageSource({ includeLinks: true }));
+
+    const source = await ctx.resolveSource('page', { mode: 'summary' });
+
+    expect(source).toMatchObject({
+      id: 'page',
+      kind: 'page',
+      description: 'Current page',
+      data: {
+        title: 'Askable test page',
+        selectedText: 'Acme Corp renewal is at risk.',
+        headings: [
+          { level: 1, text: 'Revenue dashboard' },
+          { level: 2, text: 'Pipeline risk' },
+        ],
+        links: [
+          { text: 'Acme account' },
+        ],
+      },
+    });
+
+    ctx.destroy();
+  });
+
+  it('resolves selected text as an explicit source mode', async () => {
+    setPage('<article><p id="quote">Selected product feedback.</p><p>Other text.</p></article>');
+    selectElement('#quote');
+    const ctx = createAskableContext();
+    ctx.registerSource('page', createAskablePageSource());
+
+    const source = await ctx.resolveSource('page', { mode: 'selected' });
+
+    expect(source.data).toMatchObject({
+      selectedText: 'Selected product feedback.',
+    });
+    expect(JSON.stringify(source.data)).not.toContain('Other text');
+
+    ctx.destroy();
+  });
+
+  it('resolves full page text with explicit truncation', async () => {
+    setPage('<h1>Docs</h1><p>One two three four five six.</p>');
+    const ctx = createAskableContext();
+    ctx.registerSource('page', createAskablePageSource({ maxTextLength: 12 }));
+
+    const source = await ctx.resolveSource('page', { mode: 'all' });
+
+    expect(source.data).toMatchObject({
+      text: 'Docs One two',
+      truncated: true,
+    });
+
+    ctx.destroy();
+  });
+
+  it('sanitizes page text, selections, and headings', async () => {
+    setPage('<h1>Customer SSN 123-45-6789</h1><p id="selected">SSN 123-45-6789</p>');
+    selectElement('#selected');
+    const ctx = createAskableContext();
+    ctx.registerSource('page', createAskablePageSource({
+      sanitizeText: (text) => text.replace(/\d{3}-\d{2}-\d{4}/g, '[ssn]'),
+    }));
+
+    const source = await ctx.resolveSource('page', { mode: 'all' });
+    const serialized = JSON.stringify(source.data);
+
+    expect(serialized).toContain('[ssn]');
+    expect(serialized).not.toContain('123-45-6789');
+
+    ctx.destroy();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export { ASKABLE_REGION_CAPTURE_THEME, createAskableRegionCapture } from './capt
 export { createAskableTextSelectionCapture } from './selection.js';
 export { a11yTextExtractor } from './a11y.js';
 export { createAskableCollectionSource, createAskableSource } from './sources.js';
+export { createAskablePageSource } from './page-source.js';
 export {
   WEB_CONTEXT_PROTOCOL,
   WEB_CONTEXT_VERSION,
@@ -51,6 +52,12 @@ export type {
   AskableSourceResolver,
   AskableSourceValue,
 } from './sources.js';
+export type {
+  AskableCreatePageSourceOptions,
+  AskablePageSourceHeading,
+  AskablePageSourceLink,
+  AskablePageSourceSnapshot,
+} from './page-source.js';
 export type {
   AskableContext,
   AskableAgentRequest,

--- a/packages/core/src/page-source.ts
+++ b/packages/core/src/page-source.ts
@@ -1,0 +1,218 @@
+import type {
+  AskableContextSource,
+  AskableContextSourceResolveRequest,
+} from './types.js';
+
+export interface AskablePageSourceHeading {
+  level: number;
+  text: string;
+}
+
+export interface AskablePageSourceLink {
+  text: string;
+  href: string;
+}
+
+export interface AskablePageSourceSnapshot {
+  title?: string;
+  url?: string;
+  selectedText?: string;
+  text?: string;
+  headings?: AskablePageSourceHeading[];
+  links?: AskablePageSourceLink[];
+  truncated?: boolean;
+}
+
+export interface AskableCreatePageSourceOptions {
+  /** Root document or element to read from. Defaults to global document. */
+  root?: Document | HTMLElement;
+  /** Human-readable source description. Defaults to "Current page". */
+  describe?: string | (() => string | Promise<string>);
+  /** Source category. Defaults to "page". */
+  kind?: string;
+  /** Include links in resolved snapshots. Defaults to false. */
+  includeLinks?: boolean;
+  /** Maximum links returned when includeLinks is true. Defaults to 20. */
+  maxLinks?: number;
+  /** Maximum headings returned. Defaults to 20. */
+  maxHeadings?: number;
+  /** Maximum body text characters returned for mode "all". Defaults to 8000. */
+  maxTextLength?: number;
+  /** Override how page text is extracted from the root. */
+  textExtractor?: (root: Document | HTMLElement) => string;
+  /** Redact or transform extracted page and selection text. */
+  sanitizeText?: (text: string) => string;
+}
+
+/**
+ * Create a source that snapshots page text, selection, headings, and optional links.
+ *
+ * This is useful for browser extensions or fallback integrations that need
+ * context from pages that have not added Askable annotations.
+ *
+ * @example
+ * ctx.registerSource('page', createAskablePageSource({ includeLinks: true }));
+ */
+export function createAskablePageSource(options: AskableCreatePageSourceOptions = {}): AskableContextSource {
+  return {
+    kind: options.kind ?? 'page',
+    describe: options.describe ?? 'Current page',
+    getState: () => {
+      const root = resolveRoot(options.root);
+      if (!root) return undefined;
+      const doc = rootToDocument(root);
+      const selectedText = readSelection(doc, options);
+      return {
+        title: doc.title || undefined,
+        url: doc.location?.href,
+        ...(selectedText ? { selectedTextLength: selectedText.length } : {}),
+      };
+    },
+    resolve: (request) => resolvePageSnapshot(request, options),
+  };
+}
+
+function resolvePageSnapshot(
+  request: AskableContextSourceResolveRequest,
+  options: AskableCreatePageSourceOptions,
+): AskablePageSourceSnapshot | undefined {
+  const root = resolveRoot(options.root);
+  if (!root) return undefined;
+
+  const doc = rootToDocument(root);
+  const selectedText = readSelection(doc, options);
+  const maxItems = request.maxItems;
+
+  if (request.mode === 'selected') {
+    return {
+      title: doc.title || undefined,
+      url: doc.location?.href,
+      ...(selectedText ? { selectedText } : {}),
+    };
+  }
+
+  const snapshot: AskablePageSourceSnapshot = {
+    title: doc.title || undefined,
+    url: doc.location?.href,
+    ...(selectedText ? { selectedText } : {}),
+    headings: readHeadings(root, options, maxItems),
+  };
+
+  if (options.includeLinks) {
+    snapshot.links = readLinks(root, options, maxItems);
+  }
+
+  if (request.mode === 'all') {
+    const { text, truncated } = readPageText(root, options, request.maxTokens);
+    snapshot.text = text;
+    snapshot.truncated = truncated;
+  }
+
+  return snapshot;
+}
+
+function resolveRoot(root: Document | HTMLElement | undefined): Document | HTMLElement | undefined {
+  if (root) return root;
+  return typeof document === 'undefined' ? undefined : document;
+}
+
+function rootToDocument(root: Document | HTMLElement): Document {
+  return isDocument(root) ? root : root.ownerDocument;
+}
+
+function readSelection(
+  doc: Document,
+  options: AskableCreatePageSourceOptions,
+): string | undefined {
+  const selection = doc.getSelection?.()?.toString().trim();
+  if (!selection) return undefined;
+  return sanitizeText(selection, options);
+}
+
+function readPageText(
+  root: Document | HTMLElement,
+  options: AskableCreatePageSourceOptions,
+  maxTokens?: number,
+): { text: string; truncated: boolean } {
+  const raw = options.textExtractor
+    ? options.textExtractor(root)
+    : defaultText(root);
+  const text = normalizeWhitespace(sanitizeText(raw, options));
+  const maxChars = Math.max(0, Math.min(
+    options.maxTextLength ?? 8000,
+    maxTokens ? maxTokens * 4 : Number.POSITIVE_INFINITY,
+  ));
+  if (text.length <= maxChars) return { text, truncated: false };
+  return { text: text.slice(0, maxChars), truncated: true };
+}
+
+function defaultText(root: Document | HTMLElement): string {
+  const element = isDocument(root) ? root.body : root;
+  if (!element) return '';
+  if (typeof element.innerText === 'string') return element.innerText;
+
+  const doc = element.ownerDocument;
+  const showText = doc.defaultView?.NodeFilter.SHOW_TEXT ?? 4;
+  const walker = doc.createTreeWalker(element, showText, {
+    acceptNode(node) {
+      const parent = node.parentElement?.tagName.toLowerCase();
+      if (parent === 'script' || parent === 'style' || parent === 'noscript') {
+        return doc.defaultView?.NodeFilter.FILTER_REJECT ?? 2;
+      }
+      return node.textContent?.trim()
+        ? (doc.defaultView?.NodeFilter.FILTER_ACCEPT ?? 1)
+        : (doc.defaultView?.NodeFilter.FILTER_REJECT ?? 2);
+    },
+  });
+  const chunks: string[] = [];
+  let node = walker.nextNode();
+  while (node) {
+    chunks.push(node.textContent ?? '');
+    node = walker.nextNode();
+  }
+  return chunks.join(' ');
+}
+
+function isDocument(root: Document | HTMLElement): root is Document {
+  return typeof Document !== 'undefined' && root instanceof Document;
+}
+
+function readHeadings(
+  root: Document | HTMLElement,
+  options: AskableCreatePageSourceOptions,
+  maxItems?: number,
+): AskablePageSourceHeading[] {
+  const limit = Math.max(0, maxItems ?? options.maxHeadings ?? 20);
+  if (limit === 0) return [];
+  return Array.from(root.querySelectorAll('h1,h2,h3,h4,h5,h6'))
+    .slice(0, limit)
+    .map((heading) => ({
+      level: Number(heading.tagName.slice(1)),
+      text: normalizeWhitespace(sanitizeText(heading.textContent ?? '', options)),
+    }))
+    .filter((heading) => heading.text.length > 0);
+}
+
+function readLinks(
+  root: Document | HTMLElement,
+  options: AskableCreatePageSourceOptions,
+  maxItems?: number,
+): AskablePageSourceLink[] {
+  const limit = Math.max(0, maxItems ?? options.maxLinks ?? 20);
+  if (limit === 0) return [];
+  return Array.from(root.querySelectorAll('a[href]'))
+    .slice(0, limit)
+    .map((link) => ({
+      text: normalizeWhitespace(sanitizeText(link.textContent ?? '', options)),
+      href: (link as HTMLAnchorElement).href,
+    }))
+    .filter((link) => link.text.length > 0 && link.href.length > 0);
+}
+
+function sanitizeText(text: string, options: AskableCreatePageSourceOptions): string {
+  return options.sanitizeText ? options.sanitizeText(text) : text;
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -222,7 +222,11 @@ tables, virtualized lists, documents, maps, canvases, calendars, charts, file
 trees, or any custom state.
 
 ```ts
-import { createAskableCollectionSource, createAskableSource } from '@askable-ui/core';
+import {
+  createAskableCollectionSource,
+  createAskablePageSource,
+  createAskableSource,
+} from '@askable-ui/core';
 
 const handle = ctx.registerSource('accounts', createAskableCollectionSource({
   describe: 'Customer accounts in the dashboard',
@@ -255,6 +259,12 @@ ctx.registerSource('active-document', createAskableSource({
     all: ({ maxTokens }) => editor.export({ maxTokens }),
   },
   data: ({ mode }) => editor.export({ mode }),
+}));
+
+ctx.registerSource('page', createAskablePageSource({
+  includeLinks: true,
+  maxTextLength: 6000,
+  sanitizeText: redactPageText,
 }));
 
 await ctx.toPromptContextAsync({
@@ -290,6 +300,9 @@ overrides both `modes` and `data`.
 `getSelectedItems`, `getSummary`, `maxItems`, and `sanitizeItem` so paginated or
 virtualized collections can expose more than the rows currently mounted in the
 DOM without a table-specific API.
+`createAskablePageSource()` snapshots unannotated pages for extension and
+fallback contexts. It supports `summary`, `selected`, and `all` modes for page
+title, URL, selected text, headings, optional links, and capped full-page text.
 
 `registerSource()` returns a handle with `id`, `notifyChanged()`, and
 `unregister()`. Call `notifyChanged()` when filters, pagination, selected

--- a/site/docs/guide/serialization.md
+++ b/site/docs/guide/serialization.md
@@ -119,7 +119,11 @@ lists, documents, maps, charts, calendars, canvases, or API-backed dashboards,
 register a source that resolves data from your application state.
 
 ```ts
-import { createAskableCollectionSource, createAskableSource } from '@askable-ui/core';
+import {
+  createAskableCollectionSource,
+  createAskablePageSource,
+  createAskableSource,
+} from '@askable-ui/core';
 
 ctx.registerSource('accounts', createAskableCollectionSource({
   describe: 'Customer accounts matching the active filters',
@@ -146,6 +150,11 @@ ctx.registerSource('active-chart', createAskableSource({
   },
 }));
 
+ctx.registerSource('page', createAskablePageSource({
+  includeLinks: true,
+  sanitizeText: redactPageText,
+}));
+
 const context = await ctx.toPromptContextAsync({
   sources: [{ id: 'accounts', mode: 'all', maxItems: 20, timeoutMs: 750 }],
   sourceErrorMode: 'include',
@@ -164,6 +173,10 @@ writing a custom resolver switch. Source output can be redacted with
 `sanitizeSource` hook. Failed or timed-out sources are represented with a safe
 unavailable marker by default; use `sourceErrorMode: 'omit'` or `'throw'` when
 your runtime needs stricter behavior.
+
+For browser extensions and other clients that cannot change the site code,
+`createAskablePageSource()` can still expose the page title, URL, selected
+text, headings, optional links, and capped full-page text as a normal source.
 
 ## Custom labels
 


### PR DESCRIPTION
## Summary\n- add createAskablePageSource for extension-style and fallback context capture on unannotated pages\n- support summary, selected, and all source modes for title, URL, selected text, headings, optional links, and capped page text\n- document page snapshot sources in core README and docs\n\n## Test plan\n- npm test -w @askable-ui/core -- page-source.test.ts\n- npm run build -w @askable-ui/core\n- npm test -w @askable-ui/core\n- npm run build\n- npm run build:versioned --prefix site/docs\n- git diff --check