### PR TITLE
feat(mcp): add web telemetry hook

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -81,6 +81,12 @@ const handler = createAskableMcpWebHandler({
     origin: ['https://app.example'],
     headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
   },
+  telemetry: (event) => {
+    metrics.timing('askable.mcp.duration', event.durationMs, {
+      outcome: event.outcome,
+      status: event.status,
+    });
+  },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
@@ -100,6 +106,10 @@ shape, or return MCP request options such as `authInfo`.
 `cors` handles browser preflight requests before context is read. Web responses
 also receive `Cache-Control: no-store` and `X-Content-Type-Options: nosniff`
 unless the response already set those headers.
+
+`telemetry` receives sanitized request metadata such as method, path, status,
+outcome, duration, origin, user agent, and request ID. It does not include MCP
+request bodies, Context packets, or prompt text.
 
 Claude clients can connect to the public MCP URL as a remote MCP server. The
 Anthropic Messages API MCP connector uses an object like:

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -529,6 +529,164 @@ describe('createAskableMcpWebHandler', () => {
     expect(response.headers.get('X-Mcp-Status')).toBe('401');
   });
 
+  it('emits sanitized telemetry for successful MCP responses', async () => {
+    const telemetry = vi.fn();
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(createWebContextPacket({
+        capture: { mode: 'semantic' },
+      })),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      telemetry,
+    });
+
+    const response = await handler(new Request('https://example.com/mcp?token=secret', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+        Origin: 'https://app.example',
+        'User-Agent': 'test-agent',
+        'X-Request-Id': 'req-1',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'get_current_context', arguments: {} },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'POST',
+      url: 'https://example.com/mcp',
+      path: '/mcp',
+      status: 200,
+      outcome: 'success',
+      origin: 'https://app.example',
+      userAgent: 'test-agent',
+      requestId: 'req-1',
+    }));
+    expect(telemetry.mock.calls[0][0].durationMs).toEqual(expect.any(Number));
+    expect(telemetry.mock.calls[0][0].url).not.toContain('secret');
+    expect(telemetry.mock.calls[0][0]).not.toHaveProperty('body');
+    expect(telemetry.mock.calls[0][0]).not.toHaveProperty('packet');
+  });
+
+  it('emits telemetry for preflight and rejected requests', async () => {
+    const telemetry = vi.fn();
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      authorize: () => false,
+      cors: { origin: ['https://app.example'] },
+      telemetry,
+    });
+
+    await handler(new Request('https://example.com/mcp', {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://app.example' },
+    }));
+    await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        Origin: 'https://evil.example',
+      },
+      body: '{}',
+    }));
+    await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        Origin: 'https://app.example',
+      },
+      body: '{}',
+    }));
+
+    expect(telemetry).toHaveBeenCalledTimes(3);
+    expect(telemetry.mock.calls[0][0]).toMatchObject({
+      method: 'OPTIONS',
+      status: 204,
+      outcome: 'preflight',
+    });
+    expect(telemetry.mock.calls[1][0]).toMatchObject({
+      method: 'POST',
+      status: 403,
+      outcome: 'cors_rejected',
+      origin: 'https://evil.example',
+    });
+    expect(telemetry.mock.calls[2][0]).toMatchObject({
+      method: 'POST',
+      status: 401,
+      outcome: 'unauthorized',
+      origin: 'https://app.example',
+    });
+    expect(provider.getContext).not.toHaveBeenCalled();
+  });
+
+  it('emits telemetry for setup errors', async () => {
+    const telemetry = vi.fn();
+    const handler = createAskableMcpWebHandler({
+      provider: {
+        getContext: vi.fn(),
+      },
+      requestOptions: () => {
+        throw new Error('request setup failed');
+      },
+      telemetry,
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    }));
+
+    expect(response.status).toBe(500);
+    expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({
+      status: 500,
+      outcome: 'error',
+      path: '/mcp',
+    }));
+  });
+
+  it('does not fail the response when telemetry throws', async () => {
+    const onError = vi.fn();
+    const handler = createAskableMcpWebHandler({
+      provider: {
+        getContext: vi.fn(),
+      },
+      authorize: () => false,
+      telemetry: () => {
+        throw new Error('telemetry unavailable');
+      },
+      onError,
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    }));
+
+    expect(response.status).toBe(401);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
   it('returns a JSON-RPC error response when setup fails', async () => {
     const onError = vi.fn();
     const handler = createAskableMcpWebHandler({

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -71,11 +71,34 @@ export type AskableMcpWebResponseHeaders =
   | HeadersInit
   | ((request: Request, response: Response) => HeadersInit | void | Promise<HeadersInit | void>);
 
+export type AskableMcpWebOutcome =
+  | 'success'
+  | 'preflight'
+  | 'cors_rejected'
+  | 'unauthorized'
+  | 'error';
+
+export interface AskableMcpWebTelemetryEvent {
+  method: string;
+  url: string;
+  path: string;
+  status: number;
+  outcome: AskableMcpWebOutcome;
+  durationMs: number;
+  origin?: string;
+  userAgent?: string;
+  requestId?: string;
+}
+
+export type AskableMcpWebTelemetry =
+  (event: AskableMcpWebTelemetryEvent) => void | Promise<void>;
+
 export interface AskableMcpWebHandlerOptions extends AskableMcpServerOptions {
   transport?: AskableMcpStatelessTransportOptions;
   authorize?: (request: Request) => AskableMcpAuthorizeResult | Promise<AskableMcpAuthorizeResult>;
   cors?: boolean | AskableMcpCorsOptions;
   responseHeaders?: AskableMcpWebResponseHeaders;
+  telemetry?: AskableMcpWebTelemetry;
   requestOptions?:
     | HandleRequestOptions
     | ((request: Request) => HandleRequestOptions | Promise<HandleRequestOptions>);
@@ -254,39 +277,45 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
 
 export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions): AskableMcpWebHandler {
   return async (request) => {
+    const startedAt = Date.now();
     let corsHeaders: Headers | undefined;
+    const finalize = (
+      response: Response,
+      outcome: AskableMcpWebOutcome,
+      nextCorsHeaders = corsHeaders,
+    ) => finalizeAskableMcpWebResponse(request, response, options, {
+      corsHeaders: nextCorsHeaders,
+      outcome,
+      startedAt,
+    });
+
     try {
       const cors = await resolveCorsHeaders(options.cors, request);
       if (cors === false) {
-        return finalizeAskableMcpWebResponse(
-          request,
+        return finalize(
           request.method === 'OPTIONS'
             ? new Response(null, { status: 403 })
             : createAskableMcpErrorResponse(403, -32003, 'CORS origin not allowed.'),
-          options,
+          'cors_rejected',
         );
       }
       corsHeaders = cors;
 
       if (request.method === 'OPTIONS' && options.cors) {
-        return finalizeAskableMcpWebResponse(
-          request,
+        return finalize(
           new Response(null, { status: 204 }),
-          options,
-          corsHeaders,
+          'preflight',
         );
       }
 
       const authorization = options.authorize ? await options.authorize(request) : undefined;
       if (authorization instanceof Response) {
-        return finalizeAskableMcpWebResponse(request, authorization, options, corsHeaders);
+        return finalize(authorization, authorization.status >= 400 ? 'unauthorized' : 'success');
       }
       if (authorization === false) {
-        return finalizeAskableMcpWebResponse(
-          request,
+        return finalize(
           createAskableMcpErrorResponse(401, -32001, 'Unauthorized MCP request.'),
-          options,
-          corsHeaders,
+          'unauthorized',
         );
       }
 
@@ -305,19 +334,15 @@ export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions)
         configuredRequestOptions,
       );
 
-      return finalizeAskableMcpWebResponse(
-        request,
+      return finalize(
         await transport.handleRequest(request, requestOptions),
-        options,
-        corsHeaders,
+        'success',
       );
     } catch (error) {
       options.onError?.(error, request);
-      return finalizeAskableMcpWebResponse(
-        request,
+      return finalize(
         createAskableMcpErrorResponse(500, -32000, 'Askable MCP handler failed.'),
-        options,
-        corsHeaders,
+        'error',
       );
     }
   };
@@ -502,22 +527,57 @@ async function finalizeAskableMcpWebResponse(
   request: Request,
   response: Response,
   options: AskableMcpWebHandlerOptions,
-  corsHeaders?: Headers,
+  metadata: {
+    corsHeaders?: Headers;
+    outcome: AskableMcpWebOutcome;
+    startedAt: number;
+  },
 ): Promise<Response> {
   const headers = new Headers(response.headers);
   setMissingHeaders(headers, defaultWebResponseHeaders);
-  if (corsHeaders) mergeHeaders(headers, corsHeaders);
+  if (metadata.corsHeaders) mergeHeaders(headers, metadata.corsHeaders);
 
   const configuredHeaders = typeof options.responseHeaders === 'function'
     ? await options.responseHeaders(request, response)
     : options.responseHeaders;
   if (configuredHeaders) mergeHeaders(headers, new Headers(configuredHeaders));
 
-  return new Response(response.body, {
+  const finalized = new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers,
   });
+  await emitAskableMcpTelemetry(request, finalized, options, metadata);
+  return finalized;
+}
+
+async function emitAskableMcpTelemetry(
+  request: Request,
+  response: Response,
+  options: AskableMcpWebHandlerOptions,
+  metadata: {
+    outcome: AskableMcpWebOutcome;
+    startedAt: number;
+  },
+): Promise<void> {
+  if (!options.telemetry) return;
+
+  const url = new URL(request.url);
+  try {
+    await options.telemetry({
+      method: request.method,
+      url: `${url.origin}${url.pathname}`,
+      path: url.pathname,
+      status: response.status,
+      outcome: metadata.outcome,
+      durationMs: Math.max(0, Date.now() - metadata.startedAt),
+      ...(request.headers.get('Origin') ? { origin: request.headers.get('Origin') ?? undefined } : {}),
+      ...(request.headers.get('User-Agent') ? { userAgent: request.headers.get('User-Agent') ?? undefined } : {}),
+      ...(request.headers.get('X-Request-Id') ? { requestId: request.headers.get('X-Request-Id') ?? undefined } : {}),
+    });
+  } catch (error) {
+    options.onError?.(error, request);
+  }
 }
 
 function setMissingHeaders(headers: Headers, next: HeadersInit): void {

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -94,6 +94,12 @@ const handler = createAskableMcpWebHandler({
     origin: ['https://app.example'],
     headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
   },
+  telemetry: (event) => {
+    metrics.timing('askable.mcp.duration', event.durationMs, {
+      outcome: event.outcome,
+      status: event.status,
+    });
+  },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,
@@ -112,6 +118,7 @@ export const DELETE = handler;
 | `authorize` | `(request) => AskableMcpAuthorizeResult \| Promise<AskableMcpAuthorizeResult>` | Optional request gate before context is read |
 | `cors` | `boolean \| AskableMcpCorsOptions` | Optional CORS and browser preflight handling |
 | `responseHeaders` | `HeadersInit \| (request, response) => HeadersInit` | Optional response headers for the web endpoint |
+| `telemetry` | `(event) => void \| Promise<void>` | Optional sanitized request outcome reporting |
 | `transport` | `AskableMcpStatelessTransportOptions` | Optional stateless MCP transport options |
 | `requestOptions` | `HandleRequestOptions \| (request) => HandleRequestOptions` | Optional per-request parsed body or auth info |
 | `onError` | `(error, request) => void` | Optional setup error reporter |
@@ -123,6 +130,10 @@ a custom `Response` for app-owned auth errors, or return request options such as
 When `cors` is configured, preflight requests are answered before auth or context
 reads. Web responses also receive `Cache-Control: no-store` and
 `X-Content-Type-Options: nosniff` unless the response already set those headers.
+
+`telemetry` receives sanitized request metadata such as method, path, status,
+outcome, duration, origin, user agent, and request ID. It does not include MCP
+request bodies, Context packets, or prompt text.
 
 ## Tool options
 
@@ -184,6 +195,12 @@ const handler = createAskableMcpWebHandler({
   cors: {
     origin: ['https://app.example'],
     headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
+  },
+  telemetry: (event) => {
+    metrics.timing('askable.mcp.duration', event.durationMs, {
+      outcome: event.outcome,
+      status: event.status,
+    });
   },
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -1242,6 +1242,7 @@ ctx.push(meta, text);</pre>
   authorize: (request) =>
     Boolean(request.headers.get('Authorization')),
   cors: { origin: ['https://app.example'] },
+  telemetry: (event) => metrics.track(event),
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
     includeViewport: true,


### PR DESCRIPTION
## Summary
- add sanitized telemetry events to createAskableMcpWebHandler
- report method, path, status, outcome, duration, origin, user agent, and request id without request bodies or context packets
- strip query strings from telemetry URLs and keep telemetry failures non-fatal
- update MCP README, API docs, and homepage Web MCP example

## Verification
- npm test -w @askable-ui/mcp -- index.test.ts
- npm run build -w @askable-ui/mcp
- npm run build:versioned --prefix site/docs
- git diff --check
- local homepage Playwright desktop/mobile check against http://127.0.0.1:4188