### PR TITLE
feat(core): add dismissible selection affordances

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -65,6 +65,7 @@ const capture = createAskableRegionCapture(ctx, {
   selectionAffordance: {
     label: 'Selected context',
     className: 'my-selection-marker',
+    dismissible: true,
     prompt: {
       placeholder: 'Ask about this area...',
       initialValue: 'What should I notice here?',
@@ -99,6 +100,9 @@ accepts class names, inline style hooks, and a custom `render()` escape hatch.
 Prompt inputs focus and select their initial value by default. Pass
 `prompt.autoFocus: false` to keep focus where it is, or `prompt.initialValue`
 to seed a suggested question.
+Pass `dismissible: true` to add a small built-in clear button, or use
+`dismissClassName`, `dismissStyle`, and `onDismiss(packet, selection)` to match
+your own selected-context UX.
 Set `once: false` to keep the overlay mounted for repeated captures. The handle
 reports active until `cancel()` or `destroy()` runs, and `clearSelection()`
 removes only the persisted selected-state UI.
@@ -123,6 +127,7 @@ const selection = createAskableTextSelectionCapture(ctx, {
   includeViewport: true,
   selectionAffordance: {
     label: 'Selected text',
+    dismissible: true,
     prompt: {
       placeholder: 'Ask about this text...',
       initialValue: 'Explain this quote',
@@ -152,6 +157,8 @@ accepts class names, inline styles, theme overrides, and a custom `render()`
 escape hatch.
 Prompt inputs focus and select their initial value by default. Pass
 `prompt.autoFocus: false` to opt out.
+Pass `dismissible: true` to add a built-in clear button, or use `onDismiss` to
+sync dismissed selected text with your chat composer state.
 
 ## API Reference
 

--- a/packages/core/src/__tests__/capture.test.ts
+++ b/packages/core/src/__tests__/capture.test.ts
@@ -415,6 +415,51 @@ describe('createAskableRegionCapture', () => {
     ctx.destroy();
   });
 
+  it('can dismiss a persisted selected region affordance', () => {
+    const ctx = createAskableContext();
+    const onDismiss = vi.fn();
+    const capture = createAskableRegionCapture(ctx, {
+      source: { app: 'dashboard' },
+      selectionAffordance: {
+        label: 'Selected area',
+        dismissible: true,
+        dismissLabel: 'Clear selected area',
+        dismissClassName: 'clear-region',
+        dismissStyle: { color: 'rgb(124, 58, 237)' },
+        onDismiss,
+      },
+    });
+
+    capture.start();
+
+    const overlay = document.getElementById('askable-region-capture')!;
+    overlay.dispatchEvent(pointerEvent('pointerdown', 10, 20));
+    overlay.dispatchEvent(pointerEvent('pointermove', 80, 90));
+    overlay.dispatchEvent(pointerEvent('pointerup', 80, 90));
+
+    const affordance = document.getElementById('askable-region-selection-affordance')!;
+    const button = affordance.querySelector('button[aria-label="Clear selected area"]') as HTMLButtonElement;
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    expect(button.className).toBe('clear-region');
+    expect(button.style.color).toBe('rgb(124, 58, 237)');
+
+    button.click();
+
+    expect(document.getElementById('askable-region-selection-affordance')).toBeNull();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss.mock.calls[0][0]).toMatchObject({
+      source: { app: 'dashboard' },
+      capture: { mode: 'region' },
+    });
+    expect(onDismiss.mock.calls[0][1]).toMatchObject({
+      shape: 'region',
+      bounds: { x: 10, y: 20, width: 70, height: 70 },
+    });
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
   it('renders an anchored prompt and calls onSubmit with the captured packet', () => {
     const ctx = createAskableContext();
     const onSubmit = vi.fn();

--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -111,6 +111,48 @@ describe('createAskableTextSelectionCapture', () => {
     ctx.destroy();
   });
 
+  it('can dismiss a persisted selected text affordance', () => {
+    const ctx = createAskableContext();
+    const onDismiss = vi.fn();
+    const capture = createAskableTextSelectionCapture(ctx, {
+      source: { app: 'reader' },
+      selectionAffordance: {
+        label: 'Quoted text',
+        dismissible: true,
+        dismissLabel: 'Clear selected text',
+        dismissClassName: 'clear-text-selection',
+        dismissStyle: { color: 'rgb(124, 58, 237)' },
+        onDismiss,
+      },
+    });
+
+    selectText('Selected sentence.');
+    capture.captureNow();
+
+    const affordance = document.getElementById('askable-text-selection-affordance')!;
+    const button = affordance.querySelector('button[aria-label="Clear selected text"]') as HTMLButtonElement;
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    expect(button.className).toBe('clear-text-selection');
+    expect(button.style.color).toBe('rgb(124, 58, 237)');
+
+    button.click();
+
+    expect(document.getElementById('askable-text-selection-affordance')).toBeNull();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss.mock.calls[0][0]).toMatchObject({
+      source: { app: 'reader' },
+      capture: { mode: 'text-selection' },
+      target: { text: 'Selected sentence.' },
+    });
+    expect(onDismiss.mock.calls[0][1]).toMatchObject({
+      text: 'Selected sentence.',
+      bounds: { x: 12, y: 20, width: 80, height: 18 },
+    });
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
   it('renders an anchored selected text prompt and calls onSubmit with the captured packet', () => {
     const ctx = createAskableContext();
     const onSubmit = vi.fn();

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -63,6 +63,10 @@ export interface AskableRegionCaptureSelectionAffordanceOptions {
   persist?: boolean;
   /** Render a compact prompt input anchored to the selected shape. Defaults to false. */
   prompt?: boolean | AskableRegionCapturePromptOptions;
+  /** Show a small dismiss button for the persisted selected shape. Defaults to false. */
+  dismissible?: boolean;
+  /** Accessible label/title for the dismiss button. */
+  dismissLabel?: string;
   /** Optional label shown beside the selected area. */
   label?: string;
   /** Class added to the selected-area affordance root. */
@@ -73,6 +77,15 @@ export interface AskableRegionCaptureSelectionAffordanceOptions {
   labelClassName?: string;
   /** Inline styles applied to the selected-area label. */
   labelStyle?: AskableRegionCaptureStyle;
+  /** Class added to the dismiss button. */
+  dismissClassName?: string;
+  /** Inline styles applied to the dismiss button. */
+  dismissStyle?: AskableRegionCaptureStyle;
+  /** Called after the selected-area affordance is dismissed. */
+  onDismiss?: (
+    packet: WebContextPacket,
+    selection: AskableRegionCaptureSelection,
+  ) => void;
   /** Replace the built-in selected-area affordance with consumer-rendered DOM. */
   render?: (
     packet: WebContextPacket,
@@ -483,6 +496,7 @@ export function createAskableRegionCapture(
 
     const prompt = resolvePromptOptions(selectionAffordance.prompt);
     if (prompt) root.appendChild(createPrompt(prompt, packet, selection));
+    if (selectionAffordance.dismissible) root.appendChild(createDismissButton(packet, selection));
 
     document.body.appendChild(root);
     if (prompt?.autoFocus !== false) focusPromptInput(root);
@@ -614,6 +628,41 @@ export function createAskableRegionCapture(
       input.value = '';
     });
     return form;
+  }
+
+  function createDismissButton(
+    packet: WebContextPacket,
+    selection: AskableRegionCaptureSelection,
+  ): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = 'x';
+    button.setAttribute('aria-label', selectionAffordance?.dismissLabel ?? 'Dismiss selected context');
+    if (selectionAffordance?.dismissClassName) button.className = selectionAffordance.dismissClassName;
+    button.style.cssText = [
+      'position:absolute',
+      'right:-10px',
+      'top:-10px',
+      'width:22px',
+      'height:22px',
+      'display:grid',
+      'place-items:center',
+      'border-radius:999px',
+      `border:1px solid ${theme.promptBorder}`,
+      `background:${theme.promptBackground}`,
+      `color:${theme.promptText}`,
+      'box-shadow:0 8px 20px rgba(15,23,42,0.14)',
+      'font:700 14px/1 system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',
+      'cursor:pointer',
+      'pointer-events:auto',
+      'padding:0',
+    ].join(';');
+    assignStyles(button, selectionAffordance?.dismissStyle);
+    button.addEventListener('click', () => {
+      removeAffordance();
+      selectionAffordance?.onDismiss?.(packet, selection);
+    });
+    return button;
   }
 }
 

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -53,6 +53,10 @@ export interface AskableTextSelectionCaptureAffordanceOptions {
   persist?: boolean;
   /** Render a compact prompt input anchored to the selected text. Defaults to false. */
   prompt?: boolean | AskableTextSelectionCapturePromptOptions;
+  /** Show a small dismiss button for the persisted selected text. Defaults to false. */
+  dismissible?: boolean;
+  /** Accessible label/title for the dismiss button. */
+  dismissLabel?: string;
   /** Optional label shown beside the selected text. */
   label?: string;
   /** Class added to the selected-text affordance root. */
@@ -63,6 +67,15 @@ export interface AskableTextSelectionCaptureAffordanceOptions {
   labelClassName?: string;
   /** Inline styles applied to the selected-text label. */
   labelStyle?: AskableTextSelectionCaptureStyle;
+  /** Class added to the dismiss button. */
+  dismissClassName?: string;
+  /** Inline styles applied to the dismiss button. */
+  dismissStyle?: AskableTextSelectionCaptureStyle;
+  /** Called after the selected-text affordance is dismissed. */
+  onDismiss?: (
+    packet: WebContextPacket,
+    selection: AskableTextSelectionCaptureSelection,
+  ) => void;
   /** Replace the built-in selected-text affordance with consumer-rendered DOM. */
   render?: (
     packet: WebContextPacket,
@@ -338,6 +351,7 @@ export function createAskableTextSelectionCapture(
 
     const prompt = resolvePromptOptions(selectionAffordance.prompt);
     if (prompt) rootEl.appendChild(createPrompt(prompt, packet, selection));
+    if (selectionAffordance.dismissible) rootEl.appendChild(createDismissButton(packet, selection));
 
     ownerDocument.body.appendChild(rootEl);
     if (prompt?.autoFocus !== false) focusPromptInput(rootEl);
@@ -453,6 +467,42 @@ export function createAskableTextSelectionCapture(
       input.value = '';
     });
     return form;
+  }
+
+  function createDismissButton(
+    packet: WebContextPacket,
+    selection: AskableTextSelectionCaptureSelection,
+  ): HTMLButtonElement {
+    const bounds = selection.bounds;
+    const button = ownerDocument.createElement('button');
+    button.type = 'button';
+    button.textContent = 'x';
+    button.setAttribute('aria-label', selectionAffordance?.dismissLabel ?? 'Dismiss selected text context');
+    if (selectionAffordance?.dismissClassName) button.className = selectionAffordance.dismissClassName;
+    button.style.cssText = [
+      'position:fixed',
+      `left:${bounds ? Math.max(8, bounds.x + bounds.width - 10) : 8}px`,
+      `top:${bounds ? Math.max(8, bounds.y - 12) : 8}px`,
+      'width:22px',
+      'height:22px',
+      'display:grid',
+      'place-items:center',
+      'border-radius:999px',
+      `border:1px solid ${theme.promptBorder}`,
+      `background:${theme.promptBackground}`,
+      `color:${theme.promptText}`,
+      'box-shadow:0 8px 20px rgba(15,23,42,0.14)',
+      'font:700 14px/1 system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',
+      'cursor:pointer',
+      'pointer-events:auto',
+      'padding:0',
+    ].join(';');
+    assignStyles(button, selectionAffordance?.dismissStyle);
+    button.addEventListener('click', () => {
+      removeAffordance();
+      selectionAffordance?.onDismiss?.(packet, selection);
+    });
+    return button;
   }
 }
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -286,6 +286,7 @@ function RegionTools() {
     includeViewport: true,
     selectionAffordance: {
       label: 'Selected context',
+      dismissible: true,
       prompt: {
         placeholder: 'Ask about this area...',
         initialValue: 'What should I notice here?',
@@ -324,7 +325,8 @@ The lasso overlay ships with the core `ASKABLE_REGION_CAPTURE_THEME`. Pass
 `theme` through `useAskableRegionCapture()` to override the overlay,
 region/circle fill, or lasso gradient for your app.
 Use `selectionAffordance` to keep the selected area visible and optionally show
-an anchored prompt that focuses by default.
+an anchored prompt that focuses by default. Pass `dismissible: true` to include
+a built-in clear button.
 
 Use `once: false` when the capture control should stay active for repeated
 region, circle, or lasso selections. The hook keeps `active` true until
@@ -344,6 +346,7 @@ function SelectionTools() {
     intent: 'answer using the highlighted text',
     selectionAffordance: {
       label: 'Selected text',
+      dismissible: true,
       prompt: {
         placeholder: 'Ask about this text...',
         initialValue: 'Explain this quote',

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -781,6 +781,7 @@ const capture = createAskableRegionCapture(ctx, {
   includeViewport: true,
   selectionAffordance: {
     label: 'Selected context',
+    dismissible: true,
     prompt: {
       placeholder: 'Ask about this area...',
       initialValue: 'What should I notice here?',
@@ -833,6 +834,10 @@ question.
 Prompt inputs focus and select their initial value by default. Use
 `prompt.initialValue` for suggested questions and `prompt.autoFocus: false` to
 keep focus where it is.
+Pass `dismissible: true` to add a small built-in clear button. Use
+`dismissClassName`, `dismissStyle`, `dismissLabel`, and
+`onDismiss(packet, selection)` when the selected-context UI needs to update
+external chat composer state.
 
 Square captures are constrained to equal width and height. They serialize with
 `capture.mode: 'region'` and `target.metadata.shape: 'square'` so existing
@@ -867,6 +872,7 @@ const selection = createAskableTextSelectionCapture(ctx, {
   includeViewport: true,
   selectionAffordance: {
     label: 'Selected text',
+    dismissible: true,
     prompt: {
       placeholder: 'Ask about this text...',
       initialValue: 'Explain this quote',
@@ -911,6 +917,9 @@ immediately anchor a follow-up chat question.
 Prompt inputs focus and select their initial value by default. Use
 `prompt.initialValue` for suggested questions and `prompt.autoFocus: false` to
 keep focus where it is.
+Pass `dismissible: true` to add a built-in clear button. Use
+`dismissClassName`, `dismissStyle`, `dismissLabel`, and
+`onDismiss(packet, selection)` to keep external selected-context state in sync.
 
 When browser range geometry is available, the selection includes aggregate
 `bounds` plus `rects` for multi-line selected text. Packets include

--- a/site/docs/guide/react.md
+++ b/site/docs/guide/react.md
@@ -167,6 +167,7 @@ function RegionTools() {
     includeViewport: true,
     selectionAffordance: {
       label: 'Selected context',
+      dismissible: true,
       prompt: {
         placeholder: 'Ask about this area...',
         initialValue: 'What should I notice here?',
@@ -213,7 +214,8 @@ The default lasso overlay uses the core `ASKABLE_REGION_CAPTURE_THEME`; pass
 selected-state defaults. Use `selectionAffordance` to keep the selected area
 visible after capture and optionally attach a small prompt input to it.
 The prompt focuses by default so the user can immediately revise or submit the
-suggested question.
+suggested question. Pass `dismissible: true` when users should be able to clear
+the selected-context chip directly.
 
 ## Text selection capture
 
@@ -228,6 +230,7 @@ function TextSelectionTools() {
     intent: 'answer using the highlighted text',
     selectionAffordance: {
       label: 'Selected text',
+      dismissible: true,
       prompt: {
         placeholder: 'Ask about this text...',
         initialValue: 'Explain this quote',


### PR DESCRIPTION
## Summary
- add opt-in dismissible controls to persisted region and text selection affordances
- expose dismissLabel, dismissClassName, dismissStyle, and onDismiss hooks for selected-context UI
- document the clear-button flow for core and React selection examples

## Verification
- npm test --workspace @askable-ui/core -- --run src/__tests__/capture.test.ts src/__tests__/selection.test.ts
- npm run build --workspace @askable-ui/core
- npm test --workspace @askable-ui/core -- --run
- npm run build:versioned --prefix site/docs