### PR TITLE
feat(core): pass packet selections to sources

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -477,7 +477,9 @@ For "select first, then ask" flows, pass an existing `WebContextPacket` from a
 region, circle, lasso, or text selection capture as `packet`. Askable attaches
 that exact packet to the request. Set `contextFromPacket: true` when the
 prompt-ready `context` string should be generated from the pinned selection
-instead of the current hover/click focus.
+instead of the current hover/click focus. Set `selectionFromPacket: true` when
+registered sources should receive the packet target as their `selection` input
+so app-owned state can resolve the full selected data.
 
 #### `subscribeAsync(callback, options?): () => void`
 

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -582,6 +582,84 @@ describe('createAskableContext', () => {
     ctx.destroy();
   });
 
+  it('passes packet selection data into agent request source resolvers', async () => {
+    const ctx = createAskableContext();
+    ctx.push({ widget: 'accounts-table' }, 'Accounts table');
+    let resolverSelection: unknown;
+    ctx.registerSource('accounts', {
+      kind: 'collection',
+      resolve: ({ selection }) => {
+        resolverSelection = selection;
+        return { selectedRows: selection };
+      },
+    });
+    const packet = ctx.toContextPacket({
+      mode: 'lasso',
+      gesture: 'drag',
+      target: {
+        label: 'lasso selection',
+        text: 'Acme Corp',
+        bounds: { x: 10, y: 20, width: 120, height: 80 },
+        metadata: {
+          selectedItems: [{ company: 'Acme Corp', mrr: '$8,400' }],
+        },
+      },
+      privacy: { consent: 'explicit' },
+    });
+
+    const request = await ctx.toAgentRequest('What should I do next?', {
+      packet,
+      contextFromPacket: true,
+      selectionFromPacket: true,
+      sources: ['accounts'],
+    });
+
+    expect(resolverSelection).toMatchObject({
+      capture: { mode: 'lasso', gesture: 'drag' },
+      target: {
+        label: 'lasso selection',
+        text: 'Acme Corp',
+        bounds: { x: 10, y: 20, width: 120, height: 80 },
+        metadata: {
+          selectedItems: [{ company: 'Acme Corp', mrr: '$8,400' }],
+        },
+      },
+    });
+    expect(request.context).toContain('Context sources');
+    expect(request.context).toContain('"selectedItems":[{"company":"Acme Corp","mrr":"$8,400"}]');
+
+    ctx.destroy();
+  });
+
+  it('preserves explicit source selections when packet selection is enabled', async () => {
+    const ctx = createAskableContext();
+    let resolverSelection: unknown;
+    ctx.registerSource('accounts', {
+      resolve: ({ selection }) => {
+        resolverSelection = selection;
+        return { selection };
+      },
+    });
+    const packet = ctx.toContextPacket({
+      mode: 'circle',
+      target: {
+        label: 'circled accounts',
+        metadata: { selectedItems: [{ company: 'Acme Corp' }] },
+      },
+    });
+
+    await ctx.toAgentRequest('Explain these accounts', {
+      packet,
+      contextFromPacket: true,
+      selectionFromPacket: true,
+      sources: [{ id: 'accounts', selection: { ids: ['acct_123'] } }],
+    });
+
+    expect(resolverSelection).toEqual({ ids: ['acct_123'] });
+
+    ctx.destroy();
+  });
+
   it('getFocus() returns null before any interaction', () => {
     const ctx = createAskableContext();
     ctx.observe(document);

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -503,10 +503,17 @@ export class AskableContextImpl implements AskableContext {
   }
 
   async toContextAsync(options?: AskableAsyncContextOutputOptions): Promise<string> {
+    return this.toContextAsyncWithSourceSelection(options);
+  }
+
+  private async toContextAsyncWithSourceSelection(
+    options?: AskableAsyncContextOutputOptions,
+    defaultSourceSelection?: unknown
+  ): Promise<string> {
     const resolved = this.resolveOptions(options);
     const { sources: _sources, sourceMode: _sourceMode, sourceLabel, maxTokens, ...contextOptions } = options ?? {};
     const base = this.toContext(contextOptions);
-    const sources = await this.resolveIncludedSources(options);
+    const sources = await this.resolveIncludedSources(options, defaultSourceSelection);
     if (sources.length === 0) return this.applyTokenBudget(base, maxTokens);
     const output = this.appendSourcesToOutput(base, sources, resolved, sourceLabel);
     return this.applyTokenBudget(output, maxTokens);
@@ -575,6 +582,7 @@ export class AskableContextImpl implements AskableContext {
       metadata,
       packet: packetOption,
       contextFromPacket = false,
+      selectionFromPacket = false,
       ...contextOptions
     } = options ?? {};
     let packet: WebContextPacket | undefined;
@@ -587,9 +595,12 @@ export class AskableContextImpl implements AskableContext {
         packet = await this.toContextPacketAsync(packetOption);
       }
     }
+    const defaultSourceSelection = selectionFromPacket && packet
+      ? this.packetToSourceSelection(packet)
+      : undefined;
     const context = contextFromPacket && packet
-      ? await this.toPacketContextAsync(packet, contextOptions)
-      : await this.toContextAsync(contextOptions);
+      ? await this.toPacketContextAsync(packet, contextOptions, defaultSourceSelection)
+      : await this.toContextAsyncWithSourceSelection(contextOptions, defaultSourceSelection);
 
     return {
       ...(requestId ? { requestId } : {}),
@@ -792,11 +803,21 @@ export class AskableContextImpl implements AskableContext {
 
   private normalizeSourceRequest(
     include: AskableContextSourceInclude,
-    defaultMode: AskableContextSourceMode
+    defaultMode: AskableContextSourceMode,
+    defaultSelection?: unknown
   ): AskableContextSourceRequest {
-    return typeof include === 'string'
-      ? { id: include, mode: defaultMode }
-      : { ...include, mode: include.mode ?? defaultMode };
+    if (typeof include === 'string') {
+      return {
+        id: include,
+        mode: defaultMode,
+        ...(defaultSelection !== undefined ? { selection: defaultSelection } : {}),
+      };
+    }
+    return {
+      ...include,
+      mode: include.mode ?? defaultMode,
+      ...(include.selection === undefined && defaultSelection !== undefined ? { selection: defaultSelection } : {}),
+    };
   }
 
   private shouldRefreshSources(
@@ -814,14 +835,19 @@ export class AskableContextImpl implements AskableContext {
   }
 
   private async resolveIncludedSources(
-    options?: AskableAsyncPromptContextOptions | AskableAsyncContextOutputOptions
+    options?: AskableAsyncPromptContextOptions | AskableAsyncContextOutputOptions,
+    defaultSelection?: unknown
   ): Promise<AskableResolvedContextSource[]> {
     const includes = options?.sources;
     if (!includes) return [];
     const defaultMode = options.sourceMode ?? 'summary';
     const requests = includes === 'all'
-      ? Array.from(this.sources.keys()).map((id) => ({ id, mode: defaultMode }))
-      : includes.map((include) => this.normalizeSourceRequest(include, defaultMode));
+      ? Array.from(this.sources.keys()).map((id) => ({
+          id,
+          mode: defaultMode,
+          ...(defaultSelection !== undefined ? { selection: defaultSelection } : {}),
+        }))
+      : includes.map((include) => this.normalizeSourceRequest(include, defaultMode, defaultSelection));
 
     const errorMode = options.sourceErrorMode ?? 'include';
     const resolved = await Promise.all(requests.map(({ id, ...request }) => (
@@ -1001,7 +1027,8 @@ export class AskableContextImpl implements AskableContext {
 
   private async toPacketContextAsync(
     packet: WebContextPacket,
-    options: AskableAsyncContextOutputOptions
+    options: AskableAsyncContextOutputOptions,
+    defaultSourceSelection?: unknown
   ): Promise<string> {
     const resolved = this.resolveOptions(options);
     const { sourceLabel, maxTokens } = options ?? {};
@@ -1010,11 +1037,29 @@ export class AskableContextImpl implements AskableContext {
     const base = (resolved.format ?? 'natural') === 'json'
       ? packetContext
       : `${currentLabel}: ${packetContext}`;
-    const sources = await this.resolveIncludedSources(options);
+    const sources = await this.resolveIncludedSources(options, defaultSourceSelection);
     const output = sources.length === 0
       ? base
       : this.appendSourcesToOutput(base, sources, resolved, sourceLabel, 'packet');
     return this.applyTokenBudget(output, maxTokens);
+  }
+
+  private packetToSourceSelection(packet: WebContextPacket): Record<string, unknown> {
+    const target = packet.target;
+    return {
+      capture: packet.capture,
+      source: packet.source,
+      ...(target ? {
+        target: {
+          ...(target.label ? { label: target.label } : {}),
+          ...(target.role ? { role: target.role } : {}),
+          ...(target.selector ? { selector: target.selector } : {}),
+          ...(target.bounds ? { bounds: target.bounds } : {}),
+          ...(target.text ? { text: target.text } : {}),
+          ...(target.metadata !== undefined ? { metadata: target.metadata } : {}),
+        },
+      } : {}),
+    };
   }
 
   private resolveCaptureMode(focus: AskableFocus | null): WebContextCaptureMode {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -427,6 +427,11 @@ export interface AskableAgentRequestOptions extends AskableAsyncContextOutputOpt
    * instead of the current focus. Useful for "select first, then ask" composers.
    */
   contextFromPacket?: boolean;
+  /**
+   * Pass a packet-derived selection payload into registered source resolvers.
+   * Explicit `selection` values on individual source requests take precedence.
+   */
+  selectionFromPacket?: boolean;
 }
 
 export interface AskableAgentRequest {

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -546,6 +546,12 @@ prompt-ready `context` string. This keeps the user question grounded to the
 selected area or highlighted text even if hover/click focus changes while the
 composer is open.
 
+Set `selectionFromPacket: true` when registered sources should receive the
+packet target as their `selection` input. This lets a source resolve backing app
+state for a selected table row, document range, chart region, map feature, or
+canvas shape. Explicit `selection` values on individual source requests still
+take precedence.
+
 ```ts
 let pendingPacket: WebContextPacket | null = null;
 
@@ -561,7 +567,8 @@ async function submit(question: string) {
   return ctx.toAgentRequest(question, {
     packet: pendingPacket ?? true,
     contextFromPacket: Boolean(pendingPacket),
-    sources: ['accounts'],
+    selectionFromPacket: Boolean(pendingPacket),
+    sources: [{ id: 'accounts', mode: 'selected' }],
   });
 }
 ```

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -354,6 +354,7 @@ interface AskableAgentRequestOptions extends AskableAsyncContextOutputOptions {
   metadata?: Record<string, unknown>;
   packet?: boolean | AskableAsyncContextPacketOptions | WebContextPacket;
   contextFromPacket?: boolean;
+  selectionFromPacket?: boolean;
 }
 
 interface AskableAgentRequest {

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -171,7 +171,8 @@ selection capture and pass it back with `contextFromPacket: true`:
 await ctx.toAgentRequest(userMessage, {
   packet: pendingSelectionPacket,
   contextFromPacket: true,
-  sources: ['accounts'],
+  selectionFromPacket: true,
+  sources: [{ id: 'accounts', mode: 'selected' }],
 });
 ```
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -149,6 +149,8 @@ selection capture. This supports a controlled UX where the user selects context,
 sees it pinned in the chat composer, then adds a question before sending.
 Set `contextFromPacket: true` when the prompt string should be generated from
 that pinned selection instead of the current hover or click focus.
+Set `selectionFromPacket: true` when registered sources should use that packet
+target to resolve selected app data that may not be visible in the DOM.
 
 ### Region, circle, lasso, and text capture together
 


### PR DESCRIPTION
## Summary
- add `selectionFromPacket` for packet-backed agent requests
- pass packet target details into registered source resolvers as default selection data
- preserve explicit per-source `selection` overrides
- document selection-backed source resolution for chat composers

## Tests
- npm test -w @askable-ui/core -- context.test.ts
- npm run build -w @askable-ui/core
- npm run build:versioned --prefix site/docs
- npm run build
- git diff --check