### PR TITLE
feat(core): add agent request guard

### DIFF
--- a/packages/core/src/__tests__/agent-request.test.ts
+++ b/packages/core/src/__tests__/agent-request.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { createAskableContext, isAskableAgentRequest } from '../index.js';
+
+describe('agent request helpers', () => {
+  it('accepts requests produced by toAgentRequest()', async () => {
+    const ctx = createAskableContext();
+    ctx.push({ widget: 'accounts-table' }, 'Accounts table');
+
+    const request = await ctx.toAgentRequest('Which account needs follow-up?', {
+      requestId: 'req_123',
+      metadata: { route: '/accounts' },
+      packet: true,
+    });
+
+    expect(isAskableAgentRequest(request)).toBe(true);
+
+    ctx.destroy();
+  });
+
+  it('accepts valid request payloads without optional fields', () => {
+    expect(isAskableAgentRequest({
+      question: 'What changed?',
+      context: 'Current: User is focused on: widget: revenue',
+      focus: null,
+      timestamp: Date.now(),
+    })).toBe(true);
+  });
+
+  it('rejects malformed or incomplete request payloads', () => {
+    expect(isAskableAgentRequest(null)).toBe(false);
+    expect(isAskableAgentRequest([])).toBe(false);
+    expect(isAskableAgentRequest({
+      question: '',
+      context: 'Current context',
+      focus: null,
+      timestamp: Date.now(),
+    })).toBe(false);
+    expect(isAskableAgentRequest({
+      question: 'What changed?',
+      context: 'Current context',
+      focus: null,
+      timestamp: 'now',
+    })).toBe(false);
+    expect(isAskableAgentRequest({
+      question: 'What changed?',
+      context: 'Current context',
+      focus: null,
+      packet: { protocol: 'wrong' },
+      timestamp: Date.now(),
+    })).toBe(false);
+    expect(isAskableAgentRequest({
+      question: 'What changed?',
+      context: 'Current context',
+      focus: null,
+      metadata: 'route=/accounts',
+      timestamp: Date.now(),
+    })).toBe(false);
+  });
+});

--- a/packages/core/src/agent-request.ts
+++ b/packages/core/src/agent-request.ts
@@ -1,0 +1,17 @@
+import { isWebContextPacket } from '@askable-ui/context';
+import type { AskableAgentRequest } from './types.js';
+
+export function isAskableAgentRequest(value: unknown): value is AskableAgentRequest {
+  if (!isRecord(value)) return false;
+  if (value.requestId !== undefined && typeof value.requestId !== 'string') return false;
+  if (typeof value.question !== 'string' || value.question.trim().length === 0) return false;
+  if (typeof value.context !== 'string') return false;
+  if (!(value.focus === null || isRecord(value.focus))) return false;
+  if (value.packet !== undefined && !isWebContextPacket(value.packet)) return false;
+  if (value.metadata !== undefined && !isRecord(value.metadata)) return false;
+  return typeof value.timestamp === 'number' && Number.isFinite(value.timestamp);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { createAskableInspector } from './inspector.js';
+export { isAskableAgentRequest } from './agent-request.js';
 export { ASKABLE_REGION_CAPTURE_THEME, createAskableRegionCapture } from './capture.js';
 export { ASKABLE_TEXT_SELECTION_CAPTURE_THEME, createAskableTextSelectionCapture } from './selection.js';
 export { a11yTextExtractor } from './a11y.js';

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -522,6 +522,22 @@ await fetch('/api/chat', {
 });
 ```
 
+On the server, use `isAskableAgentRequest()` before trusting an incoming JSON
+body:
+
+```ts
+import { isAskableAgentRequest } from '@askable-ui/core';
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  if (!isAskableAgentRequest(body)) {
+    return Response.json({ error: 'Invalid Askable request' }, { status: 400 });
+  }
+
+  return askWithContext(body.question, body.context, body.packet);
+}
+```
+
 The returned object includes:
 
 | Field | Description |

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -381,6 +381,10 @@ interface AskableAgentRequest {
   metadata?: Record<string, unknown>;
   timestamp: number;
 }
+
+function isAskableAgentRequest(
+  value: unknown
+): value is AskableAgentRequest;
 ```
 
 ```ts

--- a/site/docs/examples/ai-sdk.md
+++ b/site/docs/examples/ai-sdk.md
@@ -237,15 +237,21 @@ function AskButton() {
 Server routes can read the same payload shape regardless of provider:
 
 ```ts
+import { isAskableAgentRequest } from '@askable-ui/core';
+
 export async function POST(req: Request) {
-  const { question, context, packet, focus, requestId } = await req.json();
-  const answer = await askWithContext(question, context);
+  const body = await req.json();
+  if (!isAskableAgentRequest(body)) {
+    return Response.json({ error: 'Invalid Askable request' }, { status: 400 });
+  }
+
+  const answer = await askWithContext(body.question, body.context);
 
   return Response.json({
     answer,
-    requestId,
-    receivedContextPacket: Boolean(packet),
-    focusMeta: focus?.meta ?? null,
+    requestId: body.requestId,
+    receivedContextPacket: Boolean(body.packet),
+    focusMeta: body.focus?.meta ?? null,
   });
 }
 ```


### PR DESCRIPTION
## Summary
- add `isAskableAgentRequest()` for validating server-side JSON bodies
- export the guard from core
- document API route validation in core docs and the AI SDK example

## Tests
- npm test -w @askable-ui/core -- agent-request.test.ts
- npm run build -w @askable-ui/core
- npm run build:versioned --prefix site/docs
- git diff --check