### PR TITLE
feat(mcp): add web cors controls

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -77,6 +77,10 @@ const handler = createAskableMcpWebHandler({
       },
     };
   },
+  cors: {
+    origin: ['https://app.example'],
+    headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
+  },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
@@ -92,6 +96,10 @@ export const DELETE = handler;
 `authorize` runs before context is read. Return `false` for the built-in `401`
 JSON-RPC response, return a custom `Response` when the host app owns the error
 shape, or return MCP request options such as `authInfo`.
+
+`cors` handles browser preflight requests before context is read. Web responses
+also receive `Cache-Control: no-store` and `X-Content-Type-Options: nosniff`
+unless the response already set those headers.
 
 Claude clients can connect to the public MCP URL as a remote MCP server. The
 Anthropic Messages API MCP connector uses an object like:

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -394,6 +394,141 @@ describe('createAskableMcpWebHandler', () => {
     );
   });
 
+  it('handles CORS preflight requests without reading context', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      cors: {
+        origin: 'https://app.example',
+        headers: ['Authorization', 'Content-Type'],
+        credentials: true,
+        maxAge: 600,
+      },
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://app.example',
+        'Access-Control-Request-Headers': 'Authorization, Content-Type',
+      },
+    }));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, DELETE, OPTIONS');
+    expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, Content-Type');
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(response.headers.get('Access-Control-Max-Age')).toBe('600');
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(provider.getContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects disallowed CORS origins before authorization runs', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const authorize = vi.fn();
+    const handler = createAskableMcpWebHandler({
+      provider,
+      authorize,
+      cors: { origin: ['https://app.example'] },
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        Origin: 'https://evil.example',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'get_current_context', arguments: {} },
+      }),
+    }));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: -32003, message: 'CORS origin not allowed.' },
+    });
+    expect(authorize).not.toHaveBeenCalled();
+    expect(provider.getContext).not.toHaveBeenCalled();
+  });
+
+  it('adds CORS and response headers to MCP responses', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(createWebContextPacket({
+        capture: { mode: 'semantic' },
+      })),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      cors: {
+        origin: true,
+        exposedHeaders: ['Mcp-Session-Id'],
+      },
+      responseHeaders: {
+        'X-Askable-Deployment': 'production',
+      },
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+        Origin: 'https://app.example',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'get_current_context', arguments: {} },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example');
+    expect(response.headers.get('Access-Control-Expose-Headers')).toBe('Mcp-Session-Id');
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('X-Askable-Deployment')).toBe('production');
+    expect(provider.getContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets responseHeaders derive headers from the request and response', async () => {
+    const handler = createAskableMcpWebHandler({
+      provider: {
+        getContext: vi.fn(),
+      },
+      authorize: () => false,
+      responseHeaders: (request, response) => ({
+        'X-Mcp-Path': new URL(request.url).pathname,
+        'X-Mcp-Status': String(response.status),
+      }),
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    }));
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('X-Mcp-Path')).toBe('/mcp');
+    expect(response.headers.get('X-Mcp-Status')).toBe('401');
+  });
+
   it('returns a JSON-RPC error response when setup fails', async () => {
     const onError = vi.fn();
     const handler = createAskableMcpWebHandler({

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -50,9 +50,32 @@ export type AskableMcpAuthorizeResult =
   | HandleRequestOptions
   | void;
 
+export type AskableMcpCorsOriginResult = boolean | string | null | undefined;
+
+export type AskableMcpCorsOrigin =
+  | boolean
+  | string
+  | string[]
+  | ((origin: string | null, request: Request) => AskableMcpCorsOriginResult | Promise<AskableMcpCorsOriginResult>);
+
+export interface AskableMcpCorsOptions {
+  origin?: AskableMcpCorsOrigin;
+  methods?: string[];
+  headers?: string[];
+  exposedHeaders?: string[];
+  credentials?: boolean;
+  maxAge?: number;
+}
+
+export type AskableMcpWebResponseHeaders =
+  | HeadersInit
+  | ((request: Request, response: Response) => HeadersInit | void | Promise<HeadersInit | void>);
+
 export interface AskableMcpWebHandlerOptions extends AskableMcpServerOptions {
   transport?: AskableMcpStatelessTransportOptions;
   authorize?: (request: Request) => AskableMcpAuthorizeResult | Promise<AskableMcpAuthorizeResult>;
+  cors?: boolean | AskableMcpCorsOptions;
+  responseHeaders?: AskableMcpWebResponseHeaders;
   requestOptions?:
     | HandleRequestOptions
     | ((request: Request) => HandleRequestOptions | Promise<HandleRequestOptions>);
@@ -65,6 +88,11 @@ export type AskableMcpSourceContext = Pick<AskableContext, 'toContextPacket' | '
   Partial<Pick<AskableContext, 'toContextPacketAsync' | 'toContextAsync'>>;
 
 export interface CreateAskableMcpContextProviderOptions extends AskableMcpContextOptions {}
+
+const defaultWebResponseHeaders = {
+  'Cache-Control': 'no-store',
+  'X-Content-Type-Options': 'nosniff',
+};
 
 const contextOptionsShape = {
   scope: z.string().optional(),
@@ -226,13 +254,40 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
 
 export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions): AskableMcpWebHandler {
   return async (request) => {
+    let corsHeaders: Headers | undefined;
     try {
+      const cors = await resolveCorsHeaders(options.cors, request);
+      if (cors === false) {
+        return finalizeAskableMcpWebResponse(
+          request,
+          request.method === 'OPTIONS'
+            ? new Response(null, { status: 403 })
+            : createAskableMcpErrorResponse(403, -32003, 'CORS origin not allowed.'),
+          options,
+        );
+      }
+      corsHeaders = cors;
+
+      if (request.method === 'OPTIONS' && options.cors) {
+        return finalizeAskableMcpWebResponse(
+          request,
+          new Response(null, { status: 204 }),
+          options,
+          corsHeaders,
+        );
+      }
+
       const authorization = options.authorize ? await options.authorize(request) : undefined;
       if (authorization instanceof Response) {
-        return authorization;
+        return finalizeAskableMcpWebResponse(request, authorization, options, corsHeaders);
       }
       if (authorization === false) {
-        return createAskableMcpErrorResponse(401, -32001, 'Unauthorized MCP request.');
+        return finalizeAskableMcpWebResponse(
+          request,
+          createAskableMcpErrorResponse(401, -32001, 'Unauthorized MCP request.'),
+          options,
+          corsHeaders,
+        );
       }
 
       const server = createAskableMcpServer(options);
@@ -250,10 +305,20 @@ export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions)
         configuredRequestOptions,
       );
 
-      return transport.handleRequest(request, requestOptions);
+      return finalizeAskableMcpWebResponse(
+        request,
+        await transport.handleRequest(request, requestOptions),
+        options,
+        corsHeaders,
+      );
     } catch (error) {
       options.onError?.(error, request);
-      return createAskableMcpErrorResponse(500, -32000, 'Askable MCP handler failed.');
+      return finalizeAskableMcpWebResponse(
+        request,
+        createAskableMcpErrorResponse(500, -32000, 'Askable MCP handler failed.'),
+        options,
+        corsHeaders,
+      );
     }
   };
 }
@@ -370,4 +435,112 @@ function createAskableMcpErrorResponse(status: number, code: number, message: st
     status,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+async function resolveCorsHeaders(
+  cors: AskableMcpWebHandlerOptions['cors'],
+  request: Request,
+): Promise<Headers | undefined | false> {
+  if (!cors) return undefined;
+
+  const config = cors === true ? {} : cors;
+  const origin = request.headers.get('Origin');
+  const allowedOrigin = await resolveAllowedOrigin(config.origin ?? true, origin, request);
+  if (!allowedOrigin) return origin ? false : undefined;
+
+  const headers = new Headers();
+  headers.set('Access-Control-Allow-Origin', allowedOrigin);
+  if (allowedOrigin !== '*') headers.set('Vary', 'Origin');
+  if (config.credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+
+  if (request.method === 'OPTIONS') {
+    headers.set('Access-Control-Allow-Methods', (config.methods ?? [
+      'GET',
+      'POST',
+      'DELETE',
+      'OPTIONS',
+    ]).join(', '));
+    headers.set(
+      'Access-Control-Allow-Headers',
+      (config.headers ?? request.headers.get('Access-Control-Request-Headers')?.split(',').map((header) => header.trim()).filter(Boolean) ?? [
+        'Authorization',
+        'Content-Type',
+        'MCP-Protocol-Version',
+      ]).join(', '),
+    );
+    if (typeof config.maxAge === 'number') {
+      headers.set('Access-Control-Max-Age', String(config.maxAge));
+    }
+  }
+
+  if (config.exposedHeaders?.length) {
+    headers.set('Access-Control-Expose-Headers', config.exposedHeaders.join(', '));
+  }
+
+  return headers;
+}
+
+async function resolveAllowedOrigin(
+  allowed: AskableMcpCorsOrigin,
+  origin: string | null,
+  request: Request,
+): Promise<string | undefined> {
+  if (typeof allowed === 'function') {
+    const result = await allowed(origin, request);
+    if (typeof result === 'string') return result;
+    if (result === true) return origin ?? '*';
+    return undefined;
+  }
+
+  if (allowed === true) return origin ?? '*';
+  if (allowed === false) return undefined;
+  if (typeof allowed === 'string') return origin === allowed ? allowed : undefined;
+  return origin && allowed.includes(origin) ? origin : undefined;
+}
+
+async function finalizeAskableMcpWebResponse(
+  request: Request,
+  response: Response,
+  options: AskableMcpWebHandlerOptions,
+  corsHeaders?: Headers,
+): Promise<Response> {
+  const headers = new Headers(response.headers);
+  setMissingHeaders(headers, defaultWebResponseHeaders);
+  if (corsHeaders) mergeHeaders(headers, corsHeaders);
+
+  const configuredHeaders = typeof options.responseHeaders === 'function'
+    ? await options.responseHeaders(request, response)
+    : options.responseHeaders;
+  if (configuredHeaders) mergeHeaders(headers, new Headers(configuredHeaders));
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function setMissingHeaders(headers: Headers, next: HeadersInit): void {
+  for (const [key, value] of new Headers(next)) {
+    if (!headers.has(key)) headers.set(key, value);
+  }
+}
+
+function mergeHeaders(headers: Headers, next: Headers): void {
+  for (const [key, value] of next) {
+    if (key.toLowerCase() === 'vary' && headers.has('Vary')) {
+      headers.set('Vary', mergeHeaderValues(headers.get('Vary'), value));
+    } else {
+      headers.set(key, value);
+    }
+  }
+}
+
+function mergeHeaderValues(first: string | null, second: string): string {
+  const values = new Set([
+    ...(first?.split(',') ?? []),
+    ...second.split(','),
+  ].map((value) => value.trim()).filter(Boolean));
+
+  return Array.from(values).join(', ');
 }

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -90,6 +90,10 @@ const handler = createAskableMcpWebHandler({
       },
     };
   },
+  cors: {
+    origin: ['https://app.example'],
+    headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
+  },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
@@ -106,6 +110,8 @@ export const DELETE = handler;
 |---|---|---|
 | `provider` | `AskableMcpContextProvider` | Supplies packets and optional prompt formatting |
 | `authorize` | `(request) => AskableMcpAuthorizeResult \| Promise<AskableMcpAuthorizeResult>` | Optional request gate before context is read |
+| `cors` | `boolean \| AskableMcpCorsOptions` | Optional CORS and browser preflight handling |
+| `responseHeaders` | `HeadersInit \| (request, response) => HeadersInit` | Optional response headers for the web endpoint |
 | `transport` | `AskableMcpStatelessTransportOptions` | Optional stateless MCP transport options |
 | `requestOptions` | `HandleRequestOptions \| (request) => HandleRequestOptions` | Optional per-request parsed body or auth info |
 | `onError` | `(error, request) => void` | Optional setup error reporter |
@@ -113,6 +119,10 @@ export const DELETE = handler;
 When `authorize` returns `false`, the handler returns a JSON-RPC `401`. Return
 a custom `Response` for app-owned auth errors, or return request options such as
 `authInfo` to pass validated auth metadata to MCP handlers.
+
+When `cors` is configured, preflight requests are answered before auth or context
+reads. Web responses also receive `Cache-Control: no-store` and
+`X-Content-Type-Options: nosniff` unless the response already set those headers.
 
 ## Tool options
 
@@ -170,6 +180,10 @@ const handler = createAskableMcpWebHandler({
         scopes: token.scopes,
       },
     };
+  },
+  cors: {
+    origin: ['https://app.example'],
+    headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
   },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -1241,6 +1241,7 @@ ctx.push(meta, text);</pre>
             <pre>const handler = createAskableMcpWebHandler({
   authorize: (request) =>
     Boolean(request.headers.get('Authorization')),
+  cors: { origin: ['https://app.example'] },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,


### PR DESCRIPTION
## Summary
- add CORS and preflight handling to createAskableMcpWebHandler
- add default no-store and nosniff headers plus configurable responseHeaders
- cover allowed preflight, rejected origins, normal MCP responses, and derived headers in tests
- update MCP README, API docs, and homepage Web MCP example

## Verification
- npm test -w @askable-ui/mcp -- index.test.ts
- npm run build -w @askable-ui/mcp
- npm run build:versioned --prefix site/docs
- git diff --check
- local homepage Playwright desktop/mobile check against http://127.0.0.1:4188