### PR TITLE
feat(core): default packet sources to selected mode

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -479,7 +479,8 @@ that exact packet to the request. Set `contextFromPacket: true` when the
 prompt-ready `context` string should be generated from the pinned selection
 instead of the current hover/click focus. Set `selectionFromPacket: true` when
 registered sources should receive the packet target as their `selection` input
-so app-owned state can resolve the full selected data.
+so app-owned state can resolve the full selected data. String source includes
+use `mode: 'selected'` by default when `selectionFromPacket` is enabled.
 
 ```ts
 import { isAskablePacketSourceSelection } from '@askable-ui/core';

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -585,10 +585,12 @@ describe('createAskableContext', () => {
   it('passes packet selection data into agent request source resolvers', async () => {
     const ctx = createAskableContext();
     ctx.push({ widget: 'accounts-table' }, 'Accounts table');
+    let resolverMode: unknown;
     let resolverSelection: unknown;
     ctx.registerSource('accounts', {
       kind: 'collection',
-      resolve: ({ selection }) => {
+      resolve: ({ mode, selection }) => {
+        resolverMode = mode;
         resolverSelection = selection;
         return { selectedRows: selection };
       },
@@ -614,6 +616,7 @@ describe('createAskableContext', () => {
       sources: ['accounts'],
     });
 
+    expect(resolverMode).toBe('selected');
     expect(resolverSelection).toMatchObject({
       capture: { mode: 'lasso', gesture: 'drag' },
       target: {
@@ -627,6 +630,32 @@ describe('createAskableContext', () => {
     });
     expect(request.context).toContain('Context sources');
     expect(request.context).toContain('"selectedItems":[{"company":"Acme Corp","mrr":"$8,400"}]');
+
+    ctx.destroy();
+  });
+
+  it('respects explicit sourceMode when packet selection is enabled', async () => {
+    const ctx = createAskableContext();
+    let resolverMode: unknown;
+    ctx.registerSource('accounts', {
+      resolve: ({ mode }) => {
+        resolverMode = mode;
+        return { mode };
+      },
+    });
+    const packet = ctx.toContextPacket({
+      mode: 'circle',
+      target: { label: 'circled accounts' },
+    });
+
+    await ctx.toAgentRequest('Summarize these accounts', {
+      packet,
+      selectionFromPacket: true,
+      sources: ['accounts'],
+      sourceMode: 'summary',
+    });
+
+    expect(resolverMode).toBe('summary');
 
     ctx.destroy();
   });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -586,10 +586,11 @@ export class AskableContextImpl implements AskableContext {
       selectionFromPacket = false,
       ...contextOptions
     } = options ?? {};
+    const sourceContextOptions = this.agentRequestSourceOptions(contextOptions, selectionFromPacket);
     let packet: WebContextPacket | undefined;
     if (packetOption) {
       if (packetOption === true) {
-        packet = await this.toContextPacketAsync(this.agentRequestOptionsToPacketOptions(contextOptions));
+        packet = await this.toContextPacketAsync(this.agentRequestOptionsToPacketOptions(sourceContextOptions));
       } else if (isWebContextPacket(packetOption)) {
         packet = packetOption;
       } else {
@@ -600,14 +601,14 @@ export class AskableContextImpl implements AskableContext {
       ? this.packetToSourceSelection(packet)
       : undefined;
     const context = contextFromPacket && packet
-      ? await this.toPacketContextAsync(packet, contextOptions, defaultSourceSelection)
-      : await this.toContextAsyncWithSourceSelection(contextOptions, defaultSourceSelection);
+      ? await this.toPacketContextAsync(packet, sourceContextOptions, defaultSourceSelection)
+      : await this.toContextAsyncWithSourceSelection(sourceContextOptions, defaultSourceSelection);
 
     return {
       ...(requestId ? { requestId } : {}),
       question,
       context,
-      focus: this.serializeFocus(contextOptions),
+      focus: this.serializeFocus(sourceContextOptions),
       ...(packet ? { packet } : {}),
       ...(metadata ? { metadata } : {}),
       timestamp: Date.now(),
@@ -1024,6 +1025,14 @@ export class AskableContextImpl implements AskableContext {
       ...packetOptions
     } = options;
     return packetOptions;
+  }
+
+  private agentRequestSourceOptions(
+    options: AskableAsyncContextOutputOptions,
+    selectionFromPacket: boolean,
+  ): AskableAsyncContextOutputOptions {
+    if (!selectionFromPacket || options.sourceMode !== undefined) return options;
+    return { ...options, sourceMode: 'selected' };
   }
 
   private async toPacketContextAsync(

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -550,7 +550,9 @@ Set `selectionFromPacket: true` when registered sources should receive the
 packet target as their `selection` input. This lets a source resolve backing app
 state for a selected table row, document range, chart region, map feature, or
 canvas shape. Explicit `selection` values on individual source requests still
-take precedence.
+take precedence. When `selectionFromPacket` is enabled, string source includes
+use `mode: 'selected'` by default; pass `sourceMode` or an explicit source request
+when another mode is needed.
 
 Use `isAskablePacketSourceSelection()` inside a resolver when you need to narrow
 that generic `selection` payload:
@@ -585,7 +587,7 @@ async function submit(question: string) {
     packet: pendingPacket ?? true,
     contextFromPacket: Boolean(pendingPacket),
     selectionFromPacket: Boolean(pendingPacket),
-    sources: [{ id: 'accounts', mode: 'selected' }],
+    sources: ['accounts'],
   });
 }
 ```

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -172,7 +172,7 @@ await ctx.toAgentRequest(userMessage, {
   packet: pendingSelectionPacket,
   contextFromPacket: true,
   selectionFromPacket: true,
-  sources: [{ id: 'accounts', mode: 'selected' }],
+  sources: ['accounts'],
 });
 ```
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -151,6 +151,8 @@ Set `contextFromPacket: true` when the prompt string should be generated from
 that pinned selection instead of the current hover or click focus.
 Set `selectionFromPacket: true` when registered sources should use that packet
 target to resolve selected app data that may not be visible in the DOM.
+String source includes use `mode: 'selected'` by default in this flow unless
+`sourceMode` is set explicitly.
 
 ### Region, circle, lasso, and text capture together
 


### PR DESCRIPTION
## Summary
- default string source includes to `mode: selected` when `selectionFromPacket` is enabled
- preserve explicit `sourceMode` overrides
- update request docs and examples to use the simpler string source form

## Tests
- npm test -w @askable-ui/core -- context.test.ts
- npm run build -w @askable-ui/core
- npm run build:versioned --prefix site/docs
- npm run build
- git diff --check