### PR TITLE
feat(mcp): expose current context page resource

### DIFF
--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.13.1",
+    "@askable-ui/react": "^0.14.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.13.1",
-    "@askable-ui/react-native": "^0.13.1",
+    "@askable-ui/core": "^0.14.0",
+    "@askable-ui/react-native": "^0.14.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "workspaces": [
         "packages/*"
       ],
@@ -4823,28 +4823,9 @@
         "zod": "^3.25.28 || ^4"
       }
     },
-    "packages/angular": {
-      "name": "@askable-ui/angular",
-      "version": "0.13.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@askable-ui/core": "^0.13.1"
-      },
-      "devDependencies": {
-        "@angular/core": "^16.2.12",
-        "@askable-ui/core": "*",
-        "jsdom": "^25.0.0",
-        "typescript": "^5.4.5",
-        "vitest": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": ">=16.0.0"
-      }
-    },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -4867,10 +4848,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.13.1"
+        "@askable-ui/context": "^0.14.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -4894,7 +4875,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -4902,11 +4883,11 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.13.1",
-        "@askable-ui/core": "^0.13.1",
+        "@askable-ui/context": "^0.14.0",
+        "@askable-ui/core": "^0.14.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -4931,10 +4912,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.13.1"
+        "@askable-ui/core": "^0.14.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -4954,10 +4935,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.13.1"
+        "@askable-ui/core": "^0.14.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.15",
@@ -5105,34 +5086,12 @@
         "node": ">=14.17"
       }
     },
-    "packages/solid": {
-      "name": "@askable-ui/solid",
-      "version": "0.13.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@askable-ui/core": "^0.13.1"
-      },
-      "devDependencies": {
-        "@askable-ui/core": "*",
-        "@solidjs/testing-library": "^0.8.10",
-        "jsdom": "^25.0.0",
-        "solid-js": "^1.9.12",
-        "typescript": "^5.4.5",
-        "vite": "^5.0.0",
-        "vite-plugin-solid": "^2.11.12",
-        "vitest": "^2.0.0"
-      },
-      "peerDependencies": {
-        "solid-js": "^1.0.0"
-      }
-    },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.13.1"
+        "@askable-ui/core": "^0.14.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -5162,10 +5121,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.13.1"
+        "@askable-ui/core": "^0.14.0"
       },
       "devDependencies": {
         "@vue/test-utils": "^2.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Framework-agnostic context tracker for LLM-aware UIs",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.13.1"
+    "@askable-ui/context": "^0.14.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Scaffold a React + Vite + CopilotKit + askable-ui starter app",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.12.0';
+const ASKABLE_VERSION = '0.14.0';
 const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -145,9 +145,9 @@ Hosted Web MCP is the server-side path. For local browser workflows, a page
 cannot expose MCP directly to Claude or ChatGPT by itself. It needs a trusted
 browser extension or local companion process. `createAskableMcpPageBridge()`
 adds the page-side handoff: the page listens for approved bridge requests and
-returns the current packet or prompt-ready text through `window.postMessage()`.
-The extension or companion can then expose that data through its own local MCP
-server.
+returns the current packet, prompt-ready text, or a resource-shaped
+`askable://current` payload through `window.postMessage()`. The extension or
+companion can then expose that data through its own local MCP server.
 
 ```ts
 import { createAskableMcpContextProvider, createAskableMcpPageBridge } from '@askable-ui/mcp';
@@ -181,6 +181,29 @@ window.postMessage({
 ```
 
 Use `type: 'format_context_for_prompt'` when the bridge needs prompt-ready text
-instead of the structured packet. Keep user consent and installation trust in
+instead of the structured packet.
+
+Use `type: 'read_current_resource'` when the extension or companion wants a
+resource-shaped response that can map directly to MCP `resources/read` output:
+
+```ts
+window.postMessage({
+  protocol: 'askable.mcp.page_bridge',
+  version: '0.1',
+  channel: 'askable:mcp',
+  type: 'read_current_resource',
+  requestId: crypto.randomUUID(),
+  options: {
+    sources: ['accounts'],
+    resource: {
+      uri: 'askable://current',
+      format: 'packet',
+    },
+  },
+}, window.location.origin);
+```
+
+Set `resource.format` to `prompt` to receive `text/plain` prompt context at a
+URI such as `askable://current.txt`. Keep user consent and installation trust in
 the extension or companion, and enable the page bridge only when the app wants
 to participate in local browser MCP workflows.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "MCP bridge for exposing Context packets to agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,8 +36,8 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.13.1",
-    "@askable-ui/core": "^0.13.1",
+    "@askable-ui/context": "^0.14.0",
+    "@askable-ui/core": "^0.14.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createWebContextPacket } from '@askable-ui/context';
 import {
+  ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI,
   ASKABLE_MCP_PAGE_BRIDGE_CHANNEL,
   ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
   ASKABLE_MCP_PAGE_BRIDGE_VERSION,
@@ -915,6 +916,97 @@ describe('createAskableMcpPageBridge', () => {
         type: 'format_context_for_prompt:result',
         requestId: 'req-2',
         text: 'Prompt-ready selection',
+      }),
+    });
+  });
+
+  it('reads current context as a page resource', async () => {
+    const packet = createWebContextPacket({
+      source: { app: 'dashboard' },
+      capture: { mode: 'lasso', intent: 'explain selected accounts' },
+      target: { text: 'Selected accounts' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    createAskableMcpPageBridge({ provider, window: fakeWindow });
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      channel: ASKABLE_MCP_PAGE_BRIDGE_CHANNEL,
+      type: 'read_current_resource',
+      requestId: 'req-resource-1',
+      options: {
+        intent: 'explain selected accounts',
+        resource: { includePacket: true },
+      },
+    });
+    await flushPageBridge();
+
+    expect(provider.getContext).toHaveBeenCalledWith({
+      intent: 'explain selected accounts',
+    });
+    expect(fakeWindow.posted[0]).toEqual({
+      targetOrigin: 'https://app.example',
+      message: expect.objectContaining({
+        type: 'read_current_resource:result',
+        requestId: 'req-resource-1',
+        resource: expect.objectContaining({
+          uri: ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI,
+          name: 'current_context',
+          title: 'Current Askable context',
+          mimeType: 'application/json',
+          packet,
+        }),
+      }),
+    });
+    expect(fakeWindow.posted[0]?.message.resource?.text).toBe(JSON.stringify(packet, null, 2));
+  });
+
+  it('reads current context as a prompt-ready page resource', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'text-selection' },
+      target: { text: 'Usage grew 18%' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+      formatContextForPrompt: vi.fn().mockResolvedValue('Usage grew 18% selected on the dashboard'),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    createAskableMcpPageBridge({ provider, window: fakeWindow });
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      type: 'read_current_resource',
+      requestId: 'req-resource-2',
+      options: {
+        maxTokens: 200,
+        resource: {
+          uri: 'askable://current.txt',
+          format: 'prompt',
+          title: 'Prompt-ready page context',
+        },
+      },
+    });
+    await flushPageBridge();
+
+    expect(provider.formatContextForPrompt).toHaveBeenCalledWith(packet, { maxTokens: 200 });
+    expect(fakeWindow.posted[0]).toEqual({
+      targetOrigin: 'https://app.example',
+      message: expect.objectContaining({
+        type: 'read_current_resource:result',
+        requestId: 'req-resource-2',
+        resource: {
+          uri: 'askable://current.txt',
+          name: 'current_context',
+          title: 'Prompt-ready page context',
+          description: 'Approved context from the active page.',
+          mimeType: 'text/plain',
+          text: 'Usage grew 18% selected on the dashboard',
+        },
       }),
     });
   });

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -112,10 +112,28 @@ export type AskableMcpWebHandler = (request: Request) => Promise<Response>;
 export const ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL = 'askable.mcp.page_bridge';
 export const ASKABLE_MCP_PAGE_BRIDGE_VERSION = '0.1';
 export const ASKABLE_MCP_PAGE_BRIDGE_CHANNEL = 'askable:mcp';
+export const ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI = 'askable://current';
 
 export type AskableMcpPageBridgeRequestType =
   | 'get_current_context'
-  | 'format_context_for_prompt';
+  | 'format_context_for_prompt'
+  | 'read_current_resource';
+
+export type AskableMcpPageResourceFormat = 'packet' | 'prompt';
+
+export interface AskableMcpPageResourceOptions {
+  uri?: string;
+  name?: string;
+  title?: string;
+  description?: string;
+  mimeType?: string;
+  format?: AskableMcpPageResourceFormat;
+  includePacket?: boolean;
+}
+
+export interface AskableMcpPageBridgeRequestOptions extends AskableMcpContextOptions {
+  resource?: AskableMcpPageResourceOptions;
+}
 
 export interface AskableMcpPageBridgeRequest {
   protocol: typeof ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL;
@@ -123,7 +141,17 @@ export interface AskableMcpPageBridgeRequest {
   channel?: string;
   type: AskableMcpPageBridgeRequestType;
   requestId: string;
-  options?: AskableMcpContextOptions;
+  options?: AskableMcpPageBridgeRequestOptions;
+}
+
+export interface AskableMcpPageResource {
+  uri: string;
+  name: string;
+  title: string;
+  description?: string;
+  mimeType: string;
+  text: string;
+  packet?: WebContextPacket;
 }
 
 export interface AskableMcpPageBridgeSuccessResponse {
@@ -134,6 +162,7 @@ export interface AskableMcpPageBridgeSuccessResponse {
   requestId: string;
   packet?: WebContextPacket;
   text?: string;
+  resource?: AskableMcpPageResource;
 }
 
 export interface AskableMcpPageBridgeErrorResponse {
@@ -483,21 +512,35 @@ async function handleAskableMcpPageBridgeMessage(
   }
 
   try {
-    const packet = await options.provider.getContext(request.options);
+    const contextOptions = getAskableMcpPageBridgeContextOptions(request.options);
+    const packet = await options.provider.getContext(contextOptions);
     const responseBase = createAskableMcpPageBridgeResponseBase(request);
-    const response: AskableMcpPageBridgeSuccessResponse = request.type === 'format_context_for_prompt'
-      ? {
-          ...responseBase,
-          type: 'format_context_for_prompt:result',
-          text: options.provider.formatContextForPrompt
-            ? await options.provider.formatContextForPrompt(packet, request.options)
-            : defaultPromptFormatter(packet),
-        }
-      : {
-          ...responseBase,
-          type: 'get_current_context:result',
+    let response: AskableMcpPageBridgeSuccessResponse;
+
+    if (request.type === 'format_context_for_prompt') {
+      response = {
+        ...responseBase,
+        type: 'format_context_for_prompt:result',
+        text: await formatAskableMcpContextForPrompt(options.provider, packet, contextOptions),
+      };
+    } else if (request.type === 'read_current_resource') {
+      response = {
+        ...responseBase,
+        type: 'read_current_resource:result',
+        resource: await createAskableMcpCurrentContextPageResource(
+          options.provider,
           packet,
-        };
+          contextOptions,
+          request.options?.resource,
+        ),
+      };
+    } else {
+      response = {
+        ...responseBase,
+        type: 'get_current_context:result',
+        packet,
+      };
+    }
 
     bridgeWindow.postMessage(response, resolveAskableMcpPageBridgeTargetOrigin(event, options));
   } catch (error) {
@@ -518,14 +561,83 @@ function parseAskableMcpPageBridgeRequest(
   if (data.protocol !== ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL) return undefined;
   if (data.version !== ASKABLE_MCP_PAGE_BRIDGE_VERSION) return undefined;
   if ((data.channel ?? ASKABLE_MCP_PAGE_BRIDGE_CHANNEL) !== channel) return undefined;
-  if (data.type !== 'get_current_context' && data.type !== 'format_context_for_prompt') return undefined;
+  if (
+    data.type !== 'get_current_context'
+    && data.type !== 'format_context_for_prompt'
+    && data.type !== 'read_current_resource'
+  ) return undefined;
   if (typeof data.requestId !== 'string' || !data.requestId) return undefined;
   if (data.options !== undefined && !isRecord(data.options)) return undefined;
+  if (!isValidAskableMcpPageBridgeResourceOptions(data.options)) return undefined;
 
   return {
     ...data,
     channel: data.channel ?? ASKABLE_MCP_PAGE_BRIDGE_CHANNEL,
   } as unknown as AskableMcpPageBridgeRequest;
+}
+
+function getAskableMcpPageBridgeContextOptions(
+  options: AskableMcpPageBridgeRequestOptions | undefined,
+): AskableMcpContextOptions | undefined {
+  if (!options) return undefined;
+  const { resource: _resource, ...contextOptions } = options;
+  return contextOptions;
+}
+
+async function formatAskableMcpContextForPrompt(
+  provider: AskableMcpContextProvider,
+  packet: WebContextPacket,
+  options: AskableMcpContextOptions | undefined,
+): Promise<string> {
+  return provider.formatContextForPrompt
+    ? provider.formatContextForPrompt(packet, options)
+    : defaultPromptFormatter(packet);
+}
+
+async function createAskableMcpCurrentContextPageResource(
+  provider: AskableMcpContextProvider,
+  packet: WebContextPacket,
+  contextOptions: AskableMcpContextOptions | undefined,
+  resourceOptions: AskableMcpPageResourceOptions | undefined,
+): Promise<AskableMcpPageResource> {
+  const format = resourceOptions?.format ?? 'packet';
+  const text = format === 'prompt'
+    ? await formatAskableMcpContextForPrompt(provider, packet, contextOptions)
+    : JSON.stringify(packet, null, 2);
+  const mimeType = resourceOptions?.mimeType
+    ?? (format === 'prompt' ? 'text/plain' : 'application/json');
+  const resource: AskableMcpPageResource = {
+    uri: resourceOptions?.uri ?? ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI,
+    name: resourceOptions?.name ?? 'current_context',
+    title: resourceOptions?.title ?? 'Current Askable context',
+    description: resourceOptions?.description ?? 'Approved context from the active page.',
+    mimeType,
+    text,
+  };
+
+  return resourceOptions?.includePacket ? { ...resource, packet } : resource;
+}
+
+function isValidAskableMcpPageBridgeResourceOptions(options: unknown): boolean {
+  if (options === undefined) return true;
+  if (!isRecord(options)) return false;
+  if (options.resource === undefined) return true;
+  if (!isRecord(options.resource)) return false;
+
+  const resource = options.resource;
+  if (resource.uri !== undefined && typeof resource.uri !== 'string') return false;
+  if (resource.name !== undefined && typeof resource.name !== 'string') return false;
+  if (resource.title !== undefined && typeof resource.title !== 'string') return false;
+  if (resource.description !== undefined && typeof resource.description !== 'string') return false;
+  if (resource.mimeType !== undefined && typeof resource.mimeType !== 'string') return false;
+  if (
+    resource.format !== undefined
+    && resource.format !== 'packet'
+    && resource.format !== 'prompt'
+  ) return false;
+  if (resource.includePacket !== undefined && typeof resource.includePacket !== 'boolean') return false;
+
+  return true;
 }
 
 async function isAskableMcpPageBridgeOriginAllowed(

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "React Native bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.13.1"
+    "@askable-ui/core": "^0.14.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.15",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "React bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.13.1"
+    "@askable-ui/core": "^0.14.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Svelte 4 & 5 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.13.1"
+    "@askable-ui/core": "^0.14.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Vue 3 bindings for askable — LLM-aware UI context",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.13.1"
+    "@askable-ui/core": "^0.14.0"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.4.10",

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -256,7 +256,8 @@ or ChatGPT clients. It needs a trusted browser extension or local companion
 process that can receive page context and expose its own local MCP server.
 
 `createAskableMcpPageBridge()` listens for versioned `window.postMessage()`
-requests and returns either the current Context packet or prompt-ready text.
+requests and returns the current Context packet, prompt-ready text, or a
+resource-shaped `askable://current` payload.
 
 ```ts
 import { createAskableMcpContextProvider, createAskableMcpPageBridge } from '@askable-ui/mcp';
@@ -296,10 +297,48 @@ window.postMessage({
 }, window.location.origin);
 ```
 
-Use `type: 'format_context_for_prompt'` to receive prompt-ready text. Responses
-preserve `protocol`, `version`, `channel`, and `requestId`, and return
-`get_current_context:result`, `format_context_for_prompt:result`, or
-`*:error` message types.
+Use `type: 'format_context_for_prompt'` to receive prompt-ready text.
+
+Use `type: 'read_current_resource'` when a browser extension or local companion
+wants a response that can map directly to MCP `resources/read` content:
+
+```ts
+window.postMessage({
+  protocol: 'askable.mcp.page_bridge',
+  version: '0.1',
+  channel: 'askable:mcp',
+  type: 'read_current_resource',
+  requestId: crypto.randomUUID(),
+  options: {
+    sources: ['accounts'],
+    resource: {
+      uri: 'askable://current',
+      format: 'packet',
+    },
+  },
+}, window.location.origin);
+```
+
+The response includes:
+
+```ts
+{
+  type: 'read_current_resource:result',
+  resource: {
+    uri: 'askable://current',
+    name: 'current_context',
+    title: 'Current Askable context',
+    mimeType: 'application/json',
+    text: '{ ...packet json... }'
+  }
+}
+```
+
+Set `resource.format` to `prompt` for `text/plain` prompt context, or pass a
+custom `resource.uri` such as `askable://current.txt`. Responses preserve
+`protocol`, `version`, `channel`, and `requestId`, and return
+`get_current_context:result`, `format_context_for_prompt:result`,
+`read_current_resource:result`, or `*:error` message types.
 
 Enable this bridge only when the user or host app has opted into local browser
 MCP. The extension or companion should own installation trust, user consent,

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.13.1`
-- Versioned current docs URL: `/docs/v0.13.1/`
+- Latest stable: `v0.14.0`
+- Versioned current docs URL: `/docs/v0.14.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.13.1/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.14.0/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -121,6 +121,11 @@ The MCP package does not choose a transport. Use the returned MCP server with
 stdio, Streamable HTTP, or an embedded runtime depending on where context is
 captured.
 
+For browser-local MCP, `createAskableMcpPageBridge()` can also answer
+`read_current_resource` page messages with an `askable://current` resource.
+That gives a trusted extension or local companion a resource-shaped payload it
+can expose through its own local MCP server without scraping the page.
+
 ## Privacy
 
 Packets reflect the same sanitizers as prompt serialization:

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.13.1**.
+> Current npm release: **v0.14.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,10 +1,51 @@
-# What’s New in v0.13.1
+# What’s New in v0.14.0
+
+askable-ui v0.14.0 adds browser-local MCP page resources, so trusted
+extensions and local companions can read approved page context as
+`askable://current` without scraping the DOM.
+
+## Highlights
+
+### Browser-local MCP page resources
+
+`@askable-ui/mcp` now supports `read_current_resource` in
+`createAskableMcpPageBridge()`. The page can answer a versioned
+`window.postMessage()` request with a resource-shaped payload that maps cleanly
+to MCP `resources/read` output.
+
+```ts
+window.postMessage({
+  protocol: 'askable.mcp.page_bridge',
+  version: '0.1',
+  channel: 'askable:mcp',
+  type: 'read_current_resource',
+  requestId: crypto.randomUUID(),
+  options: {
+    sources: ['accounts'],
+    resource: {
+      uri: 'askable://current',
+      format: 'packet',
+    },
+  },
+}, window.location.origin);
+```
+
+Set `resource.format` to `prompt` when the local companion needs `text/plain`
+prompt context instead of packet JSON. Resource options are stripped before the
+context provider runs, so existing providers continue to receive only normal
+context options.
+
+### Website and starter alignment
+
+The main website navigation now uses a compact split-pill header, and the WebMCP
+section calls out `read_current_resource` alongside hosted MCP. New starter apps
+now pin Askable packages to `^0.14.0`.
+
+## Also in v0.13.1
 
 askable-ui v0.13.1 adds production-ready Web MCP support and stronger agent
 request wiring, so approved Claude and ChatGPT clients can request selected UI
 context through a hosted MCP endpoint.
-
-## Highlights
 
 ### Web MCP endpoint support
 
@@ -53,8 +94,8 @@ and query strings.
 `@askable-ui/mcp` also includes `createAskableMcpPageBridge()` for browser-local
 MCP workflows. This is the page-side handoff for trusted extensions or local
 companions: the page answers versioned `window.postMessage()` requests with a
-Context packet or prompt-ready text, while the extension or companion exposes
-the local MCP server.
+Context packet, prompt-ready text, or an `askable://current` resource while the
+extension or companion exposes the local MCP server.
 
 Related docs:
 
@@ -247,8 +288,8 @@ browser tools, and agent runtimes.
 
 ### Starter and docs version alignment
 
-`npm create @askable-ui/app` now scaffolds projects pinned to `^0.13.1`, and the
-versioned docs have been advanced to `/docs/v0.13.1/`.
+`npm create @askable-ui/app` now scaffolds projects pinned to `^0.14.0`, and the
+versioned docs have been advanced to `/docs/v0.14.0/`.
 
 ## Recommended next step
 
@@ -260,7 +301,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.13.1** at both:
+The current published docs track **v0.14.0** at both:
 
 - `/docs/`
-- `/docs/v0.13.1/`
+- `/docs/v0.14.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.13.1**.
+> Current npm release: **v0.14.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,7 +59,14 @@ features:
   </video>
 </div>
 
-## Latest in v0.13.1
+## Latest in v0.14.0
+
+- browser-local MCP page resources with `read_current_resource` and `askable://current`
+- page bridge responses that return resource-shaped JSON or prompt-ready text for local companions
+- starter app dependency pins advanced to `^0.14.0`
+- main website navigation and WebMCP copy aligned with the browser-local MCP flow
+
+## Also in v0.13.1
 
 - remote Web MCP support with `createAskableMcpWebHandler()` for stateless Streamable HTTP endpoints
 - Web MCP production controls for authorization, CORS/preflight, response headers, and sanitized telemetry
@@ -77,7 +84,7 @@ features:
 - agent request packaging with `toAgentRequest()`
 - source-backed live subscriptions with `subscribeAsync()`
 - point-path metadata on lasso Context packets
-- starter app dependency pins advanced to `^0.13.1`
+- starter app dependency pins advanced to `^0.14.0`
 - continued support for region/circle/text capture, MCP Context packets, and framework wrappers
 
 ## Interaction patterns
@@ -98,7 +105,7 @@ Every pattern can produce a prompt string with `toPromptContext()` or a structur
 
 Start here:
 
-- [What’s New in v0.13.1](/guide/whats-new)
+- [What’s New in v0.14.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [React interaction patterns](/guide/react#region-circle-and-lasso-capture)
 - [AI SDK integration patterns](/examples/ai-sdk)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.13.1",
-    "slug": "v0.13.1"
+    "label": "v0.14.0",
+    "slug": "v0.14.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.13.1`) is built on every deploy and published to both:
+The current release (`v0.14.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.13.1/` (version-specific URL)
+- `/docs/v0.14.0/` (version-specific URL)
 
 ## How it works
 

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -1312,10 +1312,13 @@ ctx.push(meta, text);</pre>
           </article>
           <article class="mcp-card">
             <h4>Page resources</h4>
-            <p>Askable can provide the selected element, lassoed region, highlighted text, viewport, or app-owned source as a resource or tool result.</p>
-            <pre>resource: "askable://current"
-text: ctx.toPromptContext()
-packet: ctx.toContextPacket()</pre>
+            <p>Askable can provide the selected element, lassoed region, highlighted text, viewport, or app-owned source as an <code>askable://current</code> page resource.</p>
+            <pre>window.postMessage({
+  type: "read_current_resource",
+  options: {
+    resource: { uri: "askable://current" }
+  }
+});</pre>
           </article>
           <article class="mcp-card">
             <h4>Hosted MCP</h4>

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -59,17 +59,19 @@
 
     /* NAV */
     nav {
-      position: sticky;
+      position: fixed;
       top: 1.25rem;
+      left: 50%;
+      transform: translateX(-50%);
       z-index: 40;
-      width: min(calc(100% - 2rem), 1280px);
+      width: min(calc(100% - 2.5rem), 1280px);
       height: auto;
-      min-height: 3rem;
-      margin: 1.25rem auto 0;
+      min-height: 2.8rem;
+      margin: 0 auto;
       display: flex;
       justify-content: space-between;
       align-items: center;
-      gap: 1rem;
+      gap: 1.25rem;
       padding: 0;
       background: transparent;
       border: 0;
@@ -77,58 +79,72 @@
     .nav-logo {
       display: inline-flex;
       align-items: center;
-      gap: .45rem;
-      min-height: 2.8rem;
-      padding: 0 .95rem;
+      gap: .58rem;
+      min-height: 2.65rem;
+      padding: .22rem .75rem .22rem .28rem;
       border: 1px solid rgba(0,0,0,0.07);
       border-radius: var(--radius-pill);
-      background: rgba(255,255,255,0.9);
-      box-shadow: 0 12px 34px rgba(15,23,42,0.1);
-      backdrop-filter: blur(16px) saturate(1.25);
-      font-size: 1.05rem;
+      background: rgba(255,255,255,0.86);
+      box-shadow: 0 8px 24px rgba(17,19,23,0.12);
+      backdrop-filter: blur(18px) saturate(1.18);
+      font-size: .96rem;
       font-weight: 800;
       color: var(--ink);
       text-decoration: none;
-      letter-spacing: -.04em;
+      letter-spacing: -.035em;
+      white-space: nowrap;
     }
-    .nav-logo .spark { color: var(--accent); }
+    .nav-mark {
+      display: inline-grid;
+      place-items: center;
+      width: 2.08rem;
+      height: 2.08rem;
+      border-radius: 12px;
+      background: #111317;
+      color: #fff;
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.12);
+      font-size: .98rem;
+      line-height: 1;
+    }
+    .nav-logo .spark { color: inherit; }
     .nav-links {
       display: flex;
       align-items: center;
-      gap: .35rem;
-      min-height: 3rem;
-      padding: .32rem .38rem;
+      gap: .28rem;
+      min-height: 2.8rem;
+      padding: .26rem .3rem .26rem .72rem;
       border: 1px solid rgba(0,0,0,0.07);
       border-radius: var(--radius-pill);
-      background: rgba(255,255,255,0.9);
-      box-shadow: 0 12px 34px rgba(15,23,42,0.1);
-      backdrop-filter: blur(16px) saturate(1.25);
+      background: rgba(255,255,255,0.88);
+      box-shadow: 0 8px 24px rgba(17,19,23,0.12);
+      backdrop-filter: blur(18px) saturate(1.18);
     }
     .nav-link {
       text-decoration: none;
-      color: var(--ink-2);
-      font-size: .84rem;
+      color: #2f333a;
+      font-size: .82rem;
       font-weight: 600;
-      padding: .5rem .78rem;
+      padding: .47rem .72rem;
       border-radius: var(--radius-pill);
-      transition: color .15s, background .15s;
+      transition: color .16s, background .16s, transform .16s;
     }
-    .nav-link:hover { color: var(--ink); background: rgba(0,0,0,0.04); }
+    .nav-link:hover { color: var(--ink); background: rgba(0,0,0,0.045); transform: translateY(-1px); }
     .nav-gh {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 2.05rem;
-      height: 2.05rem;
+      width: 2.25rem;
+      height: 2.25rem;
       padding: 0;
       border-radius: var(--radius-pill);
       background: var(--ink);
       color: #fff;
       text-decoration: none;
-      margin-left: .15rem;
-      transition: opacity .15s;
+      margin-left: .22rem;
+      box-shadow: 0 4px 12px rgba(17,19,23,0.2);
+      transition: opacity .15s, transform .15s;
     }
-    .nav-gh:hover { opacity: .82; }
+    .nav-gh:hover { opacity: .86; transform: translateY(-1px); }
     .github-icon {
       width: 1.05rem;
       height: 1.05rem;
@@ -741,14 +757,15 @@
     @media (max-width: 720px) {
       nav {
         top: .75rem;
-        width: min(calc(100% - 1.5rem), 1280px);
-        min-height: 2.8rem;
-        margin-top: .75rem;
+        width: min(calc(100% - 1.25rem), 1280px);
+        min-height: 2.7rem;
         padding: 0;
+        gap: .65rem;
       }
-      .nav-logo { min-height: 2.6rem; padding: 0 .8rem; }
-      .nav-links { min-height: 2.6rem; padding: .24rem; }
-      .nav-gh { width: 2.05rem; height: 2.05rem; margin-left: 0; }
+      .nav-logo { min-height: 2.55rem; padding: .2rem .68rem .2rem .26rem; }
+      .nav-mark { width: 2rem; height: 2rem; border-radius: 11px; }
+      .nav-links { min-height: 2.55rem; padding: .22rem; }
+      .nav-gh { width: 2.08rem; height: 2.08rem; margin-left: 0; }
       .nav-link { display: none; }
       .page-shell { padding: 0 1rem 4rem; }
       .hero { padding-top: 3.5rem; }
@@ -818,14 +835,13 @@
 <body>
   <canvas id="field-canvas" aria-hidden="true"></canvas>
 
-  <nav>
-    <a href="#" class="nav-logo"><span class="spark">✦</span> askable-ui</a>
+  <nav aria-label="Primary navigation">
+    <a href="#" class="nav-logo"><span class="nav-mark"><span class="spark">✦</span></span> askable-ui</a>
     <div class="nav-links">
       <a href="#demo" class="nav-link">Demo</a>
       <a href="#patterns" class="nav-link">Patterns</a>
-      <a href="#how" class="nav-link">How it works</a>
+      <a href="#integrations" class="nav-link">MCP</a>
       <a href="#packages" class="nav-link">Packages</a>
-      <a href="#integrations" class="nav-link">Integrations</a>
       <a href="https://askable-ui.com/docs/" target="_blank" rel="noopener noreferrer" class="nav-link">Docs</a>
       <a href="https://github.com/askable-ui/askable" target="_blank" rel="noopener noreferrer" class="nav-gh" aria-label="GitHub repository" title="GitHub repository">
         <svg class="github-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">


### PR DESCRIPTION
## Summary
- add `read_current_resource` to the browser-local MCP page bridge
- return `askable://current` resource payloads as packet JSON or prompt-ready text
- align MCP docs, website WebMCP copy, and current release metadata
- refine the main website navigation in a separate scoped commit

## Verification
- `npm run build --workspaces --if-present`
- `npm run test --workspaces --if-present`
- `npm run build --prefix site/docs`
- `git diff --check`
- local website render check at 1440x900 and 390x844