### PR TITLE
feat(core): expose selection capture state

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -105,7 +105,9 @@ Pass `dismissible: true` to add a small built-in clear button, or use
 your own selected-context UX.
 Set `once: false` to keep the overlay mounted for repeated captures. The handle
 reports active until `cancel()` or `destroy()` runs, and `clearSelection()`
-removes only the persisted selected-state UI.
+removes only the persisted selected-state UI. Use `getSelection()` to read the
+current pinned packet, geometry, and affordance element when a chat composer or
+external state store needs to stay aligned with the selected area.
 
 ## Text Selection Capture
 
@@ -159,6 +161,9 @@ Prompt inputs focus and select their initial value by default. Pass
 `prompt.autoFocus: false` to opt out.
 Pass `dismissible: true` to add a built-in clear button, or use `onDismiss` to
 sync dismissed selected text with your chat composer state.
+Use `getSelection()` to read the current pinned text packet, selected range
+metadata, and affordance element. It returns `null` after `clearSelection()`,
+dismiss, cancel, or destroy.
 
 ## API Reference
 

--- a/packages/core/src/__tests__/capture.test.ts
+++ b/packages/core/src/__tests__/capture.test.ts
@@ -407,9 +407,20 @@ describe('createAskableRegionCapture', () => {
     expect(affordance.style.height).toBe('70px');
     expect(affordance.style.opacity).toBe('0.92');
     expect(affordance.textContent).toContain('Selected area');
+    expect(capture.getSelection()).toMatchObject({
+      packet: {
+        capture: { mode: 'region' },
+      },
+      selection: {
+        shape: 'region',
+        bounds: { x: 10, y: 20, width: 70, height: 70 },
+      },
+      element: affordance,
+    });
 
     capture.clearSelection();
     expect(document.getElementById('askable-region-selection-affordance')).toBeNull();
+    expect(capture.getSelection()).toBeNull();
 
     capture.destroy();
     ctx.destroy();
@@ -446,6 +457,7 @@ describe('createAskableRegionCapture', () => {
     button.click();
 
     expect(document.getElementById('askable-region-selection-affordance')).toBeNull();
+    expect(capture.getSelection()).toBeNull();
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(onDismiss.mock.calls[0][0]).toMatchObject({
       source: { app: 'dashboard' },
@@ -528,9 +540,17 @@ describe('createAskableRegionCapture', () => {
     expect(affordance.style.left).toBe('10px');
     expect(affordance.style.top).toBe('20px');
     expect(path.getAttribute('d')).toBe('M0 0 L20 25 L60 15 L70 55');
+    expect(capture.getSelection()).toMatchObject({
+      selection: {
+        shape: 'lasso',
+        bounds: { x: 10, y: 20, width: 70, height: 55 },
+      },
+      element: affordance,
+    });
 
     capture.destroy();
     expect(document.getElementById('askable-region-selection-affordance')).toBeNull();
+    expect(capture.getSelection()).toBeNull();
     ctx.destroy();
   });
 });

--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -103,9 +103,21 @@ describe('createAskableTextSelectionCapture', () => {
     expect(affordance.style.opacity).toBe('0.9');
     expect(affordance.textContent).toContain('Quoted text');
     expect(affordance.querySelectorAll('span').length).toBeGreaterThanOrEqual(2);
+    expect(capture.getSelection()).toMatchObject({
+      packet: {
+        capture: { mode: 'text-selection' },
+        target: { text: 'Selected sentence.' },
+      },
+      selection: {
+        text: 'Selected sentence.',
+        bounds: { x: 12, y: 20, width: 80, height: 18 },
+      },
+      element: affordance,
+    });
 
     capture.clearSelection();
     expect(document.getElementById('askable-text-selection-affordance')).toBeNull();
+    expect(capture.getSelection()).toBeNull();
 
     capture.destroy();
     ctx.destroy();
@@ -138,6 +150,7 @@ describe('createAskableTextSelectionCapture', () => {
     button.click();
 
     expect(document.getElementById('askable-text-selection-affordance')).toBeNull();
+    expect(capture.getSelection()).toBeNull();
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(onDismiss.mock.calls[0][0]).toMatchObject({
       source: { app: 'reader' },

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -22,6 +22,15 @@ export interface AskableRegionCaptureSelection {
   endedAt: string;
 }
 
+export interface AskableRegionCaptureState {
+  /** Captured Context packet for the current selected region, circle, square, or lasso. */
+  packet: WebContextPacket;
+  /** Raw selected geometry for the current selected context. */
+  selection: AskableRegionCaptureSelection;
+  /** Persisted selected-state affordance root, when `selectionAffordance` rendered one. */
+  element?: HTMLElement;
+}
+
 export interface AskableRegionCaptureGradientStop {
   offset: string;
   color: string;
@@ -147,6 +156,7 @@ export interface AskableRegionCaptureHandle {
   start(): void;
   cancel(): void;
   clearSelection(): void;
+  getSelection(): AskableRegionCaptureState | null;
   destroy(): void;
   isActive(): boolean;
 }
@@ -214,6 +224,7 @@ export function createAskableRegionCapture(
       start: () => undefined,
       cancel: () => undefined,
       clearSelection: () => undefined,
+      getSelection: () => null,
       destroy: () => undefined,
       isActive: () => false,
     };
@@ -228,6 +239,7 @@ export function createAskableRegionCapture(
   let startedAt = '';
   let pointerType: string | undefined;
   let active = false;
+  let currentSelection: AskableRegionCaptureState | null = null;
 
   const shape = options.shape ?? 'region';
   const minSize = options.minSize ?? 6;
@@ -235,8 +247,9 @@ export function createAskableRegionCapture(
   const theme = resolveRegionCaptureTheme(options.theme);
   const selectionAffordance = resolveSelectionAffordance(options.selectionAffordance);
 
-  const removeAffordance = () => {
+  const removeAffordance = (clearState = true) => {
     document.getElementById(AFFORDANCE_ID)?.remove();
+    if (clearState) currentSelection = null;
   };
 
   const removeOverlay = () => {
@@ -436,6 +449,7 @@ export function createAskableRegionCapture(
       if (lassoSvg) lassoSvg.style.display = 'none';
     }
 
+    currentSelection = { packet, selection };
     renderSelectionAffordance(packet, selection);
     options.onCapture?.(packet, selection);
   }
@@ -454,6 +468,7 @@ export function createAskableRegionCapture(
     },
     cancel,
     clearSelection: removeAffordance,
+    getSelection: () => currentSelection,
     destroy() {
       removeOverlay();
       removeAffordance();
@@ -463,13 +478,14 @@ export function createAskableRegionCapture(
 
   function renderSelectionAffordance(packet: WebContextPacket, selection: AskableRegionCaptureSelection) {
     if (!selectionAffordance || selectionAffordance.persist === false) return;
-    removeAffordance();
+    removeAffordance(false);
 
     const custom = selectionAffordance.render?.(packet, selection);
     if (custom instanceof HTMLElement) {
       custom.id = custom.id || AFFORDANCE_ID;
       custom.setAttribute(AFFORDANCE_ATTR, selection.shape);
       document.body.appendChild(custom);
+      currentSelection = { packet, selection, element: custom };
       return;
     }
 
@@ -499,6 +515,7 @@ export function createAskableRegionCapture(
     if (selectionAffordance.dismissible) root.appendChild(createDismissButton(packet, selection));
 
     document.body.appendChild(root);
+    currentSelection = { packet, selection, element: root };
     if (prompt?.autoFocus !== false) focusPromptInput(root);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export type {
   AskableRegionCaptureSelection,
   AskableRegionCaptureSelectionAffordanceOptions,
   AskableRegionCaptureShape,
+  AskableRegionCaptureState,
   AskableRegionCaptureStyle,
   AskableRegionCaptureTheme,
 } from './capture.js';
@@ -49,6 +50,7 @@ export type {
   AskableTextSelectionCaptureOptions,
   AskableTextSelectionCapturePromptOptions,
   AskableTextSelectionCaptureSelection,
+  AskableTextSelectionCaptureState,
   AskableTextSelectionCaptureStyle,
   AskableTextSelectionCaptureTheme,
 } from './selection.js';

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -17,6 +17,15 @@ export interface AskableTextSelectionCaptureSelection {
   capturedAt: string;
 }
 
+export interface AskableTextSelectionCaptureState {
+  /** Captured Context packet for the current selected text. */
+  packet: WebContextPacket;
+  /** Raw selected text details for the current selected context. */
+  selection: AskableTextSelectionCaptureSelection;
+  /** Persisted selected-text affordance root, when `selectionAffordance` rendered one. */
+  element?: HTMLElement;
+}
+
 export type AskableTextSelectionCaptureStyle = Partial<CSSStyleDeclaration>;
 
 export interface AskableTextSelectionCapturePromptOptions {
@@ -126,6 +135,7 @@ export interface AskableTextSelectionCaptureHandle {
   captureNow(overrides?: Partial<AskableTextSelectionCaptureOptions>): WebContextPacket | null;
   cancel(): void;
   clearSelection(): void;
+  getSelection(): AskableTextSelectionCaptureState | null;
   destroy(): void;
   isActive(): boolean;
 }
@@ -178,6 +188,7 @@ export function createAskableTextSelectionCapture(
       captureNow: () => null,
       cancel: () => undefined,
       clearSelection: () => undefined,
+      getSelection: () => null,
       destroy: () => undefined,
       isActive: () => false,
     };
@@ -195,6 +206,7 @@ export function createAskableTextSelectionCapture(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let lastInteraction: LastInteraction = { gesture: 'programmatic' };
   let lastSignature = '';
+  let currentSelection: AskableTextSelectionCaptureState | null = null;
 
   const clearTimer = () => {
     if (timer !== null) {
@@ -242,6 +254,7 @@ export function createAskableTextSelectionCapture(
       },
     });
 
+    currentSelection = { packet, selection };
     renderSelectionAffordance(packet, selection);
     currentOptions.onCapture?.(packet, selection);
     if (currentOnce) stopListening();
@@ -286,8 +299,9 @@ export function createAskableTextSelectionCapture(
     ownerDocument.addEventListener('keyup', onKeyUp);
   }
 
-  const removeAffordance = () => {
+  const removeAffordance = (clearState = true) => {
     ownerDocument.getElementById(AFFORDANCE_ID)?.remove();
+    if (clearState) currentSelection = null;
   };
 
   function stopListening() {
@@ -314,19 +328,21 @@ export function createAskableTextSelectionCapture(
     captureNow: capture,
     cancel,
     clearSelection: removeAffordance,
+    getSelection: () => currentSelection,
     destroy,
     isActive: () => active,
   };
 
   function renderSelectionAffordance(packet: WebContextPacket, selection: AskableTextSelectionCaptureSelection) {
     if (!selectionAffordance || selectionAffordance.persist === false || !selection.bounds) return;
-    removeAffordance();
+    removeAffordance(false);
 
     const custom = selectionAffordance.render?.(packet, selection);
     if (custom instanceof HTMLElement) {
       custom.id = custom.id || AFFORDANCE_ID;
       custom.setAttribute(AFFORDANCE_ATTR, 'true');
       ownerDocument.body.appendChild(custom);
+      currentSelection = { packet, selection, element: custom };
       return;
     }
 
@@ -354,6 +370,7 @@ export function createAskableTextSelectionCapture(
     if (selectionAffordance.dismissible) rootEl.appendChild(createDismissButton(packet, selection));
 
     ownerDocument.body.appendChild(rootEl);
+    currentSelection = { packet, selection, element: rootEl };
     if (prompt?.autoFocus !== false) focusPromptInput(rootEl);
   }
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -326,7 +326,8 @@ The lasso overlay ships with the core `ASKABLE_REGION_CAPTURE_THEME`. Pass
 region/circle fill, or lasso gradient for your app.
 Use `selectionAffordance` to keep the selected area visible and optionally show
 an anchored prompt that focuses by default. Pass `dismissible: true` to include
-a built-in clear button.
+a built-in clear button. Call `capture.getSelection()` when the chat composer
+needs the current pinned packet, selection geometry, and affordance element.
 
 Use `once: false` when the capture control should stay active for repeated
 region, circle, or lasso selections. The hook keeps `active` true until
@@ -369,6 +370,10 @@ function SelectionTools() {
   );
 }
 ```
+
+`selection.getSelection()` returns the current pinned text packet, selected
+range metadata, and affordance element. It returns `null` after the selection is
+cleared, dismissed, cancelled, or destroyed.
 
 ## License
 

--- a/packages/react/src/__tests__/useAskableRegionCapture.test.tsx
+++ b/packages/react/src/__tests__/useAskableRegionCapture.test.tsx
@@ -32,6 +32,7 @@ describe('useAskableRegionCapture', () => {
           </button>
           <span data-testid="active">{String(capture.active)}</span>
           <span data-testid="packet">{capture.lastPacket ? JSON.stringify(capture.lastPacket) : 'null'}</span>
+          <span data-testid="selected">{capture.getSelection() ? JSON.stringify(capture.getSelection()?.selection) : 'null'}</span>
         </div>
       );
     }
@@ -54,6 +55,7 @@ describe('useAskableRegionCapture', () => {
     await waitFor(() => {
       expect(screen.getByTestId('active').textContent).toBe('false');
       expect(screen.getByTestId('packet').textContent).not.toBe('null');
+      expect(screen.getByTestId('selected').textContent).not.toBe('null');
     });
 
     const packet = JSON.parse(screen.getByTestId('packet').textContent!);
@@ -70,6 +72,10 @@ describe('useAskableRegionCapture', () => {
         metadata: { shape: 'region', pointerType: 'mouse' },
       },
       privacy: { consent: 'explicit' },
+    });
+    expect(JSON.parse(screen.getByTestId('selected').textContent!)).toMatchObject({
+      shape: 'region',
+      bounds: { x: 20, y: 30, width: 60, height: 60 },
     });
   });
 

--- a/packages/react/src/__tests__/useAskableTextSelectionCapture.test.tsx
+++ b/packages/react/src/__tests__/useAskableTextSelectionCapture.test.tsx
@@ -87,6 +87,7 @@ describe('useAskableTextSelectionCapture', () => {
             Capture
           </button>
           <span data-testid="packet">{capture.lastPacket ? JSON.stringify(capture.lastPacket) : 'null'}</span>
+          <span data-testid="selected">{capture.getSelection() ? JSON.stringify(capture.getSelection()?.selection) : 'null'}</span>
         </div>
       );
     }
@@ -100,6 +101,7 @@ describe('useAskableTextSelectionCapture', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('packet').textContent).not.toBe('null');
+      expect(screen.getByTestId('selected').textContent).not.toBe('null');
     });
 
     const packet = JSON.parse(screen.getByTestId('packet').textContent!);
@@ -115,6 +117,10 @@ describe('useAskableTextSelectionCapture', () => {
         selector: '#react-selection',
       },
       privacy: { consent: 'explicit' },
+    });
+    expect(JSON.parse(screen.getByTestId('selected').textContent!)).toMatchObject({
+      text: 'Selected React copy',
+      selector: '#react-selection',
     });
   });
 });

--- a/packages/react/src/useAskableRegionCapture.ts
+++ b/packages/react/src/useAskableRegionCapture.ts
@@ -5,6 +5,7 @@ import {
   type AskableRegionCaptureHandle,
   type AskableRegionCaptureOptions,
   type AskableRegionCaptureSelection,
+  type AskableRegionCaptureState,
   type WebContextPacket,
 } from '@askable-ui/core';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
@@ -21,6 +22,7 @@ export interface UseAskableRegionCaptureResult {
   start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
   cancel: () => void;
   clearSelection: () => void;
+  getSelection: () => AskableRegionCaptureState | null;
   destroy: () => void;
   isActive: () => boolean;
 }
@@ -54,6 +56,8 @@ export function useAskableRegionCapture(
   const clearSelection = useCallback(() => {
     handleRef.current?.clearSelection();
   }, []);
+
+  const getSelection = useCallback(() => handleRef.current?.getSelection() ?? null, []);
 
   const start = useCallback((overrides?: Partial<AskableRegionCaptureOptions>) => {
     handleRef.current?.destroy();
@@ -100,6 +104,7 @@ export function useAskableRegionCapture(
     start,
     cancel,
     clearSelection,
+    getSelection,
     destroy,
     isActive,
   };

--- a/packages/react/src/useAskableTextSelectionCapture.ts
+++ b/packages/react/src/useAskableTextSelectionCapture.ts
@@ -5,6 +5,7 @@ import {
   type AskableTextSelectionCaptureHandle,
   type AskableTextSelectionCaptureOptions,
   type AskableTextSelectionCaptureSelection,
+  type AskableTextSelectionCaptureState,
   type WebContextPacket,
 } from '@askable-ui/core';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
@@ -22,6 +23,7 @@ export interface UseAskableTextSelectionCaptureResult {
   captureNow: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => WebContextPacket | null;
   cancel: () => void;
   clearSelection: () => void;
+  getSelection: () => AskableTextSelectionCaptureState | null;
   destroy: () => void;
   isActive: () => boolean;
 }
@@ -55,6 +57,8 @@ export function useAskableTextSelectionCapture(
   const clearSelection = useCallback(() => {
     handleRef.current?.clearSelection();
   }, []);
+
+  const getSelection = useCallback(() => handleRef.current?.getSelection() ?? null, []);
 
   const ensureHandle = useCallback((overrides?: Partial<AskableTextSelectionCaptureOptions>) => {
     const currentOptions = {
@@ -112,6 +116,7 @@ export function useAskableTextSelectionCapture(
     captureNow,
     cancel,
     clearSelection,
+    getSelection,
     destroy,
     isActive,
   };

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -162,7 +162,10 @@ Starts an explicit region, circle, or lasso selection overlay and exposes the ca
 {/if}
 ```
 
-The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
+`cancel()`, `clearSelection()`, `getSelection()`, `destroy()`, `isActive()`,
+and `ctx`. Use `getSelection()` to read the current pinned packet, selection
+geometry, and affordance element.
 Pass `once: false` when the capture control should stay active for repeated
 region, circle, or lasso selections. The store keeps `active` true until
 `cancel()` or `destroy()` runs.
@@ -198,7 +201,10 @@ Svelte stores.
 {/if}
 ```
 
-The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `captureNow(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
+`captureNow(overrides)`, `cancel()`, `clearSelection()`, `getSelection()`,
+`destroy()`, `isActive()`, and `ctx`. Use `getSelection()` to read the current
+pinned text packet, selected range metadata, and affordance element.
 
 ### "Ask AI" button pattern
 

--- a/packages/svelte/src/askable.ts
+++ b/packages/svelte/src/askable.ts
@@ -17,9 +17,11 @@ import type {
   AskableRegionCaptureHandle,
   AskableRegionCaptureOptions,
   AskableRegionCaptureSelection,
+  AskableRegionCaptureState,
   AskableTextSelectionCaptureHandle,
   AskableTextSelectionCaptureOptions,
   AskableTextSelectionCaptureSelection,
+  AskableTextSelectionCaptureState,
   AskableResolvedContextSource,
   WebContextPacket,
 } from '@askable-ui/core';
@@ -47,6 +49,7 @@ export interface AskableRegionCaptureStore {
   start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
   cancel: () => void;
   clearSelection: () => void;
+  getSelection: () => AskableRegionCaptureState | null;
   destroy: () => void;
   isActive: () => boolean;
 }
@@ -62,6 +65,7 @@ export interface AskableTextSelectionCaptureStore {
   captureNow: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => WebContextPacket | null;
   cancel: () => void;
   clearSelection: () => void;
+  getSelection: () => AskableTextSelectionCaptureState | null;
   destroy: () => void;
   isActive: () => boolean;
 }
@@ -250,6 +254,10 @@ export function createAskableRegionCaptureStore(
     handle?.clearSelection();
   }
 
+  function getSelection() {
+    return handle?.getSelection() ?? null;
+  }
+
   function destroy() {
     destroyCapture();
     askable.destroy();
@@ -267,6 +275,7 @@ export function createAskableRegionCaptureStore(
     start,
     cancel,
     clearSelection,
+    getSelection,
     destroy,
     isActive,
   };
@@ -341,6 +350,10 @@ export function createAskableTextSelectionCaptureStore(
     handle?.clearSelection();
   }
 
+  function getSelection() {
+    return handle?.getSelection() ?? null;
+  }
+
   function destroy() {
     destroyCapture();
     askable.destroy();
@@ -359,6 +372,7 @@ export function createAskableTextSelectionCaptureStore(
     captureNow,
     cancel,
     clearSelection,
+    getSelection,
     destroy,
     isActive,
   };

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -154,7 +154,10 @@ const selectedContext = computed(() =>
 </template>
 ```
 
-The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
+`cancel()`, `clearSelection()`, `getSelection()`, `destroy()`, `isActive()`,
+and `ctx`. Use `getSelection()` to read the current pinned packet, selection
+geometry, and affordance element.
 Pass `once: false` when the capture control should stay active for repeated
 region, circle, or lasso selections. The composable keeps `active` true until
 `cancel()` or `destroy()` runs.
@@ -188,7 +191,10 @@ const selectedContext = computed(() =>
 </template>
 ```
 
-The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`, `captureNow(overrides)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
+`captureNow(overrides)`, `cancel()`, `clearSelection()`, `getSelection()`,
+`destroy()`, `isActive()`, and `ctx`. Use `getSelection()` to read the current
+pinned text packet, selected range metadata, and affordance element.
 
 ### "Ask AI" button pattern
 

--- a/packages/vue/src/useAskableRegionCapture.ts
+++ b/packages/vue/src/useAskableRegionCapture.ts
@@ -5,6 +5,7 @@ import {
   type AskableRegionCaptureHandle,
   type AskableRegionCaptureOptions,
   type AskableRegionCaptureSelection,
+  type AskableRegionCaptureState,
   type WebContextPacket,
 } from '@askable-ui/core';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
@@ -21,6 +22,7 @@ export interface UseAskableRegionCaptureResult {
   start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
   cancel: () => void;
   clearSelection: () => void;
+  getSelection: () => AskableRegionCaptureState | null;
   destroy: () => void;
   isActive: () => boolean;
 }
@@ -48,6 +50,10 @@ export function useAskableRegionCapture(
 
   function clearSelection() {
     handle?.clearSelection();
+  }
+
+  function getSelection() {
+    return handle?.getSelection() ?? null;
   }
 
   function start(overrides?: Partial<AskableRegionCaptureOptions>) {
@@ -95,6 +101,7 @@ export function useAskableRegionCapture(
     start,
     cancel,
     clearSelection,
+    getSelection,
     destroy,
     isActive,
   };

--- a/packages/vue/src/useAskableTextSelectionCapture.ts
+++ b/packages/vue/src/useAskableTextSelectionCapture.ts
@@ -5,6 +5,7 @@ import {
   type AskableTextSelectionCaptureHandle,
   type AskableTextSelectionCaptureOptions,
   type AskableTextSelectionCaptureSelection,
+  type AskableTextSelectionCaptureState,
   type WebContextPacket,
 } from '@askable-ui/core';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
@@ -22,6 +23,7 @@ export interface UseAskableTextSelectionCaptureResult {
   captureNow: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => WebContextPacket | null;
   cancel: () => void;
   clearSelection: () => void;
+  getSelection: () => AskableTextSelectionCaptureState | null;
   destroy: () => void;
   isActive: () => boolean;
 }
@@ -49,6 +51,10 @@ export function useAskableTextSelectionCapture(
 
   function clearSelection() {
     handle?.clearSelection();
+  }
+
+  function getSelection() {
+    return handle?.getSelection() ?? null;
   }
 
   function ensureHandle(overrides?: Partial<AskableTextSelectionCaptureOptions>) {
@@ -109,6 +115,7 @@ export function useAskableTextSelectionCapture(
     captureNow,
     cancel,
     clearSelection,
+    getSelection,
     destroy,
     isActive,
   };

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -843,6 +843,11 @@ Pass `dismissible: true` to add a small built-in clear button. Use
 `dismissClassName`, `dismissStyle`, `dismissLabel`, and
 `onDismiss(packet, selection)` when the selected-context UI needs to update
 external chat composer state.
+Use `getSelection()` on the handle to read the current pinned packet, selection
+geometry, and persisted affordance element. It returns `null` after
+`clearSelection()`, dismiss, cancel, or destroy. `lastSelection` values exposed
+by framework wrappers remain historical, while `getSelection()` reflects the
+currently pinned selected context.
 
 Square captures are constrained to equal width and height. They serialize with
 `capture.mode: 'region'` and `target.metadata.shape: 'square'` so existing
@@ -853,7 +858,7 @@ editors. The overlay stays mounted after each accepted capture, and
 `isActive()` remains `true` until `cancel()` or `destroy()` is called.
 
 **Returns:** `AskableRegionCaptureHandle` — object with `start()`, `cancel()`,
-`clearSelection()`, `destroy()`, and `isActive()` methods.
+`clearSelection()`, `getSelection()`, `destroy()`, and `isActive()` methods.
 
 ---
 
@@ -925,14 +930,17 @@ keep focus where it is.
 Pass `dismissible: true` to add a built-in clear button. Use
 `dismissClassName`, `dismissStyle`, `dismissLabel`, and
 `onDismiss(packet, selection)` to keep external selected-context state in sync.
+Use `getSelection()` on the handle to read the current pinned packet, selected
+text details, and persisted affordance element. It returns `null` after
+`clearSelection()`, dismiss, cancel, or destroy.
 
 When browser range geometry is available, the selection includes aggregate
 `bounds` plus `rects` for multi-line selected text. Packets include
 `target.metadata.rectCount` when rects are present.
 
 **Returns:** `AskableTextSelectionCaptureHandle` — object with `start()`,
-`captureNow()`, `cancel()`, `clearSelection()`, `destroy()`, and `isActive()`
-methods.
+`captureNow()`, `cancel()`, `clearSelection()`, `getSelection()`, `destroy()`,
+and `isActive()` methods.
 
 ---
 

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -434,6 +434,8 @@ function DashboardCapture() {
 | `lastSelection` | `AskableRegionCaptureSelection \| null` | Last captured geometry; lasso includes point path metadata |
 | `start(overrides?)` | `function` | Start capture, optionally overriding shape/intent/etc. |
 | `cancel()` | `function` | Cancel the active overlay |
+| `clearSelection()` | `function` | Remove the current persisted selected-state UI |
+| `getSelection()` | `function` | Read the currently pinned packet, selection, and affordance element |
 | `destroy()` | `function` | Remove the overlay without firing cancel |
 | `isActive()` | `function` | Read active state from the live capture handle |
 
@@ -475,4 +477,5 @@ function TextSelectionCapture() {
 `intent`, `privacy`, and `provenance`.
 
 **Returns:** `ctx`, `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
-`captureNow(overrides?)`, `cancel()`, `destroy()`, and `isActive()`.
+`captureNow(overrides?)`, `cancel()`, `clearSelection()`, `getSelection()`,
+`destroy()`, and `isActive()`.

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -275,6 +275,8 @@ onDestroy(capture.destroy);
 | `lastSelection` | `Readable<AskableRegionCaptureSelection \| null>` | Last raw region/circle/lasso selection geometry |
 | `start` | `(overrides?) => void` | Starts capture, optionally overriding options for one capture |
 | `cancel` | `() => void` | Cancels the active overlay |
+| `clearSelection` | `() => void` | Removes the current persisted selected-state UI |
+| `getSelection` | `() => AskableRegionCaptureState \| null` | Reads the currently pinned packet, selection, and affordance element |
 | `destroy` | `() => void` | Cancels capture and destroys the underlying store context |
 | `isActive` | `() => boolean` | Reads the current overlay state |
 | `ctx` | `AskableContext` | Store context instance |
@@ -310,4 +312,5 @@ Always call `destroy()` in `onDestroy`.
 `intent`, `ctx`, `events`, `onCapture`, and `onCancel`.
 
 **Returns:** `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
-`captureNow(overrides?)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+`captureNow(overrides?)`, `cancel()`, `clearSelection()`, `getSelection()`,
+`destroy()`, `isActive()`, and `ctx`.

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -256,6 +256,8 @@ capture.cancel();
 | `lastSelection` | `ShallowRef<AskableRegionCaptureSelection \| null>` | Last raw region/circle/lasso selection geometry |
 | `start` | `(overrides?) => void` | Starts capture, optionally overriding options for one capture |
 | `cancel` | `() => void` | Cancels the active overlay |
+| `clearSelection` | `() => void` | Removes the current persisted selected-state UI |
+| `getSelection` | `() => AskableRegionCaptureState \| null` | Reads the currently pinned packet, selection, and affordance element |
 | `destroy` | `() => void` | Cancels capture and removes overlay listeners |
 | `isActive` | `() => boolean` | Reads the current overlay state |
 | `ctx` | `AskableContext` | Shared or provided context instance |
@@ -289,4 +291,5 @@ selection.cancel();
 `intent`, `ctx`, `name`, `events`, `onCapture`, and `onCancel`.
 
 **Returns:** `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
-`captureNow(overrides?)`, `cancel()`, `destroy()`, `isActive()`, and `ctx`.
+`captureNow(overrides?)`, `cancel()`, `clearSelection()`, `getSelection()`,
+`destroy()`, `isActive()`, and `ctx`.


### PR DESCRIPTION
## Summary
- add `getSelection()` to region and text capture handles
- expose the pinned packet, selection data, and rendered affordance element
- pass the state API through React, Vue, and Svelte capture wrappers
- document the selected-state lifecycle for core and framework APIs

## Verification
- npm run test -w @askable-ui/core -- capture.test.ts selection.test.ts
- npm run test -w @askable-ui/react -- useAskableRegionCapture.test.tsx useAskableTextSelectionCapture.test.tsx
- npm run build -w @askable-ui/core
- npm run build -w @askable-ui/react
- npm run build -w @askable-ui/vue
- npm run build -w @askable-ui/svelte
- npm run build --workspaces --if-present
- npm run test --workspaces --if-present