### PR TITLE
feat(core): type packet source selections

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -481,6 +481,19 @@ instead of the current hover/click focus. Set `selectionFromPacket: true` when
 registered sources should receive the packet target as their `selection` input
 so app-owned state can resolve the full selected data.
 
+```ts
+import { isAskablePacketSourceSelection } from '@askable-ui/core';
+
+ctx.registerSource('accounts', {
+  resolve({ mode, selection }) {
+    if (mode === 'selected' && isAskablePacketSourceSelection(selection)) {
+      return getAccountsForSelection(selection.target?.metadata);
+    }
+    return getAccountsSummary();
+  },
+});
+```
+
 #### `subscribeAsync(callback, options?): () => void`
 
 Subscribe to source-backed context updates. The callback receives

--- a/packages/core/src/__tests__/sources.test.ts
+++ b/packages/core/src/__tests__/sources.test.ts
@@ -3,9 +3,25 @@ import {
   createAskableCollectionSource,
   createAskableContext,
   createAskableSource,
+  isAskablePacketSourceSelection,
 } from '../index.js';
 
 describe('source helpers', () => {
+  it('narrows packet-derived source selections', () => {
+    const selection = {
+      capture: { mode: 'lasso', gesture: 'drag' },
+      source: { timestamp: '2026-06-05T00:00:00.000Z', route: '/accounts' },
+      target: {
+        label: 'lasso selection',
+        metadata: { selectedItems: [{ id: 'acct_123' }] },
+      },
+    };
+
+    expect(isAskablePacketSourceSelection(selection)).toBe(true);
+    expect(isAskablePacketSourceSelection({ ids: ['acct_123'] })).toBe(false);
+    expect(isAskablePacketSourceSelection(null)).toBe(false);
+  });
+
   it('creates a generic app-owned context source', async () => {
     const ctx = createAskableContext();
     ctx.registerSource('document', createAskableSource({

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -26,6 +26,7 @@ import type {
   AskableFocus,
   AskableFocusSegment,
   AskableObserveOptions,
+  AskablePacketSourceSelection,
   AskablePromptContextOptions,
   AskablePromptPreset,
   AskablePushOptions,
@@ -1044,7 +1045,7 @@ export class AskableContextImpl implements AskableContext {
     return this.applyTokenBudget(output, maxTokens);
   }
 
-  private packetToSourceSelection(packet: WebContextPacket): Record<string, unknown> {
+  private packetToSourceSelection(packet: WebContextPacket): AskablePacketSourceSelection {
     const target = packet.target;
     return {
       capture: packet.capture,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@ export { createAskableInspector } from './inspector.js';
 export { ASKABLE_REGION_CAPTURE_THEME, createAskableRegionCapture } from './capture.js';
 export { ASKABLE_TEXT_SELECTION_CAPTURE_THEME, createAskableTextSelectionCapture } from './selection.js';
 export { a11yTextExtractor } from './a11y.js';
-export { createAskableCollectionSource, createAskableSource } from './sources.js';
+export { createAskableCollectionSource, createAskableSource, isAskablePacketSourceSelection } from './sources.js';
 export { createAskablePageSource } from './page-source.js';
 export {
   WEB_CONTEXT_PROTOCOL,
@@ -96,6 +96,8 @@ export type {
   AskableFocusSegment,
   AskableFocusSource,
   AskableObserveOptions,
+  AskablePacketSourceSelection,
+  AskablePacketSourceSelectionTarget,
   AskablePromptContextOptions,
   AskablePromptFormat,
   AskablePromptPreset,

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -2,6 +2,7 @@ import type {
   AskableContextSource,
   AskableContextSourceMode,
   AskableContextSourceResolveRequest,
+  AskablePacketSourceSelection,
   AskableResolvedContextSource,
 } from './types.js';
 
@@ -10,6 +11,14 @@ export type AskableSourceResolver<T> = (
   request: AskableContextSourceResolveRequest
 ) => T | Promise<T>;
 export type AskableSourceModeMap<T> = Record<string, T | AskableSourceResolver<T>>;
+
+export function isAskablePacketSourceSelection(
+  selection: unknown,
+): selection is AskablePacketSourceSelection {
+  if (!selection || typeof selection !== 'object') return false;
+  const value = selection as Partial<AskablePacketSourceSelection>;
+  return Boolean(value.capture && typeof value.capture === 'object' && value.source && typeof value.source === 'object');
+}
 
 export interface AskableCreateSourceOptions<TData = unknown, TState = unknown> {
   /** Source category. Examples: "document", "collection", "chart", "map", "canvas". */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,6 +151,20 @@ export type AskableContextSourceMode =
   | 'all'
   | (string & {});
 
+export type AskablePacketSourceSelectionTarget = Pick<
+  WebContextTarget,
+  'label' | 'role' | 'selector' | 'bounds' | 'text' | 'metadata'
+>;
+
+export interface AskablePacketSourceSelection {
+  /** Capture metadata from the selected Context packet. */
+  capture: WebContextPacket['capture'];
+  /** Page or app source metadata from the selected Context packet. */
+  source: WebContextSource;
+  /** Selected packet target, when the packet has one. */
+  target?: AskablePacketSourceSelectionTarget;
+}
+
 export interface AskableContextSourceResolveRequest {
   /** Registered source id. */
   sourceId: string;

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -552,6 +552,23 @@ state for a selected table row, document range, chart region, map feature, or
 canvas shape. Explicit `selection` values on individual source requests still
 take precedence.
 
+Use `isAskablePacketSourceSelection()` inside a resolver when you need to narrow
+that generic `selection` payload:
+
+```ts
+import { isAskablePacketSourceSelection } from '@askable-ui/core';
+
+ctx.registerSource('accounts', {
+  kind: 'collection',
+  resolve({ mode, selection }) {
+    if (mode === 'selected' && isAskablePacketSourceSelection(selection)) {
+      return getAccountsForSelection(selection.target?.metadata);
+    }
+    return getAccountsSummary();
+  },
+});
+```
+
 ```ts
 let pendingPacket: WebContextPacket | null = null;
 

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -357,6 +357,21 @@ interface AskableAgentRequestOptions extends AskableAsyncContextOutputOptions {
   selectionFromPacket?: boolean;
 }
 
+type AskablePacketSourceSelectionTarget = Pick<
+  WebContextTarget,
+  'label' | 'role' | 'selector' | 'bounds' | 'text' | 'metadata'
+>;
+
+interface AskablePacketSourceSelection {
+  capture: WebContextPacket['capture'];
+  source: WebContextSource;
+  target?: AskablePacketSourceSelectionTarget;
+}
+
+function isAskablePacketSourceSelection(
+  selection: unknown
+): selection is AskablePacketSourceSelection;
+
 interface AskableAgentRequest {
   requestId?: string;
   question: string;


### PR DESCRIPTION
## Summary
- export `AskablePacketSourceSelection` and target types
- add `isAskablePacketSourceSelection()` for narrowing packet-derived source selections
- type the internal packet-to-source selection payload
- document resolver usage and type shape

## Tests
- npm test -w @askable-ui/core -- sources.test.ts context.test.ts
- npm run build -w @askable-ui/core
- npm run build:versioned --prefix site/docs
- npm run build
- git diff --check