### PR TITLE
feat(core): advertise source modes

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -373,7 +373,10 @@ newer source with the same id.
 
 Use `ctx.hasSource(id)` and `ctx.listSources()` to drive source pickers,
 diagnostics, or chat controls without resolving source data. `listSources()`
-returns each source id, optional kind, registration time, and last update time.
+returns each source id, optional kind, advertised modes, registration time, and
+last update time. Helper factories infer modes from configured resolvers, and
+`advertisedModes` lets advanced sources expose custom slices without resolving
+data first.
 Use `ctx.resolveSources()` when a chat endpoint, MCP bridge, or debug surface
 needs structured source objects instead of prompt text. It resolves all
 registered sources by default, or a selected subset when `sources` is passed.

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -1904,13 +1904,14 @@ describe('createAskableContext', () => {
       const ctx = createAskableContext();
       const resolve = vi.fn(() => ({ count: 2 }));
 
-      ctx.registerSource('accounts', { kind: 'collection', resolve });
+      ctx.registerSource('accounts', { kind: 'collection', modes: ['summary', 'all'], resolve });
 
       expect(ctx.hasSource(' accounts ')).toBe(true);
       expect(ctx.hasSource('calendar')).toBe(false);
       expect(ctx.listSources()).toEqual([{
         id: 'accounts',
         kind: 'collection',
+        modes: ['summary', 'all'],
         registeredAt: Date.parse('2026-06-01T12:00:00Z'),
         updatedAt: Date.parse('2026-06-01T12:00:00Z'),
       }]);
@@ -1922,6 +1923,7 @@ describe('createAskableContext', () => {
       expect(ctx.listSources()[0]).toEqual({
         id: 'accounts',
         kind: 'collection',
+        modes: ['summary', 'all'],
         registeredAt: Date.parse('2026-06-01T12:00:00Z'),
         updatedAt: Date.parse('2026-06-01T12:00:02Z'),
       });

--- a/packages/core/src/__tests__/inspector.test.ts
+++ b/packages/core/src/__tests__/inspector.test.ts
@@ -102,6 +102,7 @@ describe('createAskableInspector', () => {
     const ctx = createAskableContext();
     ctx.registerSource('accounts', {
       kind: 'collection',
+      modes: ['state', 'summary', 'all'],
       resolve: () => ({ total: 12 }),
     });
     const inspector = createAskableInspector(ctx);
@@ -110,6 +111,7 @@ describe('createAskableInspector', () => {
     expect(panel.textContent).toContain('Context sources');
     expect(panel.textContent).toContain('accounts');
     expect(panel.textContent).toContain('collection');
+    expect(panel.textContent).toContain('modes: state, summary, all');
 
     inspector.destroy();
     ctx.destroy();

--- a/packages/core/src/__tests__/page-source.test.ts
+++ b/packages/core/src/__tests__/page-source.test.ts
@@ -40,6 +40,8 @@ describe('createAskablePageSource', () => {
     const ctx = createAskableContext();
     ctx.registerSource('page', createAskablePageSource({ includeLinks: true }));
 
+    expect(ctx.listSources()[0].modes).toEqual(['state', 'summary', 'selected', 'all']);
+
     const source = await ctx.resolveSource('page', { mode: 'summary' });
 
     expect(source).toMatchObject({

--- a/packages/core/src/__tests__/sources.test.ts
+++ b/packages/core/src/__tests__/sources.test.ts
@@ -64,6 +64,8 @@ describe('source helpers', () => {
       },
     }));
 
+    expect(ctx.listSources()[0].modes).toEqual(['state', 'summary', 'selected', 'all']);
+
     await expect(ctx.resolveSource('forecast', { mode: 'summary' })).resolves.toMatchObject({
       data: { totalPipeline: 420000, risk: 'medium' },
     });
@@ -116,10 +118,13 @@ describe('source helpers', () => {
       describe: 'Accounts matching active filters',
       getState: () => ({ page: 1, pageSize: 1, totalCount: accounts.length }),
       getVisibleItems: () => accounts.slice(0, 1),
+      getSelectedItems: () => accounts.slice(1, 2),
       getItems: () => accounts,
       getSummary: () => ({ totalMrr: 17400 }),
       sanitizeItem: ({ secret: _secret, ...safe }) => safe,
     }));
+
+    expect(ctx.listSources()[0].modes).toEqual(['state', 'summary', 'visible', 'selected', 'all']);
 
     await expect(ctx.resolveSource('accounts', { mode: 'visible' })).resolves.toMatchObject({
       data: {
@@ -151,6 +156,39 @@ describe('source helpers', () => {
         summary: { totalMrr: 17400 },
       },
     });
+
+    ctx.destroy();
+  });
+
+  it('advertises custom source modes without resolving data', () => {
+    const ctx = createAskableContext();
+    const resolve = () => ({ ok: true });
+    ctx.registerSource('workflow', createAskableSource({
+      kind: 'workflow',
+      advertisedModes: ['summary', 'next-actions', 'summary', ' ' as any],
+      resolve,
+    }));
+    ctx.registerSource('accounts', createAskableCollectionSource({
+      advertisedModes: ['export'],
+      resolve,
+    }));
+
+    expect(ctx.listSources().map((source) => ({
+      id: source.id,
+      kind: source.kind,
+      modes: source.modes,
+    }))).toEqual([
+      {
+        id: 'workflow',
+        kind: 'workflow',
+        modes: ['summary', 'next-actions'],
+      },
+      {
+        id: 'accounts',
+        kind: 'collection',
+        modes: ['export'],
+      },
+    ]);
 
     ctx.destroy();
   });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -344,6 +344,7 @@ export class AskableContextImpl implements AskableContext {
     return Array.from(this.sources.entries()).map(([id, entry]) => ({
       id,
       ...(entry.source.kind ? { kind: entry.source.kind } : {}),
+      ...(entry.source.modes?.length ? { modes: [...entry.source.modes] } : {}),
       registeredAt: entry.registeredAt,
       updatedAt: entry.updatedAt,
     }));

--- a/packages/core/src/inspector.ts
+++ b/packages/core/src/inspector.ts
@@ -142,6 +142,7 @@ function buildSourcesHTML(sources: AskableContextSourceInfo[]): string {
         <div style="min-width:0">
           <code style="display:block;color:#e6edf3;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${escapeHtml(source.id)}</code>
           ${source.kind ? `<span style="color:#8b949e;font-size:11px">${escapeHtml(source.kind)}</span>` : ''}
+          ${source.modes?.length ? `<span style="display:block;color:#8b949e;font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">modes: ${escapeHtml(source.modes.join(', '))}</span>` : ''}
         </div>
         <span title="Last updated" style="color:#8b949e;font-size:11px;white-space:nowrap">${escapeHtml(renderTime(source.updatedAt))}</span>
       </div>

--- a/packages/core/src/page-source.ts
+++ b/packages/core/src/page-source.ts
@@ -56,6 +56,7 @@ export interface AskableCreatePageSourceOptions {
 export function createAskablePageSource(options: AskableCreatePageSourceOptions = {}): AskableContextSource {
   return {
     kind: options.kind ?? 'page',
+    modes: ['state', 'summary', 'selected', 'all'],
     describe: options.describe ?? 'Current page',
     getState: () => {
       const root = resolveRoot(options.root);

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -23,6 +23,8 @@ export function isAskablePacketSourceSelection(
 export interface AskableCreateSourceOptions<TData = unknown, TState = unknown> {
   /** Source category. Examples: "document", "collection", "chart", "map", "canvas". */
   kind?: string;
+  /** Additional modes this source advertises for pickers and agent controls. */
+  advertisedModes?: readonly AskableContextSourceMode[];
   /** Human-readable source description. */
   describe?: string | (() => string | Promise<string>);
   /** Current app state for this source. */
@@ -49,6 +51,8 @@ export interface AskableCollectionSourceData<TItem = unknown> {
 export interface AskableCreateCollectionSourceOptions<TItem = unknown, TState = unknown> {
   /** Source category. Defaults to "collection". */
   kind?: string;
+  /** Additional modes this collection advertises for pickers and agent controls. */
+  advertisedModes?: readonly AskableContextSourceMode[];
   /** Human-readable source description. */
   describe?: string | (() => string | Promise<string>);
   /** Current collection state, such as filters, sort, page, route, or query. */
@@ -96,6 +100,7 @@ export function createAskableSource<TData = unknown, TState = unknown>(
 
   return {
     kind: options.kind,
+    modes: inferGenericSourceModes(options),
     describe: options.describe,
     getState: options.state === undefined
       ? undefined
@@ -132,6 +137,7 @@ export function createAskableCollectionSource<TItem = unknown, TState = unknown>
 ): AskableContextSource {
   return {
     kind: options.kind ?? 'collection',
+    modes: inferCollectionSourceModes(options),
     describe: options.describe,
     getState: options.getState,
     resolve: async (request) => {
@@ -142,6 +148,43 @@ export function createAskableCollectionSource<TItem = unknown, TState = unknown>
     },
     sanitize: options.sanitize,
   };
+}
+
+function normalizeSourceModes(
+  modes: Iterable<AskableContextSourceMode | undefined>
+): AskableContextSourceMode[] | undefined {
+  const normalized: AskableContextSourceMode[] = [];
+  const seen = new Set<string>();
+  for (const mode of modes) {
+    const value = typeof mode === 'string' ? mode.trim() as AskableContextSourceMode : undefined;
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    normalized.push(value);
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function inferGenericSourceModes<TData, TState>(
+  options: AskableCreateSourceOptions<TData, TState>
+): AskableContextSourceMode[] | undefined {
+  return normalizeSourceModes([
+    ...(options.state === undefined ? [] : ['state' as const]),
+    ...(Object.keys(options.modes ?? {}) as AskableContextSourceMode[]),
+    ...(options.advertisedModes ?? []),
+  ]);
+}
+
+function inferCollectionSourceModes<TItem, TState>(
+  options: AskableCreateCollectionSourceOptions<TItem, TState>
+): AskableContextSourceMode[] | undefined {
+  return normalizeSourceModes([
+    ...(options.getState ? ['state' as const] : []),
+    ...(options.getSummary ? ['summary' as const] : []),
+    ...(options.getVisibleItems ? ['visible' as const] : []),
+    ...(options.getSelectedItems ? ['selected' as const] : []),
+    ...(options.getItems ? ['all' as const] : []),
+    ...(options.advertisedModes ?? []),
+  ]);
 }
 
 async function resolveSourceValue<T>(value: AskableSourceValue<T>): Promise<T> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -189,6 +189,8 @@ export type AskableContextSourceErrorMode = 'include' | 'omit' | 'throw';
 export interface AskableContextSource {
   /** Source category. Examples: "collection", "document", "chart", "map", "canvas", "custom". */
   kind?: string;
+  /** Modes this source can resolve, for source pickers, inspectors, and agent controls. */
+  modes?: readonly AskableContextSourceMode[];
   /** Human-readable source description. */
   describe?: string | (() => string | Promise<string>);
   /** Current app state for this source, such as filters, sort, page, route, or viewport. */
@@ -210,6 +212,8 @@ export interface AskableContextSourceInfo {
   id: string;
   /** Source category, when provided by the source. */
   kind?: string;
+  /** Modes this source advertises without resolving source data. */
+  modes?: readonly AskableContextSourceMode[];
   /** Unix timestamp (ms) when this source id was last registered. */
   registeredAt: number;
   /** Unix timestamp (ms) when this source was last registered or notified as changed. */

--- a/packages/react-native/src/useAskableSource.ts
+++ b/packages/react-native/src/useAskableSource.ts
@@ -46,6 +46,9 @@ export function useAskableSource(
       get kind() {
         return sourceRef.current.kind;
       },
+      get modes() {
+        return sourceRef.current.modes;
+      },
       describe: () => {
         const describe = sourceRef.current.describe;
         if (typeof describe === 'function') return describe();

--- a/packages/react/src/useAskableSource.ts
+++ b/packages/react/src/useAskableSource.ts
@@ -46,6 +46,9 @@ export function useAskableSource(
       get kind() {
         return sourceRef.current.kind;
       },
+      get modes() {
+        return sourceRef.current.modes;
+      },
       describe: () => {
         const describe = sourceRef.current.describe;
         if (typeof describe === 'function') return describe();

--- a/packages/svelte/src/askable.ts
+++ b/packages/svelte/src/askable.ts
@@ -140,6 +140,9 @@ export function createAskableSourceStore(
       get kind() {
         return source.kind;
       },
+      get modes() {
+        return source.modes;
+      },
       describe: () => {
         const describe = source.describe;
         if (typeof describe === 'function') return describe();

--- a/packages/vue/src/useAskableSource.ts
+++ b/packages/vue/src/useAskableSource.ts
@@ -43,6 +43,9 @@ export function useAskableSource(
       get kind() {
         return source.kind;
       },
+      get modes() {
+        return source.modes;
+      },
       describe: () => {
         const describe = source.describe;
         if (typeof describe === 'function') return describe();

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -285,6 +285,7 @@ user meant; the source resolver supplies what the app knows.
 | Field | Type | Description |
 |---|---|---|
 | `kind` | `string` | Optional category, such as `collection`, `document`, `chart`, `map`, or `custom` |
+| `modes` | `readonly AskableContextSourceMode[]` | Advertised modes for source pickers, inspectors, chat controls, and MCP bridges |
 | `describe` | `string \| () => string \| Promise<string>` | Human-readable source description |
 | `getState` | `() => unknown \| Promise<unknown>` | Current state, such as filters, sort, page, route, or viewport |
 | `modes` | `Record<string, value \| resolver>` | Named slices for `summary`, `selected`, `all`, or app-defined source modes |
@@ -313,7 +314,11 @@ unregister or notify a newer source with the same id.
 
 Use `ctx.hasSource(id)` and `ctx.listSources()` to drive source pickers,
 diagnostics, or chat controls without resolving source data. `listSources()`
-returns each source id, optional kind, registration time, and last update time.
+returns each source id, optional kind, advertised modes, registration time, and
+last update time. Helper factories infer modes from configured resolvers:
+collection sources can advertise `summary`, `visible`, `selected`, and `all`;
+generic sources advertise keys from their `modes` map. Pass
+`advertisedModes` to expose custom slices such as `next-actions` or `export`.
 
 Use `ctx.resolveSources()` when an agent bridge, chat endpoint, or debug surface
 needs source data as structured objects instead of prompt text. It resolves all

--- a/site/docs/api/types.md
+++ b/site/docs/api/types.md
@@ -230,6 +230,7 @@ type AskableContextSourceMode =
 
 interface AskableContextSource {
   kind?: string;
+  modes?: readonly AskableContextSourceMode[];
   describe?: string | (() => string | Promise<string>);
   getState?: () => unknown | Promise<unknown>;
   resolve?: (request: AskableContextSourceResolveRequest) => unknown | Promise<unknown>;
@@ -280,6 +281,7 @@ interface AskableContextSourceHandle {
 interface AskableContextSourceInfo {
   id: string;
   kind?: string;
+  modes?: readonly AskableContextSourceMode[];
   registeredAt: number;
   updatedAt: number;
 }
@@ -297,9 +299,11 @@ type AskableSourceValue<T> = T | (() => T | Promise<T>);
 
 interface AskableCreateSourceOptions<TData = unknown, TState = unknown> {
   kind?: string;
+  advertisedModes?: readonly AskableContextSourceMode[];
   describe?: string | (() => string | Promise<string>);
   state?: AskableSourceValue<TState>;
   data?: TData | ((request: AskableContextSourceResolveRequest) => TData | Promise<TData>);
+  modes?: Record<string, unknown | ((request: AskableContextSourceResolveRequest) => unknown | Promise<unknown>)>;
   resolve?: (request: AskableContextSourceResolveRequest) => unknown | Promise<unknown>;
   sanitize?: (source: AskableResolvedContextSource) => AskableResolvedContextSource | Promise<AskableResolvedContextSource>;
 }
@@ -315,6 +319,7 @@ interface AskableCollectionSourceData<TItem = unknown> {
 
 interface AskableCreateCollectionSourceOptions<TItem = unknown, TState = unknown> {
   kind?: string;
+  advertisedModes?: readonly AskableContextSourceMode[];
   describe?: string | (() => string | Promise<string>);
   getState?: () => TState | Promise<TState>;
   getItems?: () => readonly TItem[] | Promise<readonly TItem[]>;

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -87,6 +87,9 @@ Each source becomes a `WebContextTarget` with the source id in `label`, source
 kind in `role`, source description in `text`, and resolved state/data in
 `metadata`. Failed sources use a safe unavailable marker by default so packet
 consumers do not receive stack traces or secret-bearing error messages.
+Use `ctx.listSources()` when the MCP endpoint, browser-local bridge, or chat UI
+needs to show available sources and advertised modes before resolving source
+data.
 
 ## MCP bridge
 

--- a/site/docs/guide/serialization.md
+++ b/site/docs/guide/serialization.md
@@ -168,11 +168,15 @@ asks that source for the logical collection, while `maxItems` keeps prompt
 budgets explicit. `createAskableSource()` covers non-collection state like
 documents, charts, maps, canvases, or workflows; use `modes` to expose named
 slices such as `summary`, `selected`, `all`, or app-defined modes without
-writing a custom resolver switch. Source output can be redacted with
-`sanitizeItem`, a source-level `sanitize` hook, or a context-level
-`sanitizeSource` hook. Failed or timed-out sources are represented with a safe
-unavailable marker by default; use `sourceErrorMode: 'omit'` or `'throw'` when
-your runtime needs stricter behavior.
+writing a custom resolver switch. `ctx.listSources()` returns advertised modes
+without resolving data, so chat controls and bridges can offer the right source
+mode before sending a prompt. Add `advertisedModes` when a custom resolver
+supports modes that are not visible from the factory options.
+Source output can be redacted with `sanitizeItem`, a source-level `sanitize`
+hook, or a context-level `sanitizeSource` hook. Failed or timed-out sources are
+represented with a safe unavailable marker by default; use
+`sourceErrorMode: 'omit'` or `'throw'` when your runtime needs stricter
+behavior.
 
 For browser extensions and other clients that cannot change the site code,
 `createAskablePageSource()` can still expose the page title, URL, selected


### PR DESCRIPTION
## Summary
- add advertised source modes to `AskableContextSource` and `listSources()`
- infer modes from generic, collection, and page source helpers
- preserve source modes through React, React Native, Svelte, and Vue source wrappers
- show advertised modes in the inspector and document the API

## Verification
- npm run test -w @askable-ui/core -- sources.test.ts context.test.ts inspector.test.ts page-source.test.ts
- npm run build -w @askable-ui/core
- npm run build -w @askable-ui/react
- npm run build -w @askable-ui/react-native
- npm run build -w @askable-ui/vue
- npm run build -w @askable-ui/svelte
- npm run test -w @askable-ui/core
- npm run build --workspaces --if-present
- npm run test --workspaces --if-present