### PR TITLE
feat(core): focus selection prompt inputs

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -67,6 +67,7 @@ const capture = createAskableRegionCapture(ctx, {
     className: 'my-selection-marker',
     prompt: {
       placeholder: 'Ask about this area...',
+      initialValue: 'What should I notice here?',
       onSubmit(question, packet) {
         sendToAgent({ question, context: packet });
       },
@@ -95,6 +96,9 @@ The built-in lasso overlay uses `ASKABLE_REGION_CAPTURE_THEME` by default; pass
 Set `selectionAffordance` to keep the selected shape visible after capture and,
 optionally, render a small prompt anchored to the selected area. The affordance
 accepts class names, inline style hooks, and a custom `render()` escape hatch.
+Prompt inputs focus and select their initial value by default. Pass
+`prompt.autoFocus: false` to keep focus where it is, or `prompt.initialValue`
+to seed a suggested question.
 Set `once: false` to keep the overlay mounted for repeated captures. The handle
 reports active until `cancel()` or `destroy()` runs, and `clearSelection()`
 removes only the persisted selected-state UI.
@@ -121,6 +125,7 @@ const selection = createAskableTextSelectionCapture(ctx, {
     label: 'Selected text',
     prompt: {
       placeholder: 'Ask about this text...',
+      initialValue: 'Explain this quote',
       onSubmit(question, packet) {
         sendToAgent({ question, context: packet });
       },
@@ -145,6 +150,8 @@ Set `selectionAffordance` to keep selected text visually marked after capture
 and optionally attach a small prompt to the highlighted range. The affordance
 accepts class names, inline styles, theme overrides, and a custom `render()`
 escape hatch.
+Prompt inputs focus and select their initial value by default. Pass
+`prompt.autoFocus: false` to opt out.
 
 ## API Reference
 

--- a/packages/core/src/__tests__/capture.test.ts
+++ b/packages/core/src/__tests__/capture.test.ts
@@ -423,6 +423,7 @@ describe('createAskableRegionCapture', () => {
       selectionAffordance: {
         prompt: {
           placeholder: 'Ask here',
+          initialValue: 'Summarize this selection',
           submitLabel: 'Send question',
           onSubmit,
         },
@@ -439,6 +440,8 @@ describe('createAskableRegionCapture', () => {
     const affordance = document.getElementById('askable-region-selection-affordance')!;
     const input = affordance.querySelector('input')!;
     const button = affordance.querySelector('button')!;
+    expect(input.value).toBe('Summarize this selection');
+    expect(document.activeElement).toBe(input);
     input.value = 'What changed here?';
     button.click();
 

--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -119,6 +119,7 @@ describe('createAskableTextSelectionCapture', () => {
       selectionAffordance: {
         prompt: {
           placeholder: 'Ask about quote',
+          initialValue: 'Explain this quote',
           submitLabel: 'Send text question',
           onSubmit,
         },
@@ -131,6 +132,8 @@ describe('createAskableTextSelectionCapture', () => {
     const affordance = document.getElementById('askable-text-selection-affordance')!;
     const input = affordance.querySelector('input')!;
     const button = affordance.querySelector('button')!;
+    expect(input.value).toBe('Explain this quote');
+    expect(document.activeElement).toBe(input);
     input.value = 'What does this mean?';
     button.click();
 

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -32,6 +32,10 @@ export type AskableRegionCaptureStyle = Partial<CSSStyleDeclaration>;
 export interface AskableRegionCapturePromptOptions {
   /** Placeholder shown in the anchored prompt input. */
   placeholder?: string;
+  /** Initial prompt input value, useful for suggested follow-up questions. */
+  initialValue?: string;
+  /** Focus and select the prompt input after rendering. Defaults to true. */
+  autoFocus?: boolean;
   /** Accessible label/title for the submit button. */
   submitLabel?: string;
   /** Class added to the prompt container. */
@@ -481,6 +485,7 @@ export function createAskableRegionCapture(
     if (prompt) root.appendChild(createPrompt(prompt, packet, selection));
 
     document.body.appendChild(root);
+    if (prompt?.autoFocus !== false) focusPromptInput(root);
   }
 
   function createSelectionMarker(selection: AskableRegionCaptureSelection): HTMLElement | SVGSVGElement {
@@ -548,7 +553,8 @@ export function createAskableRegionCapture(
   ): HTMLFormElement {
     const form = document.createElement('form');
     if (prompt.className) form.className = prompt.className;
-    const placeAbove = selection.bounds.y + selection.bounds.height + 56 > window.innerHeight;
+    const viewport = viewportSize(document);
+    const placeAbove = selection.bounds.y + selection.bounds.height + 56 > viewport.height;
     form.style.cssText = [
       'position:absolute',
       'left:0',
@@ -570,6 +576,7 @@ export function createAskableRegionCapture(
     const input = document.createElement('input');
     input.type = 'text';
     input.placeholder = prompt.placeholder ?? 'Ask about this selection...';
+    input.value = prompt.initialValue ?? '';
     if (prompt.inputClassName) input.className = prompt.inputClassName;
     input.style.cssText = [
       'min-width:0',
@@ -608,6 +615,21 @@ export function createAskableRegionCapture(
     });
     return form;
   }
+}
+
+function focusPromptInput(root: HTMLElement): void {
+  const input = root.querySelector('input');
+  const view = root.ownerDocument.defaultView;
+  if (!input || !view || !(input instanceof view.HTMLInputElement)) return;
+  input.focus({ preventScroll: true });
+  input.select();
+}
+
+function viewportSize(doc: Document): { height: number } {
+  const view = doc.defaultView;
+  return {
+    height: view?.innerHeight ?? 768,
+  };
 }
 
 function resolveRegionCaptureTheme(theme?: Partial<AskableRegionCaptureTheme>): AskableRegionCaptureTheme {

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -22,6 +22,10 @@ export type AskableTextSelectionCaptureStyle = Partial<CSSStyleDeclaration>;
 export interface AskableTextSelectionCapturePromptOptions {
   /** Placeholder shown in the anchored prompt input. */
   placeholder?: string;
+  /** Initial prompt input value, useful for suggested follow-up questions. */
+  initialValue?: string;
+  /** Focus and select the prompt input after rendering. Defaults to true. */
+  autoFocus?: boolean;
   /** Accessible label/title for the submit button. */
   submitLabel?: string;
   /** Class added to the prompt container. */
@@ -336,6 +340,7 @@ export function createAskableTextSelectionCapture(
     if (prompt) rootEl.appendChild(createPrompt(prompt, packet, selection));
 
     ownerDocument.body.appendChild(rootEl);
+    if (prompt?.autoFocus !== false) focusPromptInput(rootEl);
   }
 
   function createTextMark(rect: WebContextRect): HTMLSpanElement {
@@ -385,13 +390,14 @@ export function createAskableTextSelectionCapture(
     const bounds = selection.bounds;
     const form = ownerDocument.createElement('form');
     if (prompt.className) form.className = prompt.className;
-    const placeAbove = bounds ? bounds.y + bounds.height + 56 > window.innerHeight : false;
+    const viewport = viewportSize(ownerDocument);
+    const placeAbove = bounds ? bounds.y + bounds.height + 56 > viewport.height : false;
     form.style.cssText = [
       'position:fixed',
-      `left:${bounds ? Math.max(8, Math.min(bounds.x, window.innerWidth - 240)) : 8}px`,
+      `left:${bounds ? Math.max(8, Math.min(bounds.x, viewport.width - 240)) : 8}px`,
       bounds && placeAbove
         ? `top:${Math.max(8, bounds.y - 48)}px`
-        : `top:${bounds ? Math.min(window.innerHeight - 48, bounds.y + bounds.height + 10) : 8}px`,
+        : `top:${bounds ? Math.min(viewport.height - 48, bounds.y + bounds.height + 10) : 8}px`,
       'display:flex',
       'align-items:center',
       'gap:6px',
@@ -409,6 +415,7 @@ export function createAskableTextSelectionCapture(
     const input = ownerDocument.createElement('input');
     input.type = 'text';
     input.placeholder = prompt.placeholder ?? 'Ask about this text...';
+    input.value = prompt.initialValue ?? '';
     if (prompt.inputClassName) input.className = prompt.inputClassName;
     input.style.cssText = [
       'min-width:0',
@@ -447,6 +454,22 @@ export function createAskableTextSelectionCapture(
     });
     return form;
   }
+}
+
+function focusPromptInput(root: HTMLElement): void {
+  const input = root.querySelector('input');
+  const view = root.ownerDocument.defaultView;
+  if (!input || !view || !(input instanceof view.HTMLInputElement)) return;
+  input.focus({ preventScroll: true });
+  input.select();
+}
+
+function viewportSize(doc: Document): { width: number; height: number } {
+  const view = doc.defaultView;
+  return {
+    width: view?.innerWidth ?? 1024,
+    height: view?.innerHeight ?? 768,
+  };
 }
 
 function resolveDocument(root?: Document | HTMLElement): Document | null {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -284,6 +284,16 @@ function RegionTools() {
   const capture = useAskableRegionCapture({
     ctx,
     includeViewport: true,
+    selectionAffordance: {
+      label: 'Selected context',
+      prompt: {
+        placeholder: 'Ask about this area...',
+        initialValue: 'What should I notice here?',
+        onSubmit(question, packet) {
+          sendToAgent({ question, context: packet });
+        },
+      },
+    },
     theme: {
       lassoStrokeWidth: 4,
       lassoGlowRadius: 12,
@@ -313,6 +323,8 @@ function RegionTools() {
 The lasso overlay ships with the core `ASKABLE_REGION_CAPTURE_THEME`. Pass
 `theme` through `useAskableRegionCapture()` to override the overlay,
 region/circle fill, or lasso gradient for your app.
+Use `selectionAffordance` to keep the selected area visible and optionally show
+an anchored prompt that focuses by default.
 
 Use `once: false` when the capture control should stay active for repeated
 region, circle, or lasso selections. The hook keeps `active` true until
@@ -330,6 +342,16 @@ function SelectionTools() {
   const selection = useAskableTextSelectionCapture({
     includeViewport: true,
     intent: 'answer using the highlighted text',
+    selectionAffordance: {
+      label: 'Selected text',
+      prompt: {
+        placeholder: 'Ask about this text...',
+        initialValue: 'Explain this quote',
+        onSubmit(question, packet) {
+          sendToAgent({ question, context: packet });
+        },
+      },
+    },
     onCapture(packet) {
       sendToAgent(packet);
     },

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -783,6 +783,7 @@ const capture = createAskableRegionCapture(ctx, {
     label: 'Selected context',
     prompt: {
       placeholder: 'Ask about this area...',
+      initialValue: 'What should I notice here?',
       onSubmit(question, packet) {
         sendToAgent({ question, context: packet });
       },
@@ -829,6 +830,9 @@ after capture, or pass an object with `className`, `style`, `label`, `prompt`,
 and `render()` hooks. `prompt.onSubmit(question, packet, selection)` is useful
 when the selected area should immediately become the anchor for a follow-up chat
 question.
+Prompt inputs focus and select their initial value by default. Use
+`prompt.initialValue` for suggested questions and `prompt.autoFocus: false` to
+keep focus where it is.
 
 Square captures are constrained to equal width and height. They serialize with
 `capture.mode: 'region'` and `target.metadata.shape: 'square'` so existing
@@ -865,6 +869,7 @@ const selection = createAskableTextSelectionCapture(ctx, {
     label: 'Selected text',
     prompt: {
       placeholder: 'Ask about this text...',
+      initialValue: 'Explain this quote',
       onSubmit(question, packet) {
         sendToAgent({ question, context: packet });
       },
@@ -903,6 +908,9 @@ selection.captureNow();
 or pass an object with `className`, `style`, `label`, `prompt`, and `render()`
 hooks. `prompt.onSubmit(question, packet, selection)` lets a highlighted range
 immediately anchor a follow-up chat question.
+Prompt inputs focus and select their initial value by default. Use
+`prompt.initialValue` for suggested questions and `prompt.autoFocus: false` to
+keep focus where it is.
 
 When browser range geometry is available, the selection includes aggregate
 `bounds` plus `rects` for multi-line selected text. Packets include

--- a/site/docs/guide/react.md
+++ b/site/docs/guide/react.md
@@ -169,6 +169,7 @@ function RegionTools() {
       label: 'Selected context',
       prompt: {
         placeholder: 'Ask about this area...',
+        initialValue: 'What should I notice here?',
         onSubmit(question, packet) {
           sendToAgent({ question, context: packet });
         },
@@ -211,6 +212,8 @@ The default lasso overlay uses the core `ASKABLE_REGION_CAPTURE_THEME`; pass
 `theme` when you need brand-specific overlay colors, line styling, or
 selected-state defaults. Use `selectionAffordance` to keep the selected area
 visible after capture and optionally attach a small prompt input to it.
+The prompt focuses by default so the user can immediately revise or submit the
+suggested question.
 
 ## Text selection capture
 
@@ -227,6 +230,7 @@ function TextSelectionTools() {
       label: 'Selected text',
       prompt: {
         placeholder: 'Ask about this text...',
+        initialValue: 'Explain this quote',
         onSubmit(question, packet) {
           sendToAgent({ question, context: packet });
         },


### PR DESCRIPTION
## Summary
- add initialValue and autoFocus controls to region and text selection prompt affordances
- focus and select prompt inputs by default after selected context is confirmed
- use the owning document viewport for text prompt placement and document the suggested-question flow

## Verification
- npm test --workspace @askable-ui/core -- --run src/__tests__/capture.test.ts src/__tests__/selection.test.ts
- npm run build --workspace @askable-ui/core
- npm test --workspace @askable-ui/core -- --run
- npm run build:versioned --prefix site/docs