### PR TITLE
feat(adapters): expose reactive selection capture state

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -145,7 +145,7 @@ Starts an explicit region, circle, or lasso selection overlay and exposes the ca
     source: { app: 'analytics-dashboard' },
     intent: 'answer with this selected area as context',
   });
-  const { active, lastPacket } = capture;
+  const { active, lastPacket, selectionState } = capture;
 
   onDestroy(capture.destroy);
 </script>
@@ -160,12 +160,22 @@ Starts an explicit region, circle, or lasso selection overlay and exposes the ca
 {#if $lastPacket}
   <pre>{JSON.stringify($lastPacket, null, 2)}</pre>
 {/if}
+
+{#if $selectionState}
+  <SelectionComposer
+    packet={$selectionState.packet}
+    selection={$selectionState.selection}
+    onClear={capture.clearSelection}
+  />
+{/if}
 ```
 
-The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
-`cancel()`, `clearSelection()`, `getSelection()`, `destroy()`, `isActive()`,
-and `ctx`. Use `getSelection()` to read the current pinned packet, selection
-geometry, and affordance element.
+The store includes `active`, `lastPacket`, `lastSelection`, `selectionState`,
+`start(overrides)`, `cancel()`, `clearSelection()`, `getSelection()`,
+`destroy()`, `isActive()`, and `ctx`. Use `selectionState` to render selected
+context confirmation, inline question input, or a custom composer. Use
+`getSelection()` when non-render code needs the current pinned packet,
+selection geometry, and affordance element.
 Use `onSelectionChange(state)` to mirror pinned context into external composer
 state.
 Pass `once: false` when the capture control should stay active for repeated
@@ -187,7 +197,7 @@ Svelte stores.
     source: { app: 'analytics-dashboard' },
     intent: 'answer using the highlighted text',
   });
-  const { active, lastPacket } = selection;
+  const { active, lastPacket, selectionState } = selection;
 
   onDestroy(selection.destroy);
 </script>
@@ -201,12 +211,22 @@ Svelte stores.
 {#if $lastPacket}
   <pre>{JSON.stringify($lastPacket, null, 2)}</pre>
 {/if}
+
+{#if $selectionState}
+  <SelectedTextComposer
+    packet={$selectionState.packet}
+    selection={$selectionState.selection}
+    onClear={selection.clearSelection}
+  />
+{/if}
 ```
 
-The store includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
-`captureNow(overrides)`, `cancel()`, `clearSelection()`, `getSelection()`,
-`destroy()`, `isActive()`, and `ctx`. Use `getSelection()` to read the current
-pinned text packet, selected range metadata, and affordance element.
+The store includes `active`, `lastPacket`, `lastSelection`, `selectionState`,
+`start(overrides)`, `captureNow(overrides)`, `cancel()`, `clearSelection()`,
+`getSelection()`, `destroy()`, `isActive()`, and `ctx`. Use `selectionState` to
+render selected-text confirmation and inline chat inputs. Use `getSelection()`
+when imperative code needs the current pinned text packet, selected range
+metadata, and affordance element.
 Use `onSelectionChange(state)` to keep chat input state aligned with the pinned
 text selection.
 

--- a/packages/svelte/src/__tests__/store.test.ts
+++ b/packages/svelte/src/__tests__/store.test.ts
@@ -224,6 +224,16 @@ describe('createAskableTextSelectionCaptureStore', () => {
       text: 'Selected Svelte copy',
       selector: '#svelte-selection',
     });
+    expect(get(capture.selectionState)).toMatchObject({
+      packet,
+      selection: {
+        text: 'Selected Svelte copy',
+        selector: '#svelte-selection',
+      },
+    });
+
+    capture.clearSelection();
+    expect(get(capture.selectionState)).toBeNull();
 
     capture.destroy();
   });
@@ -382,6 +392,16 @@ describe('createAskableRegionCaptureStore', () => {
       },
       privacy: { consent: 'explicit' },
     });
+    expect(get(capture.selectionState)).toMatchObject({
+      packet: get(capture.lastPacket),
+      selection: {
+        shape: 'region',
+        bounds: { x: 20, y: 30, width: 60, height: 60 },
+      },
+    });
+
+    capture.clearSelection();
+    expect(get(capture.selectionState)).toBeNull();
 
     capture.destroy();
   });

--- a/packages/svelte/src/askable.ts
+++ b/packages/svelte/src/askable.ts
@@ -45,6 +45,7 @@ export interface AskableRegionCaptureStore {
   active: ReturnType<typeof readonly>;
   lastPacket: ReturnType<typeof readonly>;
   lastSelection: ReturnType<typeof readonly>;
+  selectionState: ReturnType<typeof readonly>;
   ctx: AskableContext;
   start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
   cancel: () => void;
@@ -60,6 +61,7 @@ export interface AskableTextSelectionCaptureStore {
   active: ReturnType<typeof readonly>;
   lastPacket: ReturnType<typeof readonly>;
   lastSelection: ReturnType<typeof readonly>;
+  selectionState: ReturnType<typeof readonly>;
   ctx: AskableContext;
   start: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => void;
   captureNow: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => WebContextPacket | null;
@@ -205,12 +207,14 @@ export function createAskableRegionCaptureStore(
   const _active = writable(false);
   const _lastPacket = writable<WebContextPacket | null>(null);
   const _lastSelection = writable<AskableRegionCaptureSelection | null>(null);
+  const _selectionState = writable<AskableRegionCaptureState | null>(null);
   let handle: AskableRegionCaptureHandle | null = null;
 
   function destroyCapture() {
     handle?.destroy();
     handle = null;
     _active.set(false);
+    _selectionState.set(null);
   }
 
   function start(overrides?: Partial<AskableRegionCaptureOptions>) {
@@ -238,6 +242,10 @@ export function createAskableRegionCaptureStore(
         _active.set(false);
         currentOptions.onCancel?.();
       },
+      onSelectionChange(state) {
+        _selectionState.set(state);
+        currentOptions.onSelectionChange?.(state);
+      },
     });
 
     handle.start();
@@ -248,10 +256,12 @@ export function createAskableRegionCaptureStore(
     handle?.cancel();
     handle = null;
     _active.set(false);
+    _selectionState.set(null);
   }
 
   function clearSelection() {
     handle?.clearSelection();
+    if (!handle) _selectionState.set(null);
   }
 
   function getSelection() {
@@ -271,6 +281,7 @@ export function createAskableRegionCaptureStore(
     active: readonly(_active),
     lastPacket: readonly(_lastPacket),
     lastSelection: readonly(_lastSelection),
+    selectionState: readonly(_selectionState),
     ctx: askable.ctx,
     start,
     cancel,
@@ -289,12 +300,14 @@ export function createAskableTextSelectionCaptureStore(
   const _active = writable(false);
   const _lastPacket = writable<WebContextPacket | null>(null);
   const _lastSelection = writable<AskableTextSelectionCaptureSelection | null>(null);
+  const _selectionState = writable<AskableTextSelectionCaptureState | null>(null);
   let handle: AskableTextSelectionCaptureHandle | null = null;
 
   function destroyCapture() {
     handle?.destroy();
     handle = null;
     _active.set(false);
+    _selectionState.set(null);
   }
 
   function ensureHandle(overrides?: Partial<AskableTextSelectionCaptureOptions>) {
@@ -320,6 +333,10 @@ export function createAskableTextSelectionCaptureStore(
         _active.set(false);
         currentOptions.onCancel?.();
       },
+      onSelectionChange(state) {
+        _selectionState.set(state);
+        currentOptions.onSelectionChange?.(state);
+      },
     });
 
     return handle;
@@ -344,10 +361,12 @@ export function createAskableTextSelectionCaptureStore(
     handle?.cancel();
     handle = null;
     _active.set(false);
+    _selectionState.set(null);
   }
 
   function clearSelection() {
     handle?.clearSelection();
+    if (!handle) _selectionState.set(null);
   }
 
   function getSelection() {
@@ -367,6 +386,7 @@ export function createAskableTextSelectionCaptureStore(
     active: readonly(_active),
     lastPacket: readonly(_lastPacket),
     lastSelection: readonly(_lastSelection),
+    selectionState: readonly(_selectionState),
     ctx: askable.ctx,
     start,
     captureNow,

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -151,13 +151,21 @@ const selectedContext = computed(() =>
   <button @click="capture.start({ shape: 'lasso' })">Lasso area</button>
   <button v-if="capture.active.value" @click="capture.cancel()">Cancel</button>
   <pre v-if="selectedContext">{{ selectedContext }}</pre>
+  <SelectionComposer
+    v-if="capture.selectionState.value"
+    :packet="capture.selectionState.value.packet"
+    :selection="capture.selectionState.value.selection"
+    @clear="capture.clearSelection()"
+  />
 </template>
 ```
 
-The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
-`cancel()`, `clearSelection()`, `getSelection()`, `destroy()`, `isActive()`,
-and `ctx`. Use `getSelection()` to read the current pinned packet, selection
-geometry, and affordance element.
+The result includes `active`, `lastPacket`, `lastSelection`, `selectionState`,
+`start(overrides)`, `cancel()`, `clearSelection()`, `getSelection()`,
+`destroy()`, `isActive()`, and `ctx`. Use `selectionState` to render selected
+context confirmation, inline question input, or a custom composer. Use
+`getSelection()` when non-render code needs the current pinned packet,
+selection geometry, and affordance element.
 Use `onSelectionChange(state)` to mirror pinned context into external composer
 state.
 Pass `once: false` when the capture control should stay active for repeated
@@ -190,13 +198,21 @@ const selectedContext = computed(() =>
   <button @click="selection.captureNow()">Send selected text</button>
   <button v-if="selection.active.value" @click="selection.cancel()">Cancel</button>
   <pre v-if="selectedContext">{{ selectedContext }}</pre>
+  <SelectedTextComposer
+    v-if="selection.selectionState.value"
+    :packet="selection.selectionState.value.packet"
+    :selection="selection.selectionState.value.selection"
+    @clear="selection.clearSelection()"
+  />
 </template>
 ```
 
-The result includes `active`, `lastPacket`, `lastSelection`, `start(overrides)`,
-`captureNow(overrides)`, `cancel()`, `clearSelection()`, `getSelection()`,
-`destroy()`, `isActive()`, and `ctx`. Use `getSelection()` to read the current
-pinned text packet, selected range metadata, and affordance element.
+The result includes `active`, `lastPacket`, `lastSelection`, `selectionState`,
+`start(overrides)`, `captureNow(overrides)`, `cancel()`, `clearSelection()`,
+`getSelection()`, `destroy()`, `isActive()`, and `ctx`. Use `selectionState` to
+render selected-text confirmation and inline chat inputs. Use `getSelection()`
+when imperative code needs the current pinned text packet, selected range
+metadata, and affordance element.
 Use `onSelectionChange(state)` to keep chat input state aligned with the pinned
 text selection.
 

--- a/packages/vue/src/__tests__/useAskableRegionCapture.test.ts
+++ b/packages/vue/src/__tests__/useAskableRegionCapture.test.ts
@@ -36,17 +36,24 @@ describe('useAskableRegionCapture (Vue)', () => {
           intent: 'explain selected area',
         });
         const packet = computed(() => capture.lastPacket.value ? JSON.stringify(capture.lastPacket.value) : 'null');
+        const selectionState = computed(() =>
+          capture.selectionState.value ? JSON.stringify(capture.selectionState.value.selection) : 'null'
+        );
         return {
           active: capture.active,
           packet,
+          selectionState,
           start: capture.start,
+          clearSelection: capture.clearSelection,
         };
       },
       template: `
         <div>
           <button type="button" @click="start()">Start</button>
+          <button type="button" data-testid="clear" @click="clearSelection()">Clear</button>
           <span data-testid="active">{{ String(active) }}</span>
           <span data-testid="packet">{{ packet }}</span>
+          <span data-testid="selection-state">{{ selectionState }}</span>
         </div>
       `,
     });
@@ -66,6 +73,7 @@ describe('useAskableRegionCapture (Vue)', () => {
 
     expect(wrapper.find('[data-testid="active"]').text()).toBe('false');
     const packet = JSON.parse(wrapper.find('[data-testid="packet"]').text());
+    const selectionState = JSON.parse(wrapper.find('[data-testid="selection-state"]').text());
     expect(packet).toMatchObject({
       protocol: 'askable.context',
       source: { app: 'vue-test' },
@@ -80,6 +88,14 @@ describe('useAskableRegionCapture (Vue)', () => {
       },
       privacy: { consent: 'explicit' },
     });
+    expect(selectionState).toMatchObject({
+      shape: 'region',
+      bounds: { x: 20, y: 30, width: 60, height: 60 },
+    });
+
+    await wrapper.find('[data-testid="clear"]').trigger('click');
+    await flushAll();
+    expect(wrapper.find('[data-testid="selection-state"]').text()).toBe('null');
   });
 
   it('supports circle capture overrides at start time', async () => {

--- a/packages/vue/src/__tests__/useAskableTextSelectionCapture.test.ts
+++ b/packages/vue/src/__tests__/useAskableTextSelectionCapture.test.ts
@@ -100,15 +100,22 @@ describe('useAskableTextSelectionCapture (Vue)', () => {
           intent: 'summarize selection',
         });
         const packet = computed(() => capture.lastPacket.value ? JSON.stringify(capture.lastPacket.value) : 'null');
+        const selectionState = computed(() =>
+          capture.selectionState.value ? JSON.stringify(capture.selectionState.value.selection) : 'null'
+        );
         return {
           packet,
+          selectionState,
           captureNow: capture.captureNow,
+          clearSelection: capture.clearSelection,
         };
       },
       template: `
         <div>
           <button type="button" @click="captureNow()">Capture</button>
+          <button type="button" data-testid="clear" @click="clearSelection()">Clear</button>
           <span data-testid="packet">{{ packet }}</span>
+          <span data-testid="selection-state">{{ selectionState }}</span>
         </div>
       `,
     });
@@ -121,6 +128,7 @@ describe('useAskableTextSelectionCapture (Vue)', () => {
     await flushAll();
 
     const packet = JSON.parse(wrapper.find('[data-testid="packet"]').text());
+    const selectionState = JSON.parse(wrapper.find('[data-testid="selection-state"]').text());
     expect(packet).toMatchObject({
       source: { app: 'vue-test' },
       capture: {
@@ -134,5 +142,13 @@ describe('useAskableTextSelectionCapture (Vue)', () => {
       },
       privacy: { consent: 'explicit' },
     });
+    expect(selectionState).toMatchObject({
+      text: 'Selected Vue copy',
+      selector: '#vue-selection',
+    });
+
+    await wrapper.find('[data-testid="clear"]').trigger('click');
+    await flushAll();
+    expect(wrapper.find('[data-testid="selection-state"]').text()).toBe('null');
   });
 });

--- a/packages/vue/src/useAskableRegionCapture.ts
+++ b/packages/vue/src/useAskableRegionCapture.ts
@@ -19,6 +19,7 @@ export interface UseAskableRegionCaptureResult {
   active: ReturnType<typeof ref<boolean>>;
   lastPacket: ReturnType<typeof shallowRef<WebContextPacket | null>>;
   lastSelection: ReturnType<typeof shallowRef<AskableRegionCaptureSelection | null>>;
+  selectionState: ReturnType<typeof shallowRef<AskableRegionCaptureState | null>>;
   start: (overrides?: Partial<AskableRegionCaptureOptions>) => void;
   cancel: () => void;
   clearSelection: () => void;
@@ -34,22 +35,26 @@ export function useAskableRegionCapture(
   const active = ref(false);
   const lastPacket = shallowRef<WebContextPacket | null>(null);
   const lastSelection = shallowRef<AskableRegionCaptureSelection | null>(null);
+  const selectionState = shallowRef<AskableRegionCaptureState | null>(null);
   let handle: AskableRegionCaptureHandle | null = null;
 
   function destroy() {
     handle?.destroy();
     handle = null;
     active.value = false;
+    selectionState.value = null;
   }
 
   function cancel() {
     handle?.cancel();
     handle = null;
     active.value = false;
+    selectionState.value = null;
   }
 
   function clearSelection() {
     handle?.clearSelection();
+    if (!handle) selectionState.value = null;
   }
 
   function getSelection() {
@@ -81,6 +86,10 @@ export function useAskableRegionCapture(
         active.value = false;
         currentOptions.onCancel?.();
       },
+      onSelectionChange(state) {
+        selectionState.value = state;
+        currentOptions.onSelectionChange?.(state);
+      },
     });
 
     handle.start();
@@ -98,6 +107,7 @@ export function useAskableRegionCapture(
     active,
     lastPacket,
     lastSelection,
+    selectionState,
     start,
     cancel,
     clearSelection,

--- a/packages/vue/src/useAskableTextSelectionCapture.ts
+++ b/packages/vue/src/useAskableTextSelectionCapture.ts
@@ -19,6 +19,7 @@ export interface UseAskableTextSelectionCaptureResult {
   active: ReturnType<typeof ref<boolean>>;
   lastPacket: ReturnType<typeof shallowRef<WebContextPacket | null>>;
   lastSelection: ReturnType<typeof shallowRef<AskableTextSelectionCaptureSelection | null>>;
+  selectionState: ReturnType<typeof shallowRef<AskableTextSelectionCaptureState | null>>;
   start: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => void;
   captureNow: (overrides?: Partial<AskableTextSelectionCaptureOptions>) => WebContextPacket | null;
   cancel: () => void;
@@ -35,22 +36,26 @@ export function useAskableTextSelectionCapture(
   const active = ref(false);
   const lastPacket = shallowRef<WebContextPacket | null>(null);
   const lastSelection = shallowRef<AskableTextSelectionCaptureSelection | null>(null);
+  const selectionState = shallowRef<AskableTextSelectionCaptureState | null>(null);
   let handle: AskableTextSelectionCaptureHandle | null = null;
 
   function destroy() {
     handle?.destroy();
     handle = null;
     active.value = false;
+    selectionState.value = null;
   }
 
   function cancel() {
     handle?.cancel();
     handle = null;
     active.value = false;
+    selectionState.value = null;
   }
 
   function clearSelection() {
     handle?.clearSelection();
+    if (!handle) selectionState.value = null;
   }
 
   function getSelection() {
@@ -79,6 +84,10 @@ export function useAskableTextSelectionCapture(
         handle = null;
         active.value = false;
         currentOptions.onCancel?.();
+      },
+      onSelectionChange(state) {
+        selectionState.value = state;
+        currentOptions.onSelectionChange?.(state);
       },
     });
 
@@ -111,6 +120,7 @@ export function useAskableTextSelectionCapture(
     active,
     lastPacket,
     lastSelection,
+    selectionState,
     start,
     captureNow,
     cancel,

--- a/site/docs/api/svelte.md
+++ b/site/docs/api/svelte.md
@@ -274,6 +274,7 @@ onDestroy(capture.destroy);
 | `active` | `Readable<boolean>` | Whether the overlay is active |
 | `lastPacket` | `Readable<WebContextPacket \| null>` | Last captured Context packet |
 | `lastSelection` | `Readable<AskableRegionCaptureSelection \| null>` | Last raw region/circle/lasso selection geometry |
+| `selectionState` | `Readable<AskableRegionCaptureState \| null>` | Reactive pinned packet, selection, and selected-state affordance element for rendering confirmation UI |
 | `start` | `(overrides?) => void` | Starts capture, optionally overriding options for one capture |
 | `cancel` | `() => void` | Cancels the active overlay |
 | `clearSelection` | `() => void` | Removes the current persisted selected-state UI |
@@ -285,6 +286,10 @@ onDestroy(capture.destroy);
 For persistent capture tools, pass `once: false`. The overlay and `active` store
 stay on after each accepted capture until the user cancels or the store is
 destroyed.
+
+Use `selectionState` when a Svelte component should visibly confirm selected
+context or render an inline question input. It mirrors `getSelection()` and
+updates when capture pins, clears, or dismisses selected context.
 
 ---
 
@@ -312,6 +317,10 @@ Always call `destroy()` in `onDestroy`.
 **Options:** `root`, `minLength`, `debounce`, `once`, `dedupe`, `source`,
 `intent`, `ctx`, `events`, `onCapture`, `onSelectionChange`, and `onCancel`.
 
-**Returns:** `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
-`captureNow(overrides?)`, `cancel()`, `clearSelection()`, `getSelection()`,
-`destroy()`, `isActive()`, and `ctx`.
+**Returns:** `active`, `lastPacket`, `lastSelection`, `selectionState`,
+`start(overrides?)`, `captureNow(overrides?)`, `cancel()`, `clearSelection()`,
+`getSelection()`, `destroy()`, `isActive()`, and `ctx`.
+
+Use `selectionState` for app-rendered selected-text confirmation and inline
+chat inputs. It mirrors `getSelection()` and updates when text context is
+pinned, cleared, dismissed, cancelled, or destroyed.

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -255,6 +255,7 @@ capture.cancel();
 | `active` | `Ref<boolean>` | Whether the overlay is active |
 | `lastPacket` | `ShallowRef<WebContextPacket \| null>` | Last captured Context packet |
 | `lastSelection` | `ShallowRef<AskableRegionCaptureSelection \| null>` | Last raw region/circle/lasso selection geometry |
+| `selectionState` | `ShallowRef<AskableRegionCaptureState \| null>` | Reactive pinned packet, selection, and selected-state affordance element for rendering confirmation UI |
 | `start` | `(overrides?) => void` | Starts capture, optionally overriding options for one capture |
 | `cancel` | `() => void` | Cancels the active overlay |
 | `clearSelection` | `() => void` | Removes the current persisted selected-state UI |
@@ -266,6 +267,10 @@ capture.cancel();
 For persistent capture tools, pass `once: false`. The overlay and `active` ref
 stay on after each accepted capture until the user cancels or the composable is
 unmounted.
+
+Use `selectionState` when a Vue component should visibly confirm selected
+context or render an inline question input. It mirrors `getSelection()` and
+updates when capture pins, clears, or dismisses selected context.
 
 ---
 
@@ -292,6 +297,10 @@ selection.cancel();
 `intent`, `ctx`, `name`, `events`, `onCapture`, `onSelectionChange`, and
 `onCancel`.
 
-**Returns:** `active`, `lastPacket`, `lastSelection`, `start(overrides?)`,
-`captureNow(overrides?)`, `cancel()`, `clearSelection()`, `getSelection()`,
-`destroy()`, `isActive()`, and `ctx`.
+**Returns:** `active`, `lastPacket`, `lastSelection`, `selectionState`,
+`start(overrides?)`, `captureNow(overrides?)`, `cancel()`, `clearSelection()`,
+`getSelection()`, `destroy()`, `isActive()`, and `ctx`.
+
+Use `selectionState` for app-rendered selected-text confirmation and inline
+chat inputs. It mirrors `getSelection()` and updates when text context is
+pinned, cleared, dismissed, cancelled, or destroyed.


### PR DESCRIPTION
## Summary
- Add reactive `selectionState` to Vue region and text selection capture composables
- Add reactive `selectionState` to Svelte region and text selection capture stores
- Document rendering selected-context confirmation and inline composer UI from the new state

## Tests
- npm --workspace packages/vue test -- --run
- npm --workspace packages/svelte test -- --run
- npm run build --workspace packages/vue
- npm run build --workspace packages/svelte

No version bump: this is framework parity for the small selection-state API addition.