### PR TITLE
feat(mcp): add browser page bridge

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -138,3 +138,49 @@ calls can also pass the same endpoint as a remote MCP server:
   "server_url": "https://your-app.com/mcp"
 }
 ```
+
+## Browser-local MCP bridge
+
+Hosted Web MCP is the server-side path. For local browser workflows, a page
+cannot expose MCP directly to Claude or ChatGPT by itself. It needs a trusted
+browser extension or local companion process. `createAskableMcpPageBridge()`
+adds the page-side handoff: the page listens for approved bridge requests and
+returns the current packet or prompt-ready text through `window.postMessage()`.
+The extension or companion can then expose that data through its own local MCP
+server.
+
+```ts
+import { createAskableMcpContextProvider, createAskableMcpPageBridge } from '@askable-ui/mcp';
+
+const bridge = createAskableMcpPageBridge({
+  provider: createAskableMcpContextProvider(ctx, {
+    history: 3,
+    includeViewport: true,
+    sources: ['accounts'],
+  }),
+  allowedOrigins: [window.location.origin],
+  onError: (error) => console.error(error),
+});
+
+// Later, when the page no longer wants to expose context:
+bridge.dispose();
+```
+
+A trusted extension or local bridge can request context with the versioned
+message shape:
+
+```ts
+window.postMessage({
+  protocol: 'askable.mcp.page_bridge',
+  version: '0.1',
+  channel: 'askable:mcp',
+  type: 'get_current_context',
+  requestId: crypto.randomUUID(),
+  options: { sources: ['accounts'], history: 3 },
+}, window.location.origin);
+```
+
+Use `type: 'format_context_for_prompt'` when the bridge needs prompt-ready text
+instead of the structured packet. Keep user consent and installation trust in
+the extension or companion, and enable the page bridge only when the app wants
+to participate in local browser MCP workflows.

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createWebContextPacket } from '@askable-ui/context';
 import {
+  ASKABLE_MCP_PAGE_BRIDGE_CHANNEL,
+  ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+  ASKABLE_MCP_PAGE_BRIDGE_VERSION,
   createAskableMcpContextProvider,
+  createAskableMcpPageBridge,
   createAskableMcpServer,
   createAskableMcpWebHandler,
   defaultPromptFormatter,
   type AskableMcpContextProvider,
+  type AskableMcpPageBridgeResponse,
+  type AskableMcpPageBridgeWindow,
   type AskableMcpSourceContext,
 } from '../index.js';
 
@@ -20,6 +26,34 @@ function getToolHandler(provider: AskableMcpContextProvider, toolName: string): 
   const tool = tools[toolName];
   if (!tool) throw new Error(`Tool ${toolName} not registered`);
   return tool.handler;
+}
+
+class FakePageBridgeWindow implements AskableMcpPageBridgeWindow {
+  location = { origin: 'https://app.example' };
+  listeners = new Set<(event: MessageEvent) => void>();
+  posted: Array<{ message: AskableMcpPageBridgeResponse; targetOrigin: string }> = [];
+
+  addEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.add(listener);
+  }
+
+  removeEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.delete(listener);
+  }
+
+  postMessage(message: AskableMcpPageBridgeResponse, targetOrigin: string): void {
+    this.posted.push({ message, targetOrigin });
+  }
+
+  emit(data: unknown, origin = this.location.origin): void {
+    for (const listener of this.listeners) {
+      listener({ data, origin } as MessageEvent);
+    }
+  }
+}
+
+function flushPageBridge(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('createAskableMcpContextProvider', () => {
@@ -804,6 +838,164 @@ describe('createAskableMcpWebHandler', () => {
       error: { message: 'Askable MCP handler failed.' },
     });
     expect(onError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createAskableMcpPageBridge', () => {
+  it('responds to same-origin page bridge context requests', async () => {
+    const packet = createWebContextPacket({
+      source: { app: 'dashboard' },
+      capture: { mode: 'region' },
+      privacy: { consent: 'explicit' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    createAskableMcpPageBridge({ provider, window: fakeWindow });
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      channel: ASKABLE_MCP_PAGE_BRIDGE_CHANNEL,
+      type: 'get_current_context',
+      requestId: 'req-1',
+      options: { intent: 'inspect selected chart', history: 2 },
+    });
+    await flushPageBridge();
+
+    expect(provider.getContext).toHaveBeenCalledWith({
+      intent: 'inspect selected chart',
+      history: 2,
+    });
+    expect(fakeWindow.posted).toEqual([
+      {
+        targetOrigin: 'https://app.example',
+        message: expect.objectContaining({
+          protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+          version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+          channel: ASKABLE_MCP_PAGE_BRIDGE_CHANNEL,
+          type: 'get_current_context:result',
+          requestId: 'req-1',
+          packet,
+        }),
+      },
+    ]);
+  });
+
+  it('formats context for prompt requests', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'text-selection' },
+      target: { text: 'Quarterly revenue rose 12%' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+      formatContextForPrompt: vi.fn().mockResolvedValue('Prompt-ready selection'),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    createAskableMcpPageBridge({
+      provider,
+      window: fakeWindow,
+      targetOrigin: 'https://extension.example',
+    });
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      type: 'format_context_for_prompt',
+      requestId: 'req-2',
+      options: { maxTokens: 100 },
+    });
+    await flushPageBridge();
+
+    expect(provider.formatContextForPrompt).toHaveBeenCalledWith(packet, { maxTokens: 100 });
+    expect(fakeWindow.posted[0]).toEqual({
+      targetOrigin: 'https://extension.example',
+      message: expect.objectContaining({
+        type: 'format_context_for_prompt:result',
+        requestId: 'req-2',
+        text: 'Prompt-ready selection',
+      }),
+    });
+  });
+
+  it('ignores invalid channels and disallowed origins', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    createAskableMcpPageBridge({
+      provider,
+      window: fakeWindow,
+      channel: 'private-channel',
+      allowedOrigins: ['https://trusted.example'],
+    });
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      channel: 'wrong-channel',
+      type: 'get_current_context',
+      requestId: 'req-3',
+    }, 'https://trusted.example');
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      channel: 'private-channel',
+      type: 'get_current_context',
+      requestId: 'req-4',
+    }, 'https://evil.example');
+    await flushPageBridge();
+
+    expect(provider.getContext).not.toHaveBeenCalled();
+    expect(fakeWindow.posted).toHaveLength(0);
+  });
+
+  it('posts a bridge error response when provider resolution fails', async () => {
+    const onError = vi.fn();
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockRejectedValue(new Error('context unavailable')),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    createAskableMcpPageBridge({ provider, window: fakeWindow, onError });
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      type: 'get_current_context',
+      requestId: 'req-5',
+    });
+    await flushPageBridge();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(fakeWindow.posted[0]).toEqual({
+      targetOrigin: 'https://app.example',
+      message: expect.objectContaining({
+        type: 'get_current_context:error',
+        requestId: 'req-5',
+        error: { message: 'Askable MCP page bridge failed.' },
+      }),
+    });
+  });
+
+  it('removes the page bridge listener on dispose', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    const bridge = createAskableMcpPageBridge({ provider, window: fakeWindow });
+    bridge.dispose();
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      type: 'get_current_context',
+      requestId: 'req-6',
+    });
+    await flushPageBridge();
+
+    expect(provider.getContext).not.toHaveBeenCalled();
+    expect(fakeWindow.listeners.size).toBe(0);
   });
 });
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -109,6 +109,74 @@ export interface AskableMcpWebHandlerOptions extends AskableMcpServerOptions {
 
 export type AskableMcpWebHandler = (request: Request) => Promise<Response>;
 
+export const ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL = 'askable.mcp.page_bridge';
+export const ASKABLE_MCP_PAGE_BRIDGE_VERSION = '0.1';
+export const ASKABLE_MCP_PAGE_BRIDGE_CHANNEL = 'askable:mcp';
+
+export type AskableMcpPageBridgeRequestType =
+  | 'get_current_context'
+  | 'format_context_for_prompt';
+
+export interface AskableMcpPageBridgeRequest {
+  protocol: typeof ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL;
+  version: typeof ASKABLE_MCP_PAGE_BRIDGE_VERSION;
+  channel?: string;
+  type: AskableMcpPageBridgeRequestType;
+  requestId: string;
+  options?: AskableMcpContextOptions;
+}
+
+export interface AskableMcpPageBridgeSuccessResponse {
+  protocol: typeof ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL;
+  version: typeof ASKABLE_MCP_PAGE_BRIDGE_VERSION;
+  channel?: string;
+  type: `${AskableMcpPageBridgeRequestType}:result`;
+  requestId: string;
+  packet?: WebContextPacket;
+  text?: string;
+}
+
+export interface AskableMcpPageBridgeErrorResponse {
+  protocol: typeof ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL;
+  version: typeof ASKABLE_MCP_PAGE_BRIDGE_VERSION;
+  channel?: string;
+  type: `${AskableMcpPageBridgeRequestType}:error`;
+  requestId: string;
+  error: {
+    message: string;
+  };
+}
+
+export type AskableMcpPageBridgeResponse =
+  | AskableMcpPageBridgeSuccessResponse
+  | AskableMcpPageBridgeErrorResponse;
+
+export type AskableMcpPageBridgeAllowedOrigins =
+  | string[]
+  | ((origin: string, event: MessageEvent) => boolean | Promise<boolean>);
+
+export interface AskableMcpPageBridgeWindow {
+  addEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  postMessage(message: AskableMcpPageBridgeResponse, targetOrigin: string): void;
+  location?: {
+    origin?: string;
+  };
+}
+
+export interface AskableMcpPageBridgeOptions {
+  provider: AskableMcpContextProvider;
+  channel?: string;
+  targetOrigin?: string;
+  allowedOrigins?: AskableMcpPageBridgeAllowedOrigins;
+  window?: AskableMcpPageBridgeWindow;
+  onError?: (error: unknown, event: MessageEvent) => void;
+}
+
+export interface AskableMcpPageBridge {
+  dispose(): void;
+}
+
 export type AskableMcpSourceContext = Pick<AskableContext, 'toContextPacket' | 'toContext'> &
   Partial<Pick<AskableContext, 'toContextPacketAsync' | 'toContextAsync'>>;
 
@@ -359,6 +427,26 @@ export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions)
   };
 }
 
+export function createAskableMcpPageBridge(options: AskableMcpPageBridgeOptions): AskableMcpPageBridge {
+  const bridgeWindow = options.window ?? getBrowserWindow();
+  if (!bridgeWindow) {
+    return { dispose() {} };
+  }
+
+  const channel = options.channel ?? ASKABLE_MCP_PAGE_BRIDGE_CHANNEL;
+  const listener = (event: MessageEvent) => {
+    void handleAskableMcpPageBridgeMessage(event, bridgeWindow, options, channel);
+  };
+
+  bridgeWindow.addEventListener('message', listener);
+
+  return {
+    dispose() {
+      bridgeWindow.removeEventListener('message', listener);
+    },
+  };
+}
+
 export function defaultPromptFormatter(packet: WebContextPacket): string {
   const parts = [
     `Context mode: ${packet.capture.mode}`,
@@ -373,6 +461,110 @@ export function defaultPromptFormatter(packet: WebContextPacket): string {
   ];
 
   return parts.filter((part): part is string => Boolean(part)).join('\n');
+}
+
+function getBrowserWindow(): AskableMcpPageBridgeWindow | undefined {
+  return typeof window === 'undefined'
+    ? undefined
+    : window;
+}
+
+async function handleAskableMcpPageBridgeMessage(
+  event: MessageEvent,
+  bridgeWindow: AskableMcpPageBridgeWindow,
+  options: AskableMcpPageBridgeOptions,
+  channel: string,
+): Promise<void> {
+  const request = parseAskableMcpPageBridgeRequest(event.data, channel);
+  if (!request) return;
+
+  if (!await isAskableMcpPageBridgeOriginAllowed(event, bridgeWindow, options.allowedOrigins)) {
+    return;
+  }
+
+  try {
+    const packet = await options.provider.getContext(request.options);
+    const responseBase = createAskableMcpPageBridgeResponseBase(request);
+    const response: AskableMcpPageBridgeSuccessResponse = request.type === 'format_context_for_prompt'
+      ? {
+          ...responseBase,
+          type: 'format_context_for_prompt:result',
+          text: options.provider.formatContextForPrompt
+            ? await options.provider.formatContextForPrompt(packet, request.options)
+            : defaultPromptFormatter(packet),
+        }
+      : {
+          ...responseBase,
+          type: 'get_current_context:result',
+          packet,
+        };
+
+    bridgeWindow.postMessage(response, resolveAskableMcpPageBridgeTargetOrigin(event, options));
+  } catch (error) {
+    options.onError?.(error, event);
+    bridgeWindow.postMessage({
+      ...createAskableMcpPageBridgeResponseBase(request),
+      type: `${request.type}:error`,
+      error: { message: 'Askable MCP page bridge failed.' },
+    }, resolveAskableMcpPageBridgeTargetOrigin(event, options));
+  }
+}
+
+function parseAskableMcpPageBridgeRequest(
+  data: unknown,
+  channel: string,
+): AskableMcpPageBridgeRequest | undefined {
+  if (!isRecord(data)) return undefined;
+  if (data.protocol !== ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL) return undefined;
+  if (data.version !== ASKABLE_MCP_PAGE_BRIDGE_VERSION) return undefined;
+  if ((data.channel ?? ASKABLE_MCP_PAGE_BRIDGE_CHANNEL) !== channel) return undefined;
+  if (data.type !== 'get_current_context' && data.type !== 'format_context_for_prompt') return undefined;
+  if (typeof data.requestId !== 'string' || !data.requestId) return undefined;
+  if (data.options !== undefined && !isRecord(data.options)) return undefined;
+
+  return {
+    ...data,
+    channel: data.channel ?? ASKABLE_MCP_PAGE_BRIDGE_CHANNEL,
+  } as unknown as AskableMcpPageBridgeRequest;
+}
+
+async function isAskableMcpPageBridgeOriginAllowed(
+  event: MessageEvent,
+  bridgeWindow: AskableMcpPageBridgeWindow,
+  allowedOrigins: AskableMcpPageBridgeAllowedOrigins | undefined,
+): Promise<boolean> {
+  const origin = event.origin || bridgeWindow.location?.origin || '';
+  if (!allowedOrigins) {
+    return !bridgeWindow.location?.origin || origin === bridgeWindow.location.origin;
+  }
+
+  if (Array.isArray(allowedOrigins)) {
+    return allowedOrigins.includes(origin);
+  }
+
+  return allowedOrigins(origin, event);
+}
+
+function createAskableMcpPageBridgeResponseBase(
+  request: AskableMcpPageBridgeRequest,
+): Omit<AskableMcpPageBridgeSuccessResponse, 'type'> {
+  return {
+    protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+    version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+    ...(request.channel ? { channel: request.channel } : {}),
+    requestId: request.requestId,
+  };
+}
+
+function resolveAskableMcpPageBridgeTargetOrigin(
+  event: MessageEvent,
+  options: AskableMcpPageBridgeOptions,
+): string {
+  return options.targetOrigin ?? (event.origin || '*');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function mergeContextOptions(

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -247,3 +247,60 @@ requests can also pass the endpoint as a remote MCP server:
 For current client setup details, check the official
 [Anthropic MCP connector docs](https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector)
 and [OpenAI remote MCP docs](https://platform.openai.com/docs/guides/tools-remote-mcp).
+
+## `createAskableMcpPageBridge(options)`
+
+Creates the page-side handoff for browser-local MCP workflows. This is separate
+from hosted Web MCP: a normal webpage cannot expose MCP directly to local Claude
+or ChatGPT clients. It needs a trusted browser extension or local companion
+process that can receive page context and expose its own local MCP server.
+
+`createAskableMcpPageBridge()` listens for versioned `window.postMessage()`
+requests and returns either the current Context packet or prompt-ready text.
+
+```ts
+import { createAskableMcpContextProvider, createAskableMcpPageBridge } from '@askable-ui/mcp';
+
+const bridge = createAskableMcpPageBridge({
+  provider: createAskableMcpContextProvider(ctx, {
+    history: 3,
+    includeViewport: true,
+    sources: ['accounts'],
+  }),
+  allowedOrigins: [window.location.origin],
+  onError: (error) => reportBridgeError(error),
+});
+
+bridge.dispose();
+```
+
+| Option | Type | Description |
+|---|---|---|
+| `provider` | `AskableMcpContextProvider` | Supplies packets and optional prompt formatting |
+| `channel` | `string` | Optional message channel. Defaults to `askable:mcp` |
+| `targetOrigin` | `string` | Optional response target origin for `postMessage()` |
+| `allowedOrigins` | `string[] \| (origin, event) => boolean` | Optional origin gate. Defaults to the current page origin |
+| `window` | `AskableMcpPageBridgeWindow` | Optional window-like object for tests or custom browser surfaces |
+| `onError` | `(error, event) => void` | Optional bridge error reporter |
+
+Trusted extensions or local companions request context with:
+
+```ts
+window.postMessage({
+  protocol: 'askable.mcp.page_bridge',
+  version: '0.1',
+  channel: 'askable:mcp',
+  type: 'get_current_context',
+  requestId: crypto.randomUUID(),
+  options: { sources: ['accounts'], history: 3 },
+}, window.location.origin);
+```
+
+Use `type: 'format_context_for_prompt'` to receive prompt-ready text. Responses
+preserve `protocol`, `version`, `channel`, and `requestId`, and return
+`get_current_context:result`, `format_context_for_prompt:result`, or
+`*:error` message types.
+
+Enable this bridge only when the user or host app has opted into local browser
+MCP. The extension or companion should own installation trust, user consent,
+local MCP server authentication, and any storage or forwarding rules.

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -50,6 +50,12 @@ request body limits, response headers, default `no-store`/`nosniff` headers,
 and sanitized telemetry that omits request bodies, Context packets, prompt text,
 and query strings.
 
+`@askable-ui/mcp` also includes `createAskableMcpPageBridge()` for browser-local
+MCP workflows. This is the page-side handoff for trusted extensions or local
+companions: the page answers versioned `window.postMessage()` requests with a
+Context packet or prompt-ready text, while the extension or companion exposes
+the local MCP server.
+
 Related docs:
 
 - [@askable-ui/mcp API](/api/mcp)

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -673,7 +673,7 @@
     .mcp-panel h3 { font-size: clamp(1.35rem, 2.4vw, 2rem); line-height: 1.05; letter-spacing: -.045em; margin-bottom: .6rem; }
     .mcp-panel p { color: var(--ink-2); font-size: .9rem; line-height: 1.62; }
     .mcp-endpoint { display: flex; align-items: center; gap: .5rem; align-self: start; padding: .8rem .95rem; border: 1px solid rgba(79,70,229,0.16); border-radius: 16px; background: rgba(79,70,229,0.05); font-family: var(--mono); color: var(--accent); font-size: .78rem; word-break: break-all; }
-    .mcp-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .mcp-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); }
     .mcp-card { padding: 1.25rem; border-right: 1px solid rgba(0,0,0,0.06); }
     .mcp-card:last-child { border-right: 0; }
     .mcp-card h4 { font-size: .92rem; letter-spacing: -.02em; margin-bottom: .42rem; }
@@ -1230,7 +1230,7 @@ ctx.push(meta, text);</pre>
           <div>
             <p class="section-label" style="margin-bottom:.55rem">Web MCP</p>
             <h3>Expose selected UI context to Claude and ChatGPT.</h3>
-            <p>Host <code>@askable-ui/mcp</code> behind a public HTTPS MCP transport so approved clients can call <code>get_current_context</code> and <code>format_context_for_prompt</code>.</p>
+            <p>Use hosted Web MCP for public HTTPS endpoints, or the page bridge for trusted browser extensions and local MCP companions.</p>
           </div>
           <div class="mcp-endpoint">https://your-app.com/mcp</div>
         </div>
@@ -1270,6 +1270,16 @@ export const POST = handler;</pre>
   "server_label": "askable",
   "server_url": "https://your-app.com/mcp"
 }</pre>
+          </article>
+          <article class="mcp-card">
+            <h4>Browser local</h4>
+            <p>Add a page bridge for approved extensions or local companions. They receive context from the page, then expose their own local MCP server.</p>
+            <pre>createAskableMcpPageBridge({
+  provider,
+  allowedOrigins: [
+    window.location.origin
+  ]
+});</pre>
           </article>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add createAskableMcpPageBridge for browser-local MCP handoff through versioned postMessage requests
- support packet and prompt text requests, channel matching, same-origin/default origin gating, custom origins, errors, and dispose
- document hosted Web MCP versus browser-local MCP in package docs, site docs, What's New, and the main website

## Verification
- npm test --workspace @askable-ui/mcp -- --run
- npm run build --workspace @askable-ui/mcp
- npm run build:versioned --prefix site/docs
- local Chromium check for the main website MCP panel at http://127.0.0.1:4192/