### PR TITLE
docs(site): update current docs version

### DIFF
--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.12.0`
-- Versioned current docs URL: `/docs/v0.12.0/`
+- Latest stable: `v0.13.1`
+- Versioned current docs URL: `/docs/v0.13.1/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.12.0/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.13.1/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.12.0**.
+> Current npm release: **v0.13.1**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,10 +1,80 @@
-# What’s New in v0.12.0
+# What’s New in v0.13.1
+
+askable-ui v0.13.1 adds production-ready Web MCP support and stronger agent
+request wiring, so approved Claude and ChatGPT clients can request selected UI
+context through a hosted MCP endpoint.
+
+## Highlights
+
+### Web MCP endpoint support
+
+`@askable-ui/mcp` now ships `createAskableMcpWebHandler()`, a stateless
+Streamable HTTP `Request -> Response` handler for Next.js, Vercel, Cloudflare
+Workers, Bun, Deno, and Node 18+ runtimes.
+
+```ts
+import { createAskableMcpContextProvider, createAskableMcpWebHandler } from '@askable-ui/mcp';
+
+const handler = createAskableMcpWebHandler({
+  authorize: async (request) => {
+    const token = await verifyMcpToken(request);
+    if (!token) return false;
+    return {
+      authInfo: {
+        token: token.value,
+        clientId: token.clientId,
+        scopes: token.scopes,
+      },
+    };
+  },
+  cors: {
+    origin: ['https://app.example'],
+    headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
+  },
+  telemetry: (event) => metrics.timing('askable.mcp.duration', event.durationMs),
+  provider: createAskableMcpContextProvider(ctx, {
+    history: 3,
+    includeViewport: true,
+    sources: ['accounts'],
+  }),
+});
+
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+```
+
+The web handler supports authorization, browser preflight handling, custom
+response headers, default `no-store`/`nosniff` headers, and sanitized telemetry
+that omits request bodies, Context packets, prompt text, and query strings.
+
+Related docs:
+
+- [@askable-ui/mcp API](/api/mcp)
+- [AI SDK integration patterns](/examples/ai-sdk)
+
+### Agent request validation
+
+`@askable-ui/core` now exports `isAskableAgentRequest()` so server routes can
+validate agent request payloads before using prompt context, packets, selected
+source options, or user questions.
+
+```ts
+import { isAskableAgentRequest } from '@askable-ui/core';
+
+if (!isAskableAgentRequest(body)) {
+  return new Response('Invalid Askable request', { status: 400 });
+}
+```
+
+Agent requests can also preserve packet-backed selections and source requests,
+which keeps app-owned context available to downstream AI handlers.
+
+## Also in v0.12.0
 
 askable-ui v0.12.0 adds generic app-owned context sources and refines explicit
 selection capture, so users can freehand lasso irregular areas, keep selected
 text highlighted, and send richer page context to agents.
-
-## Highlights
 
 ### Freehand lasso selection
 
@@ -168,8 +238,8 @@ browser tools, and agent runtimes.
 
 ### Starter and docs version alignment
 
-`npm create @askable-ui/app` now scaffolds projects pinned to `^0.12.0`, and the
-versioned docs have been advanced to `/docs/v0.12.0/`.
+`npm create @askable-ui/app` now scaffolds projects pinned to `^0.13.1`, and the
+versioned docs have been advanced to `/docs/v0.13.1/`.
 
 ## Recommended next step
 
@@ -181,7 +251,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.12.0** at both:
+The current published docs track **v0.13.1** at both:
 
 - `/docs/`
-- `/docs/v0.12.0/`
+- `/docs/v0.13.1/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.12.0**.
+> Current npm release: **v0.13.1**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,7 +59,16 @@ features:
   </video>
 </div>
 
-## Latest in v0.12.0
+## Latest in v0.13.1
+
+- remote Web MCP support with `createAskableMcpWebHandler()` for stateless Streamable HTTP endpoints
+- Web MCP production controls for authorization, CORS/preflight, response headers, and sanitized telemetry
+- MCP docs and homepage examples for connecting approved Claude and ChatGPT clients
+- server-side agent request validation with `isAskableAgentRequest()`
+- packet-backed agent requests that preserve structured source selections for downstream AI handlers
+- typed packet source selections and default packet sources based on selected interaction mode
+
+## Also in v0.12.0
 
 - lasso capture via `shape: 'lasso'` for freehand-selected page regions
 - generic `registerSource()` resolvers plus source helper factories for app-owned context
@@ -68,7 +77,7 @@ features:
 - agent request packaging with `toAgentRequest()`
 - source-backed live subscriptions with `subscribeAsync()`
 - point-path metadata on lasso Context packets
-- starter app dependency pins advanced to `^0.12.0`
+- starter app dependency pins advanced to `^0.13.1`
 - continued support for region/circle/text capture, MCP Context packets, and framework wrappers
 
 ## Interaction patterns
@@ -89,7 +98,7 @@ Every pattern can produce a prompt string with `toPromptContext()` or a structur
 
 Start here:
 
-- [What’s New in v0.12.0](/guide/whats-new)
+- [What’s New in v0.13.1](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [React interaction patterns](/guide/react#region-circle-and-lasso-capture)
 - [AI SDK integration patterns](/examples/ai-sdk)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.12.0",
-    "slug": "v0.12.0"
+    "label": "v0.13.1",
+    "slug": "v0.13.1"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.12.0`) is built on every deploy and published to both:
+The current release (`v0.13.1`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.12.0/` (version-specific URL)
+- `/docs/v0.13.1/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- update docs current version metadata from v0.12.0 to v0.13.1
- update docs homepage, Getting Started, Versioning, and What’s New copy
- publish the current versioned docs URL as /docs/v0.13.1/

## Verification
- npm run build:versioned --prefix site/docs
- exact stale current-version search for v0.12.0 labels returned no matches
- local Playwright docs check for /docs/, /docs/api/versioning.html, and /docs/v0.13.1/
- git diff --check