### PR TITLE
feat(mcp): limit web request body size

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -81,6 +81,7 @@ const handler = createAskableMcpWebHandler({
     origin: ['https://app.example'],
     headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
   },
+  maxRequestBodyBytes: 256 * 1024,
   telemetry: (event) => {
     metrics.timing('askable.mcp.duration', event.durationMs, {
       outcome: event.outcome,
@@ -106,6 +107,11 @@ shape, or return MCP request options such as `authInfo`.
 `cors` handles browser preflight requests before context is read. Web responses
 also receive `Cache-Control: no-store` and `X-Content-Type-Options: nosniff`
 unless the response already set those headers.
+
+`maxRequestBodyBytes` rejects oversized MCP requests with a JSON-RPC `413`
+before authorization, server setup, or MCP body parsing runs. The default is
+1 MiB. Pass `false` to disable the built-in guard when another layer already
+enforces request limits.
 
 `telemetry` receives sanitized request metadata such as method, path, status,
 outcome, duration, origin, user agent, and request ID. It does not include MCP

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -461,6 +461,88 @@ describe('createAskableMcpWebHandler', () => {
     expect(provider.getContext).not.toHaveBeenCalled();
   });
 
+  it('rejects oversized MCP requests before authorization or context is read', async () => {
+    const telemetry = vi.fn();
+    const authorize = vi.fn();
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      authorize,
+      telemetry,
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'Content-Length': '1048577',
+      },
+      body: '{}',
+    }));
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: -32004, message: 'MCP request body is too large.' },
+    });
+    expect(authorize).not.toHaveBeenCalled();
+    expect(provider.getContext).not.toHaveBeenCalled();
+    expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'POST',
+      status: 413,
+      outcome: 'payload_too_large',
+    }));
+  });
+
+  it('supports custom and disabled MCP request body limits', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'semantic' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const smallLimit = createAskableMcpWebHandler({
+      provider,
+      maxRequestBodyBytes: 10,
+    });
+    const disabledLimit = createAskableMcpWebHandler({
+      provider,
+      maxRequestBodyBytes: false,
+    });
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'get_current_context', arguments: {} },
+    });
+
+    const rejected = await smallLimit(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'Content-Length': String(body.length),
+      },
+      body,
+    }));
+    const accepted = await disabledLimit(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+        'Content-Length': String(body.length),
+      },
+      body,
+    }));
+
+    expect(rejected.status).toBe(413);
+    expect(accepted.status).toBe(200);
+    expect(provider.getContext).toHaveBeenCalledTimes(1);
+  });
+
   it('adds CORS and response headers to MCP responses', async () => {
     const provider: AskableMcpContextProvider = {
       getContext: vi.fn().mockResolvedValue(createWebContextPacket({

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -76,6 +76,7 @@ export type AskableMcpWebOutcome =
   | 'preflight'
   | 'cors_rejected'
   | 'unauthorized'
+  | 'payload_too_large'
   | 'error';
 
 export interface AskableMcpWebTelemetryEvent {
@@ -97,6 +98,7 @@ export interface AskableMcpWebHandlerOptions extends AskableMcpServerOptions {
   transport?: AskableMcpStatelessTransportOptions;
   authorize?: (request: Request) => AskableMcpAuthorizeResult | Promise<AskableMcpAuthorizeResult>;
   cors?: boolean | AskableMcpCorsOptions;
+  maxRequestBodyBytes?: number | false;
   responseHeaders?: AskableMcpWebResponseHeaders;
   telemetry?: AskableMcpWebTelemetry;
   requestOptions?:
@@ -116,6 +118,8 @@ const defaultWebResponseHeaders = {
   'Cache-Control': 'no-store',
   'X-Content-Type-Options': 'nosniff',
 };
+
+const defaultMaxRequestBodyBytes = 1_048_576;
 
 const contextOptionsShape = {
   scope: z.string().optional(),
@@ -308,6 +312,13 @@ export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions)
         );
       }
 
+      if (isRequestBodyTooLarge(request, resolveMaxRequestBodyBytes(options.maxRequestBodyBytes))) {
+        return finalize(
+          createAskableMcpErrorResponse(413, -32004, 'MCP request body is too large.'),
+          'payload_too_large',
+        );
+      }
+
       const authorization = options.authorize ? await options.authorize(request) : undefined;
       if (authorization instanceof Response) {
         return finalize(authorization, authorization.status >= 400 ? 'unauthorized' : 'success');
@@ -460,6 +471,26 @@ function createAskableMcpErrorResponse(status: number, code: number, message: st
     status,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+function resolveMaxRequestBodyBytes(value: AskableMcpWebHandlerOptions['maxRequestBodyBytes']): number | false {
+  if (value === false) return false;
+  if (typeof value === 'number') return Math.max(0, Math.floor(value));
+  return defaultMaxRequestBodyBytes;
+}
+
+function isRequestBodyTooLarge(request: Request, maxRequestBodyBytes: number | false): boolean {
+  if (maxRequestBodyBytes === false || !requestMayHaveBody(request)) return false;
+
+  const contentLength = request.headers.get('Content-Length');
+  if (!contentLength) return false;
+
+  const bytes = Number(contentLength);
+  return Number.isFinite(bytes) && bytes > maxRequestBodyBytes;
+}
+
+function requestMayHaveBody(request: Request): boolean {
+  return !['GET', 'HEAD', 'OPTIONS'].includes(request.method.toUpperCase());
 }
 
 async function resolveCorsHeaders(

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -94,6 +94,7 @@ const handler = createAskableMcpWebHandler({
     origin: ['https://app.example'],
     headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
   },
+  maxRequestBodyBytes: 256 * 1024,
   telemetry: (event) => {
     metrics.timing('askable.mcp.duration', event.durationMs, {
       outcome: event.outcome,
@@ -117,6 +118,7 @@ export const DELETE = handler;
 | `provider` | `AskableMcpContextProvider` | Supplies packets and optional prompt formatting |
 | `authorize` | `(request) => AskableMcpAuthorizeResult \| Promise<AskableMcpAuthorizeResult>` | Optional request gate before context is read |
 | `cors` | `boolean \| AskableMcpCorsOptions` | Optional CORS and browser preflight handling |
+| `maxRequestBodyBytes` | `number \| false` | Maximum request body size before the MCP transport parses the body. Defaults to 1 MiB |
 | `responseHeaders` | `HeadersInit \| (request, response) => HeadersInit` | Optional response headers for the web endpoint |
 | `telemetry` | `(event) => void \| Promise<void>` | Optional sanitized request outcome reporting |
 | `transport` | `AskableMcpStatelessTransportOptions` | Optional stateless MCP transport options |
@@ -130,6 +132,11 @@ a custom `Response` for app-owned auth errors, or return request options such as
 When `cors` is configured, preflight requests are answered before auth or context
 reads. Web responses also receive `Cache-Control: no-store` and
 `X-Content-Type-Options: nosniff` unless the response already set those headers.
+
+`maxRequestBodyBytes` rejects oversized MCP requests with a JSON-RPC `413`
+before authorization, server setup, or MCP body parsing runs. The default is
+1 MiB. Pass `false` to disable the built-in guard when another layer already
+enforces request limits.
 
 `telemetry` receives sanitized request metadata such as method, path, status,
 outcome, duration, origin, user agent, and request ID. It does not include MCP
@@ -196,6 +203,7 @@ const handler = createAskableMcpWebHandler({
     origin: ['https://app.example'],
     headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
   },
+  maxRequestBodyBytes: 256 * 1024,
   telemetry: (event) => {
     metrics.timing('askable.mcp.duration', event.durationMs, {
       outcome: event.outcome,

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -31,6 +31,7 @@ const handler = createAskableMcpWebHandler({
     origin: ['https://app.example'],
     headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
   },
+  maxRequestBodyBytes: 256 * 1024,
   telemetry: (event) => metrics.timing('askable.mcp.duration', event.durationMs),
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,
@@ -45,8 +46,9 @@ export const DELETE = handler;
 ```
 
 The web handler supports authorization, browser preflight handling, custom
-response headers, default `no-store`/`nosniff` headers, and sanitized telemetry
-that omits request bodies, Context packets, prompt text, and query strings.
+request body limits, response headers, default `no-store`/`nosniff` headers,
+and sanitized telemetry that omits request bodies, Context packets, prompt text,
+and query strings.
 
 Related docs:
 

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -1242,6 +1242,7 @@ ctx.push(meta, text);</pre>
   authorize: (request) =>
     Boolean(request.headers.get('Authorization')),
   cors: { origin: ['https://app.example'] },
+  maxRequestBodyBytes: 256 * 1024,
   telemetry: (event) => metrics.track(event),
   provider: createAskableMcpContextProvider(ctx, {
     history: 3,


### PR DESCRIPTION
## Summary
- add maxRequestBodyBytes to the Web MCP handler with a default 1 MiB guard
- return a JSON-RPC 413 payload_too_large response before auth, server setup, or MCP parsing
- document the production control in MCP docs and the main website sample

## Verification
- npm test --workspace @askable-ui/mcp -- --run
- npm run build --workspace @askable-ui/mcp
- npm run build:versioned --prefix site/docs
- local Chromium check for the main website MCP panel at http://127.0.0.1:4191/