### PR TITLE
feat(core): support packet-backed agent context

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -475,8 +475,9 @@ await fetch('/api/chat', {
 
 For "select first, then ask" flows, pass an existing `WebContextPacket` from a
 region, circle, lasso, or text selection capture as `packet`. Askable attaches
-that exact packet to the request while still generating the prompt-ready context
-string from the current focus and registered sources.
+that exact packet to the request. Set `contextFromPacket: true` when the
+prompt-ready `context` string should be generated from the pinned selection
+instead of the current hover/click focus.
 
 #### `subscribeAsync(callback, options?): () => void`
 

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -515,6 +515,73 @@ describe('createAskableContext', () => {
     ctx.destroy();
   });
 
+  it('can build agent request context from an attached selection packet', async () => {
+    const ctx = createAskableContext();
+    ctx.push({ widget: 'hovered-card' }, 'Hovered card');
+    const packet = ctx.toContextPacket({
+      mode: 'lasso',
+      gesture: 'drag',
+      target: {
+        label: 'lasso selection',
+        text: 'Acme Corp row',
+        bounds: { x: 10, y: 20, width: 120, height: 80 },
+        metadata: {
+          selectedItems: [{ company: 'Acme Corp', mrr: '$8,400', plan: 'Enterprise' }],
+        },
+      },
+      privacy: { consent: 'explicit' },
+    });
+
+    const request = await ctx.toAgentRequest('Why is this account healthy?', {
+      packet,
+      contextFromPacket: true,
+    });
+
+    expect(request.packet).toBe(packet);
+    expect(request.context).toContain('Current: User selected context:');
+    expect(request.context).toContain('capture: lasso');
+    expect(request.context).toContain('label: lasso selection');
+    expect(request.context).toContain('"company":"Acme Corp"');
+    expect(request.context).toContain('value "Acme Corp row"');
+    expect(request.context).toContain('bounds: 120x80 at 10,20');
+    expect(request.context).not.toContain('hovered-card');
+
+    ctx.destroy();
+  });
+
+  it('can append sources while building agent request context from a packet', async () => {
+    const ctx = createAskableContext();
+    ctx.push({ widget: 'chart' }, 'Revenue chart');
+    ctx.registerSource('accounts', {
+      kind: 'collection',
+      resolve: () => ({ totalMatching: 12 }),
+    });
+    const packet = ctx.toContextPacket({
+      mode: 'circle',
+      target: {
+        label: 'circled accounts',
+        metadata: { segment: 'enterprise' },
+      },
+    });
+
+    const request = await ctx.toAgentRequest('Summarize this selection', {
+      packet,
+      contextFromPacket: true,
+      sources: ['accounts'],
+      format: 'json',
+    });
+    const parsed = JSON.parse(request.context);
+
+    expect(parsed.packet.capture.mode).toBe('circle');
+    expect(parsed.packet.target.label).toBe('circled accounts');
+    expect(parsed.sources[0]).toMatchObject({
+      id: 'accounts',
+      data: { totalMatching: 12 },
+    });
+
+    ctx.destroy();
+  });
+
   it('getFocus() returns null before any interaction', () => {
     const ctx = createAskableContext();
     ctx.observe(document);

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -174,7 +174,7 @@ export class AskableContextImpl implements AskableContext {
   private formatFocusMeta(meta: Record<string, unknown> | string): string {
     return typeof meta === 'string'
       ? meta
-      : Object.entries(meta).map(([k, v]) => `${k}: ${String(v)}`).join(', ');
+      : Object.entries(meta).map(([k, v]) => `${k}: ${this.formatMetaValue(v)}`).join(', ');
   }
 
   private filterAncestorSegments(segments: AskableFocusSegment[] | undefined, scope?: string): AskableFocusSegment[] {
@@ -570,9 +570,9 @@ export class AskableContextImpl implements AskableContext {
       requestId,
       metadata,
       packet: packetOption,
+      contextFromPacket = false,
       ...contextOptions
     } = options ?? {};
-    const context = await this.toContextAsync(contextOptions);
     let packet: WebContextPacket | undefined;
     if (packetOption) {
       if (packetOption === true) {
@@ -583,6 +583,9 @@ export class AskableContextImpl implements AskableContext {
         packet = await this.toContextPacketAsync(packetOption);
       }
     }
+    const context = contextFromPacket && packet
+      ? await this.toPacketContextAsync(packet, contextOptions)
+      : await this.toContextAsync(contextOptions);
 
     return {
       ...(requestId ? { requestId } : {}),
@@ -845,11 +848,12 @@ export class AskableContextImpl implements AskableContext {
     base: string,
     sources: AskableResolvedContextSource[],
     options: AskablePromptContextOptions,
-    label = 'Context sources'
+    label = 'Context sources',
+    jsonBaseKey = 'focus'
   ): string {
     if ((options.format ?? 'natural') === 'json') {
       return JSON.stringify({
-        focus: this.safeParseJson(base),
+        [jsonBaseKey]: this.safeParseJson(base),
         sources,
       });
     }
@@ -876,6 +880,22 @@ export class AskableContextImpl implements AskableContext {
 
   private stringifySourceValue(value: unknown): string {
     if (typeof value === 'string') return `"${value}"`;
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  private formatMetaValue(value: unknown): string {
+    if (
+      value === null ||
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      return String(value);
+    }
     try {
       return JSON.stringify(value);
     } catch {
@@ -973,6 +993,24 @@ export class AskableContextImpl implements AskableContext {
       ...packetOptions
     } = options;
     return packetOptions;
+  }
+
+  private async toPacketContextAsync(
+    packet: WebContextPacket,
+    options: AskableAsyncContextOutputOptions
+  ): Promise<string> {
+    const resolved = this.resolveOptions(options);
+    const { sourceLabel, maxTokens } = options ?? {};
+    const currentLabel = options.currentLabel ?? 'Current';
+    const packetContext = this.buildPacketPromptString(packet, resolved);
+    const base = (resolved.format ?? 'natural') === 'json'
+      ? packetContext
+      : `${currentLabel}: ${packetContext}`;
+    const sources = await this.resolveIncludedSources(options);
+    const output = sources.length === 0
+      ? base
+      : this.appendSourcesToOutput(base, sources, resolved, sourceLabel, 'packet');
+    return this.applyTokenBudget(output, maxTokens);
   }
 
   private resolveCaptureMode(focus: AskableFocus | null): WebContextCaptureMode {
@@ -1074,6 +1112,49 @@ export class AskableContextImpl implements AskableContext {
     const parts: string[] = [prefix];
     if (metaWithHierarchy) parts.push(metaWithHierarchy);
     if (serialized.text) parts.push(`${textLabel} "${serialized.text}"`);
+
+    return parts.join(' — ');
+  }
+
+  private buildPacketPromptString(packet: WebContextPacket, options?: AskablePromptContextOptions): string {
+    const resolved = this.resolveOptions(options);
+    const format = resolved.format ?? 'natural';
+    const target = packet.target ?? null;
+
+    if (format === 'json') {
+      return JSON.stringify({
+        capture: packet.capture,
+        target,
+        ...(packet.surrounding ? { surrounding: packet.surrounding } : {}),
+        privacy: packet.privacy,
+        provenance: packet.provenance,
+      });
+    }
+
+    if (!target) return 'No packet target is available.';
+
+    const prefix = resolved.prefix ?? 'User selected context:';
+    const textLabel = resolved.textLabel ?? 'value';
+    const metadata = typeof target.metadata === 'string'
+      ? target.metadata
+      : target.metadata
+        ? this.normalizeMeta(target.metadata, resolved)
+        : undefined;
+    const metaStr = metadata ? this.formatFocusMeta(metadata) : '';
+    const text = target.text && (resolved.includeText ?? true)
+      ? this.normalizeText(target.text, resolved.maxTextLength)
+      : '';
+    const bounds = target.bounds
+      ? `bounds: ${Math.round(target.bounds.width)}x${Math.round(target.bounds.height)} at ${Math.round(target.bounds.x)},${Math.round(target.bounds.y)}`
+      : '';
+
+    const parts: string[] = [prefix];
+    if (packet.capture.mode) parts.push(`capture: ${packet.capture.mode}`);
+    if (target.label) parts.push(`label: ${target.label}`);
+    if (target.role) parts.push(`role: ${target.role}`);
+    if (metaStr) parts.push(metaStr);
+    if (text) parts.push(`${textLabel} "${text}"`);
+    if (bounds) parts.push(bounds);
 
     return parts.join(' — ');
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -422,6 +422,11 @@ export interface AskableAgentRequestOptions extends AskableAsyncContextOutputOpt
   metadata?: Record<string, unknown>;
   /** Include a structured Context packet. Pass true, packet options, or an existing packet from a capture tool. */
   packet?: boolean | AskableAsyncContextPacketOptions | WebContextPacket;
+  /**
+   * Build the prompt-ready `context` string from the attached packet target
+   * instead of the current focus. Useful for "select first, then ask" composers.
+   */
+  contextFromPacket?: boolean;
 }
 
 export interface AskableAgentRequest {

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -541,6 +541,11 @@ pass an existing `WebContextPacket` from a region, circle, lasso, or text
 selection capture. Existing packets are attached as-is, which is useful for
 "select first, then ask a question" chat composers.
 
+Set `contextFromPacket: true` when that pinned packet should also become the
+prompt-ready `context` string. This keeps the user question grounded to the
+selected area or highlighted text even if hover/click focus changes while the
+composer is open.
+
 ```ts
 let pendingPacket: WebContextPacket | null = null;
 
@@ -555,6 +560,7 @@ const lasso = createAskableRegionCapture(ctx, {
 async function submit(question: string) {
   return ctx.toAgentRequest(question, {
     packet: pendingPacket ?? true,
+    contextFromPacket: Boolean(pendingPacket),
     sources: ['accounts'],
   });
 }

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -353,6 +353,7 @@ interface AskableAgentRequestOptions extends AskableAsyncContextOutputOptions {
   requestId?: string;
   metadata?: Record<string, unknown>;
   packet?: boolean | AskableAsyncContextPacketOptions | WebContextPacket;
+  contextFromPacket?: boolean;
 }
 
 interface AskableAgentRequest {

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -164,6 +164,17 @@ async function ask(userMessage: string) {
 }
 ```
 
+For a selection composer, keep the packet from region, circle, lasso, or text
+selection capture and pass it back with `contextFromPacket: true`:
+
+```ts
+await ctx.toAgentRequest(userMessage, {
+  packet: pendingSelectionPacket,
+  contextFromPacket: true,
+  sources: ['accounts'],
+});
+```
+
 When the user clicks a revenue chart and asks *"why is this dropping?"*, `promptContext` becomes:
 
 ```

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -147,6 +147,8 @@ const request = await ctx.toAgentRequest(question, {
 You can also pass a packet that came from a region, circle, lasso, or text
 selection capture. This supports a controlled UX where the user selects context,
 sees it pinned in the chat composer, then adds a question before sending.
+Set `contextFromPacket: true` when the prompt string should be generated from
+that pinned selection instead of the current hover or click focus.
 
 ### Region, circle, lasso, and text capture together
 


### PR DESCRIPTION
## Summary
- add `contextFromPacket` for selection-first chat composers
- format packet targets into prompt-ready agent request context
- keep nested metadata readable in natural prompt context
- document packet-backed request usage

## Tests
- npm test -w @askable-ui/core -- context.test.ts
- npm test -w @askable-ui/core
- npm run build -w @askable-ui/core
- npm run build:versioned --prefix site/docs
- npm run build
- git diff --check