### PR TITLE
feat(mcp): add web handler authorization

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -66,6 +66,17 @@ host app.
 import { createAskableMcpContextProvider, createAskableMcpWebHandler } from '@askable-ui/mcp';
 
 const handler = createAskableMcpWebHandler({
+  authorize: async (request) => {
+    const token = await verifyMcpToken(request);
+    if (!token) return false;
+    return {
+      authInfo: {
+        token: token.value,
+        clientId: token.clientId,
+        scopes: token.scopes,
+      },
+    };
+  },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
@@ -77,6 +88,10 @@ export const GET = handler;
 export const POST = handler;
 export const DELETE = handler;
 ```
+
+`authorize` runs before context is read. Return `false` for the built-in `401`
+JSON-RPC response, return a custom `Response` when the host app owns the error
+shape, or return MCP request options such as `authInfo`.
 
 Claude clients can connect to the public MCP URL as a remote MCP server. The
 Anthropic Messages API MCP connector uses an object like:

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -299,6 +299,101 @@ describe('createAskableMcpWebHandler', () => {
     expect(provider.getContext).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects unauthorized requests before context is read', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      authorize: () => false,
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'get_current_context', arguments: {} },
+      }),
+    }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: -32001, message: 'Unauthorized MCP request.' },
+    });
+    expect(provider.getContext).not.toHaveBeenCalled();
+  });
+
+  it('allows custom authorization responses', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      authorize: () => new Response('token expired', {
+        status: 403,
+        headers: { 'WWW-Authenticate': 'Bearer error="invalid_token"' },
+      }),
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    }));
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"');
+    await expect(response.text()).resolves.toBe('token expired');
+    expect(provider.getContext).not.toHaveBeenCalled();
+  });
+
+  it('uses authorized request options before reading the request body', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(createWebContextPacket({
+        capture: { mode: 'semantic' },
+      })),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      authorize: (request) => ({
+        parsedBody: {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'get_current_context',
+            arguments: { intent: request.headers.get('x-intent') ?? undefined },
+          },
+        },
+      }),
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+        'x-intent': 'inspect authorized context',
+      },
+      body: 'not-json',
+    }));
+
+    expect(response.status).toBe(200);
+    expect(provider.getContext).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'inspect authorized context' }),
+    );
+  });
+
   it('returns a JSON-RPC error response when setup fails', async () => {
     const onError = vi.fn();
     const handler = createAskableMcpWebHandler({

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -44,8 +44,15 @@ export type AskableMcpStatelessTransportOptions = Omit<
   'sessionIdGenerator' | 'onsessioninitialized' | 'onsessionclosed'
 >;
 
+export type AskableMcpAuthorizeResult =
+  | boolean
+  | Response
+  | HandleRequestOptions
+  | void;
+
 export interface AskableMcpWebHandlerOptions extends AskableMcpServerOptions {
   transport?: AskableMcpStatelessTransportOptions;
+  authorize?: (request: Request) => AskableMcpAuthorizeResult | Promise<AskableMcpAuthorizeResult>;
   requestOptions?:
     | HandleRequestOptions
     | ((request: Request) => HandleRequestOptions | Promise<HandleRequestOptions>);
@@ -220,6 +227,14 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
 export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions): AskableMcpWebHandler {
   return async (request) => {
     try {
+      const authorization = options.authorize ? await options.authorize(request) : undefined;
+      if (authorization instanceof Response) {
+        return authorization;
+      }
+      if (authorization === false) {
+        return createAskableMcpErrorResponse(401, -32001, 'Unauthorized MCP request.');
+      }
+
       const server = createAskableMcpServer(options);
       const transport = new WebStandardStreamableHTTPServerTransport({
         enableJsonResponse: true,
@@ -227,24 +242,18 @@ export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions)
         sessionIdGenerator: undefined,
       });
       await server.connect(transport);
-      const requestOptions = typeof options.requestOptions === 'function'
+      const configuredRequestOptions = typeof options.requestOptions === 'function'
         ? await options.requestOptions(request)
         : options.requestOptions;
+      const requestOptions = mergeHandleRequestOptions(
+        authorization && typeof authorization === 'object' ? authorization : undefined,
+        configuredRequestOptions,
+      );
 
       return transport.handleRequest(request, requestOptions);
     } catch (error) {
       options.onError?.(error, request);
-      return new Response(JSON.stringify({
-        jsonrpc: '2.0',
-        error: {
-          code: -32000,
-          message: 'Askable MCP handler failed.',
-        },
-        id: null,
-      }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return createAskableMcpErrorResponse(500, -32000, 'Askable MCP handler failed.');
     }
   };
 }
@@ -331,4 +340,34 @@ function toPacketOptions(options: AskableMcpContextOptions): AskableMcpContextOp
   } = options;
 
   return packetOptions;
+}
+
+function mergeHandleRequestOptions(
+  first?: HandleRequestOptions,
+  second?: HandleRequestOptions,
+): HandleRequestOptions | undefined {
+  if (!first) return second;
+  if (!second) return first;
+
+  return {
+    ...first,
+    ...second,
+    ...(first.authInfo || second.authInfo
+      ? { authInfo: second.authInfo ?? first.authInfo }
+      : {}),
+  };
+}
+
+function createAskableMcpErrorResponse(status: number, code: number, message: string): Response {
+  return new Response(JSON.stringify({
+    jsonrpc: '2.0',
+    error: {
+      code,
+      message,
+    },
+    id: null,
+  }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -79,6 +79,17 @@ Bun, Deno, and Node 18+ runtimes.
 import { createAskableMcpContextProvider, createAskableMcpWebHandler } from '@askable-ui/mcp';
 
 const handler = createAskableMcpWebHandler({
+  authorize: async (request) => {
+    const token = await verifyMcpToken(request);
+    if (!token) return false;
+    return {
+      authInfo: {
+        token: token.value,
+        clientId: token.clientId,
+        scopes: token.scopes,
+      },
+    };
+  },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
@@ -94,9 +105,14 @@ export const DELETE = handler;
 | Option | Type | Description |
 |---|---|---|
 | `provider` | `AskableMcpContextProvider` | Supplies packets and optional prompt formatting |
+| `authorize` | `(request) => AskableMcpAuthorizeResult \| Promise<AskableMcpAuthorizeResult>` | Optional request gate before context is read |
 | `transport` | `AskableMcpStatelessTransportOptions` | Optional stateless MCP transport options |
 | `requestOptions` | `HandleRequestOptions \| (request) => HandleRequestOptions` | Optional per-request parsed body or auth info |
 | `onError` | `(error, request) => void` | Optional setup error reporter |
+
+When `authorize` returns `false`, the handler returns a JSON-RPC `401`. Return
+a custom `Response` for app-owned auth errors, or return request options such as
+`authInfo` to pass validated auth metadata to MCP handlers.
 
 ## Tool options
 
@@ -130,8 +146,9 @@ options:
 | `get_context_schema` | Tool | Returns the packet JSON Schema |
 | `format_context_for_prompt` | Tool | Returns prompt-ready text |
 
-The package does not start a transport. Connect the returned server with the MCP
-transport that fits your runtime.
+`createAskableMcpServer()` does not start a transport. Connect the returned
+server with the MCP transport that fits your runtime, or use
+`createAskableMcpWebHandler()` for Web Standards route handlers.
 
 ## Web MCP for Claude and ChatGPT
 
@@ -143,6 +160,17 @@ should own authentication, rate limits, tenancy checks, and consent boundaries.
 import { createAskableMcpContextProvider, createAskableMcpWebHandler } from '@askable-ui/mcp';
 
 const handler = createAskableMcpWebHandler({
+  authorize: async (request) => {
+    const token = await verifyMcpToken(request);
+    if (!token) return false;
+    return {
+      authInfo: {
+        token: token.value,
+        clientId: token.clientId,
+        scopes: token.scopes,
+      },
+    };
+  },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -1239,6 +1239,8 @@ ctx.push(meta, text);</pre>
             <h4>Server</h4>
             <p>Adapt the same Askable context your app already uses. Keep auth, rate limits, and tenancy in your host app.</p>
             <pre>const handler = createAskableMcpWebHandler({
+  authorize: (request) =>
+    Boolean(request.headers.get('Authorization')),
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,


### PR DESCRIPTION
## Summary
- add an authorize hook to createAskableMcpWebHandler so hosts can reject unknown MCP clients before context is read
- support built-in JSON-RPC 401 responses, custom auth responses, and authorized request options such as authInfo
- document secure Web MCP setup in the MCP README, API docs, and homepage example

## Verification
- npm test -w @askable-ui/mcp -- index.test.ts
- npm run build -w @askable-ui/mcp
- npm run build:versioned --prefix site/docs
- git diff --check
- local homepage Playwright desktop/mobile check against http://127.0.0.1:4188