### PR TITLE
feat(mcp): add web streamable handler

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -51,8 +51,9 @@ const server = createAskableMcpServer({
 });
 ```
 
-Transports are intentionally left to the host app so the same server factory can
-be used with stdio, Streamable HTTP, or an embedded web runtime.
+Use `createAskableMcpServer()` when you want to attach your own MCP transport.
+For web runtimes, `createAskableMcpWebHandler()` creates a stateless Streamable
+HTTP `Request -> Response` handler.
 
 ## Web MCP for Claude and ChatGPT
 
@@ -62,7 +63,9 @@ Keep authentication, rate limits, tenancy checks, and consent handling in the
 host app.
 
 ```ts
-const server = createAskableMcpServer({
+import { createAskableMcpContextProvider, createAskableMcpWebHandler } from '@askable-ui/mcp';
+
+const handler = createAskableMcpWebHandler({
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
@@ -70,7 +73,9 @@ const server = createAskableMcpServer({
   }),
 });
 
-// Attach `server` to the Streamable HTTP or SSE transport supported by your MCP runtime.
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
 ```
 
 Claude clients can connect to the public MCP URL as a remote MCP server. The

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import { createWebContextPacket } from '@askable-ui/context';
 import {
   createAskableMcpContextProvider,
   createAskableMcpServer,
+  createAskableMcpWebHandler,
   defaultPromptFormatter,
   type AskableMcpContextProvider,
   type AskableMcpSourceContext,
@@ -218,6 +219,121 @@ describe('createAskableMcpServer', () => {
     expect(result.content[0].text).toContain('Context mode: element-focus');
     expect(result.content[0].text).toContain('User intent: test');
     expect(result.content[0].text).toContain('URL: https://example.com');
+  });
+});
+
+describe('createAskableMcpWebHandler', () => {
+  it('handles stateless Streamable HTTP tool calls', async () => {
+    const packet = createWebContextPacket({
+      source: { app: 'dashboard' },
+      capture: { mode: 'region' },
+      privacy: { consent: 'explicit' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const handler = createAskableMcpWebHandler({ provider });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'get_current_context',
+          arguments: { intent: 'inspect selected dashboard' },
+        },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      result: { content: Array<{ type: string; text: string }> };
+    };
+    expect(body.result.content[0].type).toBe('text');
+    expect(JSON.parse(body.result.content[0].text)).toMatchObject({
+      source: { app: 'dashboard' },
+      capture: { mode: 'region' },
+      privacy: { consent: 'explicit' },
+    });
+    expect(provider.getContext).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'inspect selected dashboard' }),
+    );
+  });
+
+  it('accepts per-request transport options', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(createWebContextPacket({
+        capture: { mode: 'semantic' },
+      })),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      requestOptions: () => ({
+        parsedBody: {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'get_current_context', arguments: {} },
+        },
+      }),
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+      },
+      body: 'not-json',
+    }));
+
+    expect(response.status).toBe(200);
+    expect(provider.getContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a JSON-RPC error response when setup fails', async () => {
+    const onError = vi.fn();
+    const handler = createAskableMcpWebHandler({
+      provider: {
+        getContext: vi.fn(),
+      },
+      requestOptions: () => {
+        throw new Error('request setup failed');
+      },
+      onError,
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0.0' },
+        },
+      }),
+    }));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { message: 'Askable MCP handler failed.' },
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,7 +1,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { z } from 'zod';
 import { webContextPacketSchema } from '@askable-ui/context';
 import type { WebContextPacket } from '@askable-ui/context';
+import type {
+  HandleRequestOptions,
+  WebStandardStreamableHTTPServerTransportOptions,
+} from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import type {
   AskableAsyncContextOutputOptions,
   AskableAsyncContextPacketOptions,
@@ -33,6 +38,21 @@ export interface AskableMcpServerOptions {
   version?: string;
   provider: AskableMcpContextProvider;
 }
+
+export type AskableMcpStatelessTransportOptions = Omit<
+  WebStandardStreamableHTTPServerTransportOptions,
+  'sessionIdGenerator' | 'onsessioninitialized' | 'onsessionclosed'
+>;
+
+export interface AskableMcpWebHandlerOptions extends AskableMcpServerOptions {
+  transport?: AskableMcpStatelessTransportOptions;
+  requestOptions?:
+    | HandleRequestOptions
+    | ((request: Request) => HandleRequestOptions | Promise<HandleRequestOptions>);
+  onError?: (error: unknown, request: Request) => void;
+}
+
+export type AskableMcpWebHandler = (request: Request) => Promise<Response>;
 
 export type AskableMcpSourceContext = Pick<AskableContext, 'toContextPacket' | 'toContext'> &
   Partial<Pick<AskableContext, 'toContextPacketAsync' | 'toContextAsync'>>;
@@ -195,6 +215,38 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
   );
 
   return server;
+}
+
+export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions): AskableMcpWebHandler {
+  return async (request) => {
+    try {
+      const server = createAskableMcpServer(options);
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        enableJsonResponse: true,
+        ...options.transport,
+        sessionIdGenerator: undefined,
+      });
+      await server.connect(transport);
+      const requestOptions = typeof options.requestOptions === 'function'
+        ? await options.requestOptions(request)
+        : options.requestOptions;
+
+      return transport.handleRequest(request, requestOptions);
+    } catch (error) {
+      options.onError?.(error, request);
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Askable MCP handler failed.',
+        },
+        id: null,
+      }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  };
 }
 
 export function defaultPromptFormatter(packet: WebContextPacket): string {

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -69,6 +69,35 @@ Creates an MCP server with tools/resources for reading structured Context packet
 | `name` | `string` | MCP server name |
 | `version` | `string` | MCP server version |
 
+## `createAskableMcpWebHandler(options)`
+
+Creates a stateless Streamable HTTP handler for Web Standards runtimes. Use this
+for `Request -> Response` route handlers in Next.js, Vercel, Cloudflare Workers,
+Bun, Deno, and Node 18+ runtimes.
+
+```ts
+import { createAskableMcpContextProvider, createAskableMcpWebHandler } from '@askable-ui/mcp';
+
+const handler = createAskableMcpWebHandler({
+  provider: createAskableMcpContextProvider(ctx, {
+    history: 3,
+    includeViewport: true,
+    sources: ['accounts'],
+  }),
+});
+
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+```
+
+| Option | Type | Description |
+|---|---|---|
+| `provider` | `AskableMcpContextProvider` | Supplies packets and optional prompt formatting |
+| `transport` | `AskableMcpStatelessTransportOptions` | Optional stateless MCP transport options |
+| `requestOptions` | `HandleRequestOptions \| (request) => HandleRequestOptions` | Optional per-request parsed body or auth info |
+| `onError` | `(error, request) => void` | Optional setup error reporter |
+
 ## Tool options
 
 `get_current_context` and `format_context_for_prompt` accept common context
@@ -111,7 +140,9 @@ HTTPS endpoint such as `https://your-app.com/mcp`. The app hosting that endpoint
 should own authentication, rate limits, tenancy checks, and consent boundaries.
 
 ```ts
-const server = createAskableMcpServer({
+import { createAskableMcpContextProvider, createAskableMcpWebHandler } from '@askable-ui/mcp';
+
+const handler = createAskableMcpWebHandler({
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
@@ -119,7 +150,9 @@ const server = createAskableMcpServer({
   }),
 });
 
-// Attach `server` to the Streamable HTTP or SSE transport supported by your MCP runtime.
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
 ```
 
 Claude clients can connect to the URL as a remote MCP server. The Anthropic

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -1238,13 +1238,15 @@ ctx.push(meta, text);</pre>
           <article class="mcp-card">
             <h4>Server</h4>
             <p>Adapt the same Askable context your app already uses. Keep auth, rate limits, and tenancy in your host app.</p>
-            <pre>const server = createAskableMcpServer({
+            <pre>const handler = createAskableMcpWebHandler({
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
     sources: ['accounts']
   })
-});</pre>
+});
+
+export const POST = handler;</pre>
           </article>
           <article class="mcp-card">
             <h4>Claude</h4>


### PR DESCRIPTION
## Summary
- add createAskableMcpWebHandler for stateless Streamable HTTP Request/Response routes
- add real MCP JSON-RPC coverage for the web handler
- update MCP README, API docs, and homepage Web MCP example for Claude and ChatGPT usage

## Verification
- npm test -w @askable-ui/mcp -- index.test.ts
- npm run build -w @askable-ui/mcp
- npm run build:versioned --prefix site/docs
- git diff --check
- local homepage Playwright desktop/mobile check against http://127.0.0.1:4188