### PR TITLE
feat(core): notify selection state changes

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -108,6 +108,8 @@ reports active until `cancel()` or `destroy()` runs, and `clearSelection()`
 removes only the persisted selected-state UI. Use `getSelection()` to read the
 current pinned packet, geometry, and affordance element when a chat composer or
 external state store needs to stay aligned with the selected area.
+Use `onSelectionChange(state)` when that state should be pushed into your
+composer automatically; it receives `null` when the selection is cleared.
 
 ## Text Selection Capture
 
@@ -164,6 +166,8 @@ sync dismissed selected text with your chat composer state.
 Use `getSelection()` to read the current pinned text packet, selected range
 metadata, and affordance element. It returns `null` after `clearSelection()`,
 dismiss, cancel, or destroy.
+Use `onSelectionChange(state)` to mirror the current pinned text context into
+your own composer state; it receives `null` when the selection is cleared.
 
 ## API Reference
 

--- a/packages/core/src/__tests__/capture.test.ts
+++ b/packages/core/src/__tests__/capture.test.ts
@@ -381,7 +381,9 @@ describe('createAskableRegionCapture', () => {
 
   it('can persist a selected region affordance after capture', () => {
     const ctx = createAskableContext();
+    const onSelectionChange = vi.fn();
     const capture = createAskableRegionCapture(ctx, {
+      onSelectionChange,
       selectionAffordance: {
         label: 'Selected area',
         className: 'custom-affordance',
@@ -417,10 +419,19 @@ describe('createAskableRegionCapture', () => {
       },
       element: affordance,
     });
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange.mock.calls[0][0]).toMatchObject({
+      selection: {
+        shape: 'region',
+        bounds: { x: 10, y: 20, width: 70, height: 70 },
+      },
+      element: affordance,
+    });
 
     capture.clearSelection();
     expect(document.getElementById('askable-region-selection-affordance')).toBeNull();
     expect(capture.getSelection()).toBeNull();
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null);
 
     capture.destroy();
     ctx.destroy();
@@ -429,8 +440,10 @@ describe('createAskableRegionCapture', () => {
   it('can dismiss a persisted selected region affordance', () => {
     const ctx = createAskableContext();
     const onDismiss = vi.fn();
+    const onSelectionChange = vi.fn();
     const capture = createAskableRegionCapture(ctx, {
       source: { app: 'dashboard' },
+      onSelectionChange,
       selectionAffordance: {
         label: 'Selected area',
         dismissible: true,
@@ -458,6 +471,7 @@ describe('createAskableRegionCapture', () => {
 
     expect(document.getElementById('askable-region-selection-affordance')).toBeNull();
     expect(capture.getSelection()).toBeNull();
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null);
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(onDismiss.mock.calls[0][0]).toMatchObject({
       source: { app: 'dashboard' },

--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -85,7 +85,9 @@ describe('createAskableTextSelectionCapture', () => {
 
   it('can persist selected text affordance after capture', () => {
     const ctx = createAskableContext();
+    const onSelectionChange = vi.fn();
     const capture = createAskableTextSelectionCapture(ctx, {
+      onSelectionChange,
       selectionAffordance: {
         label: 'Quoted text',
         className: 'custom-text-affordance',
@@ -114,10 +116,19 @@ describe('createAskableTextSelectionCapture', () => {
       },
       element: affordance,
     });
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange.mock.calls[0][0]).toMatchObject({
+      selection: {
+        text: 'Selected sentence.',
+        bounds: { x: 12, y: 20, width: 80, height: 18 },
+      },
+      element: affordance,
+    });
 
     capture.clearSelection();
     expect(document.getElementById('askable-text-selection-affordance')).toBeNull();
     expect(capture.getSelection()).toBeNull();
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null);
 
     capture.destroy();
     ctx.destroy();
@@ -126,8 +137,10 @@ describe('createAskableTextSelectionCapture', () => {
   it('can dismiss a persisted selected text affordance', () => {
     const ctx = createAskableContext();
     const onDismiss = vi.fn();
+    const onSelectionChange = vi.fn();
     const capture = createAskableTextSelectionCapture(ctx, {
       source: { app: 'reader' },
+      onSelectionChange,
       selectionAffordance: {
         label: 'Quoted text',
         dismissible: true,
@@ -151,6 +164,7 @@ describe('createAskableTextSelectionCapture', () => {
 
     expect(document.getElementById('askable-text-selection-affordance')).toBeNull();
     expect(capture.getSelection()).toBeNull();
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null);
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(onDismiss.mock.calls[0][0]).toMatchObject({
       source: { app: 'reader' },
@@ -206,6 +220,25 @@ describe('createAskableTextSelectionCapture', () => {
       bounds: { x: 12, y: 20, width: 80, height: 18 },
     });
     expect(input.value).toBe('');
+
+    capture.destroy();
+    ctx.destroy();
+  });
+
+  it('uses captureNow override selection change callbacks', () => {
+    const ctx = createAskableContext();
+    const onSelectionChange = vi.fn();
+    const capture = createAskableTextSelectionCapture(ctx);
+
+    selectText('Override callback text.');
+    capture.captureNow({ onSelectionChange });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange.mock.calls[0][0]).toMatchObject({
+      selection: {
+        text: 'Override callback text.',
+      },
+    });
 
     capture.destroy();
     ctx.destroy();

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -148,6 +148,8 @@ export interface AskableRegionCaptureOptions extends Omit<AskableContextPacketOp
   selectionAffordance?: boolean | AskableRegionCaptureSelectionAffordanceOptions;
   /** Called after a region/circle/lasso is accepted and serialized to a Context packet. */
   onCapture?: (packet: WebContextPacket, selection: AskableRegionCaptureSelection) => void;
+  /** Called whenever the pinned selection state changes or is cleared. */
+  onSelectionChange?: (state: AskableRegionCaptureState | null) => void;
   /** Called when an active capture is cancelled. */
   onCancel?: () => void;
 }
@@ -249,7 +251,13 @@ export function createAskableRegionCapture(
 
   const removeAffordance = (clearState = true) => {
     document.getElementById(AFFORDANCE_ID)?.remove();
-    if (clearState) currentSelection = null;
+    if (clearState) setCurrentSelection(null);
+  };
+
+  const setCurrentSelection = (state: AskableRegionCaptureState | null) => {
+    if (currentSelection === state) return;
+    currentSelection = state;
+    options.onSelectionChange?.(state);
   };
 
   const removeOverlay = () => {
@@ -449,8 +457,9 @@ export function createAskableRegionCapture(
       if (lassoSvg) lassoSvg.style.display = 'none';
     }
 
-    currentSelection = { packet, selection };
-    renderSelectionAffordance(packet, selection);
+    const nextSelection: AskableRegionCaptureState = { packet, selection };
+    renderSelectionAffordance(packet, selection, nextSelection);
+    setCurrentSelection(nextSelection);
     options.onCapture?.(packet, selection);
   }
 
@@ -476,7 +485,11 @@ export function createAskableRegionCapture(
     isActive: () => Boolean(overlay),
   };
 
-  function renderSelectionAffordance(packet: WebContextPacket, selection: AskableRegionCaptureSelection) {
+  function renderSelectionAffordance(
+    packet: WebContextPacket,
+    selection: AskableRegionCaptureSelection,
+    state: AskableRegionCaptureState,
+  ) {
     if (!selectionAffordance || selectionAffordance.persist === false) return;
     removeAffordance(false);
 
@@ -485,7 +498,7 @@ export function createAskableRegionCapture(
       custom.id = custom.id || AFFORDANCE_ID;
       custom.setAttribute(AFFORDANCE_ATTR, selection.shape);
       document.body.appendChild(custom);
-      currentSelection = { packet, selection, element: custom };
+      state.element = custom;
       return;
     }
 
@@ -515,7 +528,7 @@ export function createAskableRegionCapture(
     if (selectionAffordance.dismissible) root.appendChild(createDismissButton(packet, selection));
 
     document.body.appendChild(root);
-    currentSelection = { packet, selection, element: root };
+    state.element = root;
     if (prompt?.autoFocus !== false) focusPromptInput(root);
   }
 

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -126,6 +126,8 @@ export interface AskableTextSelectionCaptureOptions extends Omit<AskableContextP
   selectionAffordance?: boolean | AskableTextSelectionCaptureAffordanceOptions;
   /** Called after selected text is serialized to a Context packet. */
   onCapture?: (packet: WebContextPacket, selection: AskableTextSelectionCaptureSelection) => void;
+  /** Called whenever the pinned selection state changes or is cleared. */
+  onSelectionChange?: (state: AskableTextSelectionCaptureState | null) => void;
   /** Called when active selection capture is cancelled. */
   onCancel?: () => void;
 }
@@ -254,8 +256,9 @@ export function createAskableTextSelectionCapture(
       },
     });
 
-    currentSelection = { packet, selection };
-    renderSelectionAffordance(packet, selection);
+    const nextSelection: AskableTextSelectionCaptureState = { packet, selection };
+    renderSelectionAffordance(packet, selection, nextSelection);
+    setCurrentSelection(nextSelection, currentOptions.onSelectionChange);
     currentOptions.onCapture?.(packet, selection);
     if (currentOnce) stopListening();
     return packet;
@@ -301,7 +304,16 @@ export function createAskableTextSelectionCapture(
 
   const removeAffordance = (clearState = true) => {
     ownerDocument.getElementById(AFFORDANCE_ID)?.remove();
-    if (clearState) currentSelection = null;
+    if (clearState) setCurrentSelection(null);
+  };
+
+  const setCurrentSelection = (
+    state: AskableTextSelectionCaptureState | null,
+    onSelectionChange = options.onSelectionChange,
+  ) => {
+    if (currentSelection === state) return;
+    currentSelection = state;
+    onSelectionChange?.(state);
   };
 
   function stopListening() {
@@ -333,7 +345,11 @@ export function createAskableTextSelectionCapture(
     isActive: () => active,
   };
 
-  function renderSelectionAffordance(packet: WebContextPacket, selection: AskableTextSelectionCaptureSelection) {
+  function renderSelectionAffordance(
+    packet: WebContextPacket,
+    selection: AskableTextSelectionCaptureSelection,
+    state: AskableTextSelectionCaptureState,
+  ) {
     if (!selectionAffordance || selectionAffordance.persist === false || !selection.bounds) return;
     removeAffordance(false);
 
@@ -342,7 +358,7 @@ export function createAskableTextSelectionCapture(
       custom.id = custom.id || AFFORDANCE_ID;
       custom.setAttribute(AFFORDANCE_ATTR, 'true');
       ownerDocument.body.appendChild(custom);
-      currentSelection = { packet, selection, element: custom };
+      state.element = custom;
       return;
     }
 
@@ -370,7 +386,7 @@ export function createAskableTextSelectionCapture(
     if (selectionAffordance.dismissible) rootEl.appendChild(createDismissButton(packet, selection));
 
     ownerDocument.body.appendChild(rootEl);
-    currentSelection = { packet, selection, element: rootEl };
+    state.element = rootEl;
     if (prompt?.autoFocus !== false) focusPromptInput(rootEl);
   }
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -328,6 +328,8 @@ Use `selectionAffordance` to keep the selected area visible and optionally show
 an anchored prompt that focuses by default. Pass `dismissible: true` to include
 a built-in clear button. Call `capture.getSelection()` when the chat composer
 needs the current pinned packet, selection geometry, and affordance element.
+Use `onSelectionChange(state)` to mirror that pinned context into external
+state; it receives `null` when the selection is cleared.
 
 Use `once: false` when the capture control should stay active for repeated
 region, circle, or lasso selections. The hook keeps `active` true until
@@ -374,6 +376,8 @@ function SelectionTools() {
 `selection.getSelection()` returns the current pinned text packet, selected
 range metadata, and affordance element. It returns `null` after the selection is
 cleared, dismissed, cancelled, or destroyed.
+Use `onSelectionChange(state)` to keep chat input state aligned with the pinned
+text selection.
 
 ## License
 

--- a/packages/react/src/useAskableRegionCapture.ts
+++ b/packages/react/src/useAskableRegionCapture.ts
@@ -81,6 +81,9 @@ export function useAskableRegionCapture(
         // was called still fires correctly.
         optionsRef.current.onCapture?.(packet, selection);
       },
+      onSelectionChange(state) {
+        optionsRef.current.onSelectionChange?.(state);
+      },
       onCancel() {
         setActive(false);
         optionsRef.current.onCancel?.();

--- a/packages/react/src/useAskableTextSelectionCapture.ts
+++ b/packages/react/src/useAskableTextSelectionCapture.ts
@@ -77,6 +77,9 @@ export function useAskableTextSelectionCapture(
         }
         optionsRef.current.onCapture?.(packet, selection);
       },
+      onSelectionChange(state) {
+        optionsRef.current.onSelectionChange?.(state);
+      },
       onCancel() {
         handleRef.current = null;
         setActive(false);

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -166,6 +166,8 @@ The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
 `cancel()`, `clearSelection()`, `getSelection()`, `destroy()`, `isActive()`,
 and `ctx`. Use `getSelection()` to read the current pinned packet, selection
 geometry, and affordance element.
+Use `onSelectionChange(state)` to mirror pinned context into external composer
+state.
 Pass `once: false` when the capture control should stay active for repeated
 region, circle, or lasso selections. The store keeps `active` true until
 `cancel()` or `destroy()` runs.
@@ -205,6 +207,8 @@ The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
 `captureNow(overrides)`, `cancel()`, `clearSelection()`, `getSelection()`,
 `destroy()`, `isActive()`, and `ctx`. Use `getSelection()` to read the current
 pinned text packet, selected range metadata, and affordance element.
+Use `onSelectionChange(state)` to keep chat input state aligned with the pinned
+text selection.
 
 ### "Ask AI" button pattern
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -158,6 +158,8 @@ The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
 `cancel()`, `clearSelection()`, `getSelection()`, `destroy()`, `isActive()`,
 and `ctx`. Use `getSelection()` to read the current pinned packet, selection
 geometry, and affordance element.
+Use `onSelectionChange(state)` to mirror pinned context into external composer
+state.
 Pass `once: false` when the capture control should stay active for repeated
 region, circle, or lasso selections. The composable keeps `active` true until
 `cancel()` or `destroy()` runs.
@@ -195,6 +197,8 @@ The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
 `captureNow(overrides)`, `cancel()`, `clearSelection()`, `getSelection()`,
 `destroy()`, `isActive()`, and `ctx`. Use `getSelection()` to read the current
 pinned text packet, selected range metadata, and affordance element.
+Use `onSelectionChange(state)` to keep chat input state aligned with the pinned
+text selection.
 
 ### "Ask AI" button pattern
 

--- a/site/docs/api/core.md
+++ b/site/docs/api/core.md
@@ -823,6 +823,7 @@ capture.start();
 | `theme` | `Partial<AskableRegionCaptureTheme>` | `ASKABLE_REGION_CAPTURE_THEME` | Overlay colors, selection fill/stroke, and lasso gradient/glow styling |
 | `selectionAffordance` | `boolean \| AskableRegionCaptureSelectionAffordanceOptions` | `false` | Keep selected geometry visible after capture, optionally with an anchored prompt |
 | `onCapture` | `(packet, selection) => void` | — | Called with the Context packet and selection geometry |
+| `onSelectionChange` | `(state) => void` | — | Called with the current pinned packet/selection/element, or `null` when cleared |
 | `onCancel` | `() => void` | — | Called when the capture is cancelled |
 | _...most `AskableContextPacketOptions`_ | | | Passed through to `toContextPacket()` |
 
@@ -848,6 +849,8 @@ geometry, and persisted affordance element. It returns `null` after
 `clearSelection()`, dismiss, cancel, or destroy. `lastSelection` values exposed
 by framework wrappers remain historical, while `getSelection()` reflects the
 currently pinned selected context.
+`onSelectionChange(state)` is the push-style equivalent for chat composers and
+stores that should mirror selected context automatically.
 
 Square captures are constrained to equal width and height. They serialize with
 `capture.mode: 'region'` and `target.metadata.shape: 'square'` so existing
@@ -917,6 +920,7 @@ selection.captureNow();
 | `theme` | `Partial<AskableTextSelectionCaptureTheme>` | `ASKABLE_TEXT_SELECTION_CAPTURE_THEME` | Selected-text mark and anchored prompt styling |
 | `selectionAffordance` | `boolean \| AskableTextSelectionCaptureAffordanceOptions` | `false` | Keep highlighted text visible after capture, optionally with an anchored prompt |
 | `onCapture` | `(packet, selection) => void` | — | Called with the Context packet and selected text details |
+| `onSelectionChange` | `(state) => void` | — | Called with the current pinned packet/selection/element, or `null` when cleared |
 | `onCancel` | `() => void` | — | Called when active capture is cancelled |
 | _...most `AskableContextPacketOptions`_ | | | Passed through to `toContextPacket()` |
 
@@ -933,6 +937,8 @@ Pass `dismissible: true` to add a built-in clear button. Use
 Use `getSelection()` on the handle to read the current pinned packet, selected
 text details, and persisted affordance element. It returns `null` after
 `clearSelection()`, dismiss, cancel, or destroy.
+Use `onSelectionChange(state)` when an external composer should mirror selected
+text context automatically.
 
 When browser range geometry is available, the selection includes aggregate
 `bounds` plus `rects` for multi-line selected text. Packets include

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -419,6 +419,7 @@ function DashboardCapture() {
 | `once` | `boolean` | Remove the overlay after the first accepted capture |
 | `theme` | `Partial<AskableRegionCaptureTheme>` | Override overlay colors, selection fill/stroke, and lasso gradient/glow styling |
 | `onCapture` | `(packet, selection) => void` | Called when the user completes a selection |
+| `onSelectionChange` | `(state) => void` | Called when pinned selected context changes or is cleared |
 | `onCancel` | `() => void` | Called when selection is cancelled |
 | `ctx` | `AskableContext` | Reuse an existing context |
 | `includeViewport` | `boolean` | Include visible annotated elements in the emitted packet |
@@ -473,7 +474,7 @@ function TextSelectionCapture() {
 ```
 
 **Options:** `root`, `minLength`, `debounce`, `once`, `dedupe`, `onCapture`,
-`onCancel`, `ctx`, and packet options such as `includeViewport`, `source`,
+`onSelectionChange`, `onCancel`, `ctx`, and packet options such as `includeViewport`, `source`,
 `intent`, `privacy`, and `provenance`.
 
 **Returns:** `ctx`, `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -264,6 +264,7 @@ onDestroy(capture.destroy);
 | `ctx` | `AskableContext` | Optional context to share with other Svelte stores/components |
 | `events` | `AskableEvent[]` | Observation events for the underlying store context |
 | `onCapture` | `(packet, selection) => void` | Called after a region, circle, or lasso is accepted |
+| `onSelectionChange` | `(state) => void` | Called when pinned selected context changes or is cleared |
 | `onCancel` | `() => void` | Called after active capture is cancelled |
 
 **Returns:**
@@ -309,7 +310,7 @@ selection.cancel();
 Always call `destroy()` in `onDestroy`.
 
 **Options:** `root`, `minLength`, `debounce`, `once`, `dedupe`, `source`,
-`intent`, `ctx`, `events`, `onCapture`, and `onCancel`.
+`intent`, `ctx`, `events`, `onCapture`, `onSelectionChange`, and `onCancel`.
 
 **Returns:** `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
 `captureNow(overrides?)`, `cancel()`, `clearSelection()`, `getSelection()`,

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -245,6 +245,7 @@ capture.cancel();
 | `name` | `string` | Optional shared context name when `ctx` is not provided |
 | `events` | `AskableEvent[]` | Observation events for the underlying `useAskable()` context |
 | `onCapture` | `(packet, selection) => void` | Called after a region, circle, or lasso is accepted |
+| `onSelectionChange` | `(state) => void` | Called when pinned selected context changes or is cleared |
 | `onCancel` | `() => void` | Called after active capture is cancelled |
 
 **Returns:**
@@ -288,7 +289,8 @@ selection.cancel();
 ```
 
 **Options:** `root`, `minLength`, `debounce`, `once`, `dedupe`, `source`,
-`intent`, `ctx`, `name`, `events`, `onCapture`, and `onCancel`.
+`intent`, `ctx`, `name`, `events`, `onCapture`, `onSelectionChange`, and
+`onCancel`.
 
 **Returns:** `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
 `captureNow(overrides?)`, `cancel()`, `clearSelection()`, `getSelection()`,


### PR DESCRIPTION
## Summary
- add `onSelectionChange(state)` to region and text capture options
- emit the pinned packet/selection/affordance state after capture and `null` on clear/dismiss
- forward latest React callback refs for active capture sessions
- document the callback for core, React, Vue, and Svelte APIs

## Verification
- npm run test -w @askable-ui/core -- capture.test.ts selection.test.ts
- npm run test -w @askable-ui/react -- useAskableRegionCapture.test.tsx useAskableTextSelectionCapture.test.tsx
- npm run build -w @askable-ui/core
- npm run build -w @askable-ui/react
- npm run build -w @askable-ui/vue
- npm run build -w @askable-ui/svelte
- npm run build --workspaces --if-present
- npm run test --workspaces --if-present