### PR TITLE
feat: README rewrite, MCP section, vanilla/Vue demos + security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npm install @askable-ui/react
 ```
 
 ```tsx
-import { Askable, useAskable } from '@askable/react';
+import { Askable, useAskable } from '@askable-ui/react';
 
 function Dashboard({ metrics }) {
   const { promptContext } = useAskable();
@@ -412,7 +412,10 @@ Or open [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html)
 
 - **Docs:** [askable-ui.com/docs](https://askable-ui.com/docs/)
 - **Analytics dashboard demo:** [askable-mu.vercel.app](https://askable-mu.vercel.app/)
-- **Zero-install demo:** [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html)
+- **Zero-install vanilla demo:** [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html) — open directly in browser, no install
+- **Vue 3 example:** [`examples/vue-dashboard/`](./examples/vue-dashboard/) — `npm install && npm run dev`
+- **React + Next.js example:** [`examples/analytics-dashboard-react/`](./examples/analytics-dashboard-react/)
+- **React Native example:** [`examples/react-native-expo/`](./examples/react-native-expo/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">askable-ui</h1>
 
 <p align="center">
-  <strong>Two lines of code to give your LLM eyes.</strong><br />
-  One attribute. Zero prompt engineering. It knows exactly what the user sees.
+  <strong>Your LLM doesn't know what the user is looking at. Fix that in two lines.</strong><br />
+  One attribute. Real-time UI context. Works with every LLM SDK and MCP client.
 </p>
 
 <p align="center">
@@ -16,7 +16,6 @@
   <a href="https://www.npmjs.com/package/@askable-ui/core">
     <img src="https://img.shields.io/npm/dw/@askable-ui/core?color=4f46e5&label=downloads" alt="npm downloads" />
   </a>
-
   <a href="./LICENSE">
     <img src="https://img.shields.io/npm/l/@askable-ui/core?color=4f46e5" alt="MIT license" />
   </a>
@@ -31,16 +30,60 @@
 </p>
 
 <p align="center">
-  <a href="#quick-start">Quick Start</a> &nbsp;·&nbsp;
-  <a href="#why">Why</a> &nbsp;·&nbsp;
+  <a href="#what-the-ai-receives">What the AI receives</a> &nbsp;·&nbsp;
+  <a href="#quick-start">Quick start</a> &nbsp;·&nbsp;
+  <a href="#mcp-claude-desktop--cursor">MCP</a> &nbsp;·&nbsp;
   <a href="#how-it-works">How it works</a> &nbsp;·&nbsp;
-  <a href="#works-with">Works with</a> &nbsp;·&nbsp;
-  <a href="#features">Features</a> &nbsp;·&nbsp;
+  <a href="#capture-modes">Capture modes</a> &nbsp;·&nbsp;
   <a href="#packages">Packages</a> &nbsp;·&nbsp;
   <a href="https://askable-ui.com/docs/">Docs</a> &nbsp;·&nbsp;
-  <a href="https://askable-ui.com/docs/guide/agents">Agent Templates</a> &nbsp;·&nbsp;
   <a href="https://askable-mu.vercel.app/">Live Demo</a>
 </p>
+
+---
+
+## What the AI receives
+
+When a user clicks a KPI card in your dashboard, the AI gets this — automatically, with no extra code:
+
+```
+User is focused on: metric=net revenue retention, value=118%, delta=+6pp QoQ
+Page: Analytics Dashboard · Q3 2024
+Visible: pipeline coverage 3.9x, support backlog 24 tickets (−31%)
+History: support backlog → pipeline coverage → net revenue retention
+```
+
+Not a screenshot. Not a stale system prompt. The real data the user sees, updated on every interaction.
+
+---
+
+## The problem it solves
+
+**Before askable-ui** — you write this (and update it every time the UI changes):
+
+```ts
+const system = `You are an analytics assistant. The dashboard shows:
+  - Revenue KPI (updates monthly from Salesforce)
+  - Pipeline coverage metric (target: 3.5x)
+  - Support backlog counter (SLA: < 50 tickets)
+  - Deal pipeline table (12 open deals)
+  The user might be looking at any of these.`
+
+// User: "explain this"
+// AI: "Could you clarify which metric you're referring to?"
+```
+
+**With askable-ui** — annotate once, the AI always knows:
+
+```tsx
+<Askable meta={{ metric: 'net revenue retention', value: '118%', delta: '+6pp' }}>
+  <NRRCard data={data} />
+</Askable>
+
+// User: "explain this"
+// AI: "NRR at 118% means your existing customers are spending 18% more than last period.
+//       The +6pp trend indicates your recent expansion motion is working..."
+```
 
 ---
 
@@ -51,48 +94,79 @@ npm install @askable-ui/react
 ```
 
 ```tsx
-import { Askable, useAskable } from '@askable-ui/react';
+import { Askable, useAskable } from '@askable/react';
 
-function Dashboard({ kpi }) {
+function Dashboard({ metrics }) {
   const { promptContext } = useAskable();
-  // promptContext: "User is focused on: metric=revenue, value=$2.3M, delta=+12%"
 
   return (
-    <Askable meta={{ metric: kpi.name, value: kpi.value, delta: kpi.delta }}>
-      <KPICard data={kpi} />
-    </Askable>
+    <>
+      {metrics.map(m => (
+        <Askable key={m.id} meta={{ metric: m.name, value: m.value, delta: m.delta }}>
+          <MetricCard data={m} />
+        </Askable>
+      ))}
+
+      {/* promptContext updates automatically as the user interacts */}
+      <AIChat systemPrompt={`You are a helpful assistant.\n\n${promptContext}`} />
+    </>
   );
 }
 ```
 
-That's it. `promptContext` updates automatically as the user interacts. Pass it to any LLM.
+`promptContext` is a plain string. Pass it to any LLM.
 
-Need a runnable starter app with Askable and CopilotKit?
+**Need a full runnable app?**
 
 ```bash
 npm create @askable-ui/app my-app
-cd my-app
-npm install
-npm run dev
+cd my-app && npm install && npm run dev
 ```
 
+React + Vite + CopilotKit, wired up and ready to go.
 
 ---
 
-## Why
+## MCP — Claude Desktop, Cursor, and any MCP client
 
-AI copilots ask users to _describe_ what they're looking at.
-That's friction — and it's imprecise.
+Expose your app's live UI context as an MCP server. Any agent that connects can ask what the user currently sees.
 
-askable-ui solves this with one HTML attribute. Mark any element with `data-askable`, and the library tracks user focus and serializes it into a prompt-ready string. The model gets the user's exact visual context — not a guess, the real thing.
+```bash
+npm install @askable-ui/mcp
+```
 
-No page scraping. No DOM serialization. No prompt bloat. **Lightweight and zero-dependency.**
+```ts
+import { createAskableMcpServer, createAskableMcpContextProvider } from '@askable-ui/mcp';
+
+const server = createAskableMcpServer({
+  provider: createAskableMcpContextProvider(ctx),
+});
+
+server.connect(transport);
+```
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "node",
+      "args": ["path/to/your/mcp-server.js"]
+    }
+  }
+}
+```
+
+Claude Desktop can now call `get_current_context` and `format_context_for_prompt` — it sees exactly what your user sees, without screenshots or manual description.
+
+→ **[MCP integration guide](https://askable-ui.com/docs/guide/mcp)**
 
 ---
 
 ## How it works
 
-**1. Annotate** — same data that renders your chart feeds the AI
+**1. Annotate** — your existing data, on your existing elements
 
 ```tsx
 <Askable meta={{ metric: 'revenue', value: '$2.3M', delta: '+12%', period: 'Q3' }}>
@@ -100,27 +174,76 @@ No page scraping. No DOM serialization. No prompt bloat. **Lightweight and zero-
 </Askable>
 ```
 
-**2. Observe** — automatic, zero config
+**2. Observe** — zero config, one call
 
 ```tsx
-const { ctx, promptContext } = useAskable();
-// promptContext updates whenever the user clicks, hovers, or focuses
-
-const { ctx: tableCtx } = useAskable({ name: 'table' });
-const { ctx: chartCtx } = useAskable({ name: 'chart' });
-// named contexts stay isolated for multi-region pages
-
-const { ctx: screenCtx } = useAskable({ viewport: true });
-// screenCtx.toViewportContext() serializes currently visible annotated elements
+const { promptContext } = useAskable();
+// Updates on click, hover, focus — any user interaction
 ```
 
-**3. Inject** — at the AI boundary, one line
+**3. Inject** — at the LLM boundary
 
 ```ts
+// Vercel AI SDK
 const result = await streamText({
   model: openai('gpt-4o'),
-  system: `You are a helpful analytics assistant.\n\n${promptContext}`,
+  system: `You are a helpful assistant.\n\n${promptContext}`,
   messages,
+});
+
+// Anthropic SDK
+const msg = await anthropic.messages.create({
+  model: 'claude-opus-4-8',
+  system: `You are a helpful assistant.\n\n${promptContext}`,
+  messages,
+});
+
+// CopilotKit
+useCopilotReadable({ description: 'UI context', value: promptContext }, [promptContext]);
+```
+
+---
+
+## Capture modes
+
+Beyond passive focus tracking, askable-ui has explicit capture tools that let users point the AI at exactly what they mean.
+
+### Region & lasso capture
+
+The user draws a rectangle, circle, or freehand lasso. The AI receives the context of every annotated element inside that selection.
+
+```tsx
+const regionCapture = useAskableRegionCapture({
+  onCapture(packet, selection) {
+    sendToAI(JSON.stringify(packet));
+  },
+});
+
+<button onClick={() => regionCapture.start({ shape: 'lasso' })}>
+  Circle it for the AI
+</button>
+```
+
+### Text selection capture
+
+The user highlights any text on the page. The AI receives the selection with its surrounding context.
+
+```tsx
+const textCapture = useAskableTextSelectionCapture({
+  onCapture(packet) {
+    sendToAI(JSON.stringify(packet));
+  },
+});
+```
+
+### Scroll & viewport context
+
+For infinite lists and dashboards — track which item the user is currently reading.
+
+```tsx
+const { scrollCtx } = useAskableScrollView({
+  selectVisible: (items) => items[0], // top visible item
+  getMeta: (item) => ({ id: item.id, title: item.title }),
 });
 ```
 
@@ -128,73 +251,33 @@ const result = await streamText({
 
 ## Works with
 
-**LLM SDKs** — OpenAI · Anthropic · Vercel AI SDK · CopilotKit · LangChain · any SDK
+**LLM SDKs**
 
-**Frameworks** — React · Vue 3 · Svelte · Vanilla JS · Next.js · Nuxt · SvelteKit
+| SDK | Integration |
+|---|---|
+| [Vercel AI SDK](https://sdk.vercel.ai/) | Pass `promptContext` to `system` in `streamText` / `generateText` |
+| [CopilotKit](https://copilotkit.ai/) | `useCopilotReadable({ value: promptContext })` |
+| [Anthropic SDK](https://github.com/anthropic-ai/sdk-python) | Pass `promptContext` to `system` in `messages.create` |
+| [OpenAI SDK](https://github.com/openai/openai-node) | Pass `promptContext` to the system message |
+| [LangChain.js](https://js.langchain.com/) | Inject via `SystemMessage` |
+| Any MCP client | Use `@askable-ui/mcp` to expose as MCP tools |
 
-askable-ui is the context layer. It doesn't replace your LLM SDK — it gives it eyes.
+**Frameworks**
 
----
-
-## Features
-
-- **Zero config** — one attribute, works with any DOM structure, styling system, or component library
-- **React, Vue, Svelte** — idiomatic hooks and components; core is framework-agnostic
-- **SSR safe** — defers to client lifecycle, no `window is not defined`
-- **"Ask AI" button** — `ctx.select(element)` pins focus to any element programmatically
-- **Conversation history** — `ctx.toHistoryContext(n)` for multi-turn context
-- **Viewport awareness** — `ctx.getVisibleElements()` / `ctx.toViewportContext()` for on-screen context
-- **Structured Context packets** — `ctx.toContextPacket()` for agent/MCP-ready page context
-- **Explicit capture tools** — region, circle, lasso, and highlighted text capture for user-selected context
-- **Redaction hooks** — strip sensitive fields before data reaches serialization
-- **Inspector panel** — `<AskableInspector />` or `useAskable({ inspector: true })` for a live dev overlay
-- **Agent templates** — reusable `AGENTS.md` guidance and copy-paste prompts for coding-agent-driven adoption
-- **Lightweight core** — zero runtime dependencies
-
----
-
-## Packages
-
-| Package | Version | Use when |
+| | Package | |
 |---|---|---|
-| [`@askable-ui/core`](https://www.npmjs.com/package/@askable-ui/core) | [![npm](https://img.shields.io/npm/v/@askable-ui/core?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/core) | Vanilla JS, custom framework, or as a peer dep |
-| [`@askable-ui/context`](https://www.npmjs.com/package/@askable-ui/context) | [![npm](https://img.shields.io/npm/v/@askable-ui/context?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/context) | Shared Context packet types, schema, and validators |
-| [`@askable-ui/react`](https://www.npmjs.com/package/@askable-ui/react) | [![npm](https://img.shields.io/npm/v/@askable-ui/react?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/react) | React 18+ |
-| [`@askable-ui/react-native`](https://www.npmjs.com/package/@askable-ui/react-native) | [![npm](https://img.shields.io/npm/v/@askable-ui/react-native?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/react-native) | React Native (initial press-driven adapter) |
-| [`@askable-ui/vue`](https://www.npmjs.com/package/@askable-ui/vue) | [![npm](https://img.shields.io/npm/v/@askable-ui/vue?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/vue) | Vue 3 |
-| [`@askable-ui/svelte`](https://www.npmjs.com/package/@askable-ui/svelte) | [![npm](https://img.shields.io/npm/v/@askable-ui/svelte?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/svelte) | Svelte 4 & 5 |
-| [`@askable-ui/mcp`](https://www.npmjs.com/package/@askable-ui/mcp) | [![npm](https://img.shields.io/npm/v/@askable-ui/mcp?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/mcp) | MCP bridge for exposing Context packets to agents |
-| [`@askable-ui/create-app`](https://www.npmjs.com/package/@askable-ui/create-app) | [![npm](https://img.shields.io/npm/v/@askable-ui/create-app?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/create-app) | React + Vite + CopilotKit starter scaffold |
+| React 18+ | `@askable-ui/react` | `useAskable()`, `<Askable>`, `useAskableRegionCapture()` |
+| Vue 3 | `@askable-ui/vue` | `useAskable()`, `<Askable>`, composables |
+| Svelte 4 & 5 | `@askable-ui/svelte` | `createAskableStore()`, `<Askable>` |
+| React Native | `@askable-ui/react-native` | `useAskable()`, `<Askable>`, scroll view adapter |
+| Vanilla JS | `@askable-ui/core` | `createAskableContext()`, zero dependencies |
+
+---
+
+## Framework quick starts
 
 <details>
-<summary><strong>Framework quick starts</strong></summary>
-
-### React Native
-
-```bash
-npm install @askable-ui/react-native
-```
-
-```tsx
-import { Pressable, Text } from 'react-native';
-import { Askable, useAskable } from '@askable-ui/react-native';
-
-function RevenueCard() {
-  const { ctx, promptContext } = useAskable();
-
-  return (
-    <Askable ctx={ctx} meta={{ widget: 'revenue' }} text="Revenue card">
-      <Pressable>
-        <Text>Revenue</Text>
-      </Pressable>
-    </Askable>
-  );
-}
-```
-
-For a runnable mobile demo, see [`examples/react-native-expo`](./examples/react-native-expo).
-
-### Vue 3
+<summary><strong>Vue 3</strong></summary>
 
 ```bash
 npm install @askable-ui/vue
@@ -208,13 +291,16 @@ const props = defineProps(['kpi']);
 </script>
 
 <template>
-  <Askable :meta="{ metric: kpi.name, value: kpi.value }">
+  <Askable :meta="{ metric: kpi.name, value: kpi.value, delta: kpi.delta }">
     <KPICard :data="kpi" />
   </Askable>
 </template>
 ```
 
-### Svelte
+</details>
+
+<details>
+<summary><strong>Svelte 4 & 5</strong></summary>
 
 ```bash
 npm install @askable-ui/svelte
@@ -227,12 +313,42 @@ npm install @askable-ui/svelte
   export let kpi;
 </script>
 
-<Askable meta={{ metric: kpi.name, value: kpi.value }}>
+<Askable meta={{ metric: kpi.name, value: kpi.value, delta: kpi.delta }}>
   <KPICard data={kpi} />
 </Askable>
 ```
 
-### Vanilla JS
+</details>
+
+<details>
+<summary><strong>React Native</strong></summary>
+
+```bash
+npm install @askable-ui/react-native
+```
+
+```tsx
+import { Askable, useAskable } from '@askable-ui/react-native';
+
+function RevenueCard({ data }) {
+  const { promptContext } = useAskable();
+
+  return (
+    <Askable meta={{ metric: 'revenue', value: data.value }}>
+      <Pressable>
+        <Text>{data.value}</Text>
+      </Pressable>
+    </Askable>
+  );
+}
+```
+
+See [`examples/react-native-expo`](./examples/react-native-expo) for a full runnable app.
+
+</details>
+
+<details>
+<summary><strong>Vanilla JS</strong></summary>
 
 ```bash
 npm install @askable-ui/core
@@ -245,12 +361,50 @@ const ctx = createAskableContext();
 ctx.observe(document.body);
 
 ctx.on('focus', () => {
-  console.log(ctx.toPromptContext());
-  // "User is focused on: — metric: revenue, value: $2.3M"
+  const context = ctx.toContext();
+  // "User is focused on: metric=revenue, value=$2.3M"
+  fetch('/api/chat', {
+    method: 'POST',
+    body: JSON.stringify({ context, message: userMessage }),
+  });
 });
 ```
 
+Or open [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html) directly in a browser — zero build step, zero install, works offline.
+
 </details>
+
+---
+
+## Packages
+
+| Package | Version | Description |
+|---|---|---|
+| [`@askable-ui/core`](https://www.npmjs.com/package/@askable-ui/core) | [![npm](https://img.shields.io/npm/v/@askable-ui/core?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/core) | Framework-agnostic core. Zero runtime deps. |
+| [`@askable-ui/context`](https://www.npmjs.com/package/@askable-ui/context) | [![npm](https://img.shields.io/npm/v/@askable-ui/context?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/context) | Context packet types, schema, validators |
+| [`@askable-ui/react`](https://www.npmjs.com/package/@askable-ui/react) | [![npm](https://img.shields.io/npm/v/@askable-ui/react?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/react) | React 18+ hooks and components |
+| [`@askable-ui/vue`](https://www.npmjs.com/package/@askable-ui/vue) | [![npm](https://img.shields.io/npm/v/@askable-ui/vue?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/vue) | Vue 3 composables and components |
+| [`@askable-ui/svelte`](https://www.npmjs.com/package/@askable-ui/svelte) | [![npm](https://img.shields.io/npm/v/@askable-ui/svelte?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/svelte) | Svelte 4 & 5 stores and components |
+| [`@askable-ui/react-native`](https://www.npmjs.com/package/@askable-ui/react-native) | [![npm](https://img.shields.io/npm/v/@askable-ui/react-native?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/react-native) | React Native adapter |
+| [`@askable-ui/mcp`](https://www.npmjs.com/package/@askable-ui/mcp) | [![npm](https://img.shields.io/npm/v/@askable-ui/mcp?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/mcp) | MCP server — expose UI context to Claude, Cursor, etc. |
+| [`create-@askable-ui/app`](https://www.npmjs.com/package/@askable-ui/create-app) | [![npm](https://img.shields.io/npm/v/@askable-ui/create-app?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/create-app) | Starter scaffold: React + Vite + CopilotKit |
+
+---
+
+## Features
+
+- **Zero config** — one attribute, works with any DOM structure or component library
+- **Real-time updates** — context refreshes on click, hover, focus, scroll — any interaction
+- **Structured packets** — `ctx.toContextPacket()` emits typed, validated JSON for agent pipelines
+- **Conversation history** — `ctx.toHistoryContext(n)` for multi-turn awareness
+- **Viewport awareness** — `ctx.toViewportContext()` serializes all currently visible annotated elements
+- **Named contexts** — isolate `table`, `chart`, and `form` contexts independently on the same page
+- **Explicit capture** — region, circle, lasso, and text-selection capture for user-directed AI
+- **Privacy & redaction** — strip sensitive fields before data leaves the page
+- **MCP bridge** — expose any context as `get_current_context` and `format_context_for_prompt` MCP tools
+- **Dev inspector** — `<AskableInspector />` overlay showing live context packets and source data
+- **SSR safe** — defers to client lifecycle, no `window is not defined`
+- **Zero runtime dependencies** in core
 
 ---
 
@@ -258,32 +412,21 @@ ctx.on('focus', () => {
 
 - **Docs:** [askable-ui.com/docs](https://askable-ui.com/docs/)
 - **Analytics dashboard demo:** [askable-mu.vercel.app](https://askable-mu.vercel.app/)
-
----
-
-## Documentation
-
-**[askable-ui.com/docs](https://askable-ui.com/docs/)**
-
-| Guide | |
-|---|---|
-| [Getting started](https://askable-ui.com/docs/guide/getting-started) | Install, observe, inject |
-| [Annotating elements](https://askable-ui.com/docs/guide/annotating) | `data-askable`, nesting, priority |
-| [React](https://askable-ui.com/docs/guide/react) · [Vue](https://askable-ui.com/docs/guide/vue) · [Svelte](https://askable-ui.com/docs/guide/svelte) | Framework guides |
-| [CopilotKit integration](https://askable-ui.com/docs/guide/copilotkit) | Context-in-input pattern |
-| [API reference](https://askable-ui.com/docs/api/core) | Full type docs |
+- **Zero-install demo:** [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html)
 
 ---
 
 ## Using with coding agents
 
-[`AGENTS.md`](./AGENTS.md) contains copy-pasteable instructions for Claude, Cursor, Codex, and similar tools. Drop it into your project root and your coding agent will know how to integrate `askable-ui` correctly — annotation patterns, passive vs explicit flows, sanitization, and common mistakes.
+[`AGENTS.md`](./AGENTS.md) has copy-pasteable instructions for Claude, Cursor, Codex, and similar tools. Drop it into your project root and your coding agent will annotate elements correctly, avoid common mistakes, and wire up the full context pipeline.
 
 ---
 
 ## Contributing
 
-PRs welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions.
+PRs welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+The easiest contribution: a framework adapter. If you use Angular, Solid, Qwik, or HTMX, the adapter pattern is nearly mechanical — see any of the existing framework packages as a template and open an issue to claim it.
 
 ## License
 

--- a/examples/svelte-dashboard/README.md
+++ b/examples/svelte-dashboard/README.md
@@ -1,0 +1,105 @@
+# askable-ui — Svelte 5 Dashboard Example
+
+An analytics dashboard built with **Svelte 5 runes** and **askable-ui**, showing how your AI assistant can see exactly which metric or deal the user is looking at.
+
+## What this shows
+
+1. Click any KPI card or deal row — `askable-ui` captures that element's structured metadata
+2. The **"What the AI sees"** panel updates in real time with `askable.promptContext`
+3. The mock chat uses that context string to give accurate, element-aware answers
+
+## Quick start
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173).
+
+## Svelte 5 runes API
+
+```svelte
+<script lang="ts">
+  import { useAskable } from '@askable-ui/svelte/useAskable.svelte';
+  import Askable5 from '@askable-ui/svelte/Askable5.svelte';
+
+  const askable = useAskable({ observe: true });
+</script>
+
+<!-- Wrap any element with structured metadata -->
+<Askable5 meta={{ metric: 'nrr', value: 118 }}>
+  <button onclick={(e) => askable.ctx.select(e.currentTarget)}>
+    NRR: 118%
+  </button>
+</Askable5>
+
+<!-- Read the live context string anywhere -->
+<pre>{askable.promptContext}</pre>
+```
+
+## Wiring a real LLM
+
+Replace the mock `sendMessage` function in `App.svelte` with a real API call:
+
+```typescript
+async function sendMessage() {
+  const text = chatInput.trim();
+  if (!text) return;
+  chatInput = '';
+  chatMessages = [...chatMessages, { role: 'user', text }];
+
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      messages: [
+        {
+          role: 'system',
+          content: `You are a helpful AI assistant. Current UI context:\n\n${askable.promptContext}`,
+        },
+        { role: 'user', content: text },
+      ],
+    }),
+  });
+
+  const { reply } = await res.json();
+  chatMessages = [...chatMessages, { role: 'ai', text: reply }];
+}
+```
+
+Server-side (Node/Express):
+
+```javascript
+import OpenAI from 'openai';
+const openai = new OpenAI();
+
+app.post('/api/chat', async (req, res) => {
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: req.body.messages,
+  });
+  res.json({ reply: completion.choices[0].message.content });
+});
+```
+
+## Svelte 4 (store-based) alternative
+
+If you're on Svelte 4, use the store API instead:
+
+```svelte
+<script lang="ts">
+  import { createAskableStore } from '@askable-ui/svelte';
+  import Askable from '@askable-ui/svelte/Askable.svelte';
+
+  const store = createAskableStore({ observe: true });
+</script>
+
+<Askable meta={{ metric: 'nrr', value: 118 }}>
+  <button on:click={(e) => store.ctx.select(e.currentTarget)}>
+    NRR: 118%
+  </button>
+</Askable>
+
+<pre>{$store.promptContext}</pre>
+```

--- a/examples/svelte-dashboard/index.html
+++ b/examples/svelte-dashboard/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>askable-ui Svelte 5 Dashboard</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/svelte-dashboard/package.json
+++ b/examples/svelte-dashboard/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "svelte-dashboard-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "askable-ui Svelte 5 example — analytics dashboard with live AI context",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@askable-ui/svelte": "^0.14.0",
+    "svelte": "^5.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/svelte-dashboard/src/App.svelte
+++ b/examples/svelte-dashboard/src/App.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  import { useAskable } from '@askable-ui/svelte/useAskable.svelte';
+  import Askable5 from '@askable-ui/svelte/Askable5.svelte';
+
+  // --- Data ---
+  const metrics = [
+    {
+      id: 'nrr',
+      label: 'Net Revenue Retention',
+      value: '118%',
+      delta: '+4pp vs last quarter',
+      positive: true,
+      meta: { metric: 'nrr', value: 118, unit: 'percent', benchmark: 110 },
+    },
+    {
+      id: 'pipeline',
+      label: 'Pipeline Coverage',
+      value: '$4.2M',
+      delta: '3.1× quota',
+      positive: true,
+      meta: { metric: 'pipeline', value: 4200000, unit: 'usd', multiplier: 3.1 },
+    },
+    {
+      id: 'backlog',
+      label: 'Support Backlog',
+      value: '47',
+      delta: '+12 vs last week',
+      positive: false,
+      meta: { metric: 'backlog', value: 47, unit: 'tickets', weekDelta: 12 },
+    },
+  ];
+
+  const deals = [
+    { id: 'd1', company: 'Acme Corp', stage: 'Proposal', value: '$85,000', owner: 'Sara K.', risk: 'low' },
+    { id: 'd2', company: 'Globex Inc', stage: 'Negotiation', value: '$210,000', owner: 'Tom R.', risk: 'medium' },
+    { id: 'd3', company: 'Initech', stage: 'Discovery', value: '$42,000', owner: 'Amy J.', risk: 'high' },
+    { id: 'd4', company: 'Umbrella Ltd', stage: 'Closed Won', value: '$130,000', owner: 'Dan W.', risk: 'low' },
+  ];
+
+  const riskColor: Record<string, string> = {
+    low: '#16a34a',
+    medium: '#d97706',
+    high: '#dc2626',
+  };
+
+  // --- Askable ---
+  const askable = useAskable({ observe: true });
+
+  let activeId: string | null = $state(null);
+  let chatMessages: { role: 'user' | 'ai'; text: string }[] = $state([
+    { role: 'ai', text: 'Hello! Click any metric or deal row then ask me about it.' },
+  ]);
+  let chatInput = $state('');
+  let sending = $state(false);
+
+  function focusEl(el: EventTarget | null, id: string) {
+    if (el instanceof HTMLElement) {
+      askable.ctx.select(el);
+      activeId = id;
+    }
+  }
+
+  function clearFocus() {
+    askable.ctx.clear();
+    activeId = null;
+  }
+
+  function copyContext() {
+    navigator.clipboard.writeText(askable.promptContext ?? '').catch(() => undefined);
+  }
+
+  async function sendMessage() {
+    const text = chatInput.trim();
+    if (!text || sending) return;
+    chatInput = '';
+    chatMessages = [...chatMessages, { role: 'user', text }];
+    sending = true;
+
+    // Mock AI response using the actual context
+    await new Promise<void>((r) => setTimeout(r, 700));
+    const ctx = askable.promptContext;
+    let reply = "I don't see anything focused — click a metric or deal row first.";
+    if (ctx) {
+      if (text.toLowerCase().includes('explain') || text.toLowerCase().includes('what')) {
+        reply = `Based on the current context:\n\n${ctx}\n\nIs there something specific you'd like me to dig into?`;
+      } else if (text.toLowerCase().includes('risk') || text.toLowerCase().includes('concern')) {
+        reply = `Looking at the focused element:\n\n${ctx}\n\nWould you like recommendations on how to address this?`;
+      } else {
+        reply = `Here's what I can see:\n\n${ctx}`;
+      }
+    }
+    chatMessages = [...chatMessages, { role: 'ai', text: reply }];
+    sending = false;
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
+</script>
+
+<div class="app">
+  <!-- Left: Dashboard -->
+  <main class="dashboard">
+    <header class="dash-header">
+      <div>
+        <h1>Revenue Dashboard</h1>
+        <p class="subtitle">Q2 2026 · Real-time AI context via <code>askable-ui</code></p>
+      </div>
+      {#if activeId}
+        <button class="btn-clear" onclick={clearFocus}>Clear focus ✕</button>
+      {/if}
+    </header>
+
+    <!-- KPI Cards -->
+    <section class="metrics-grid">
+      {#each metrics as m (m.id)}
+        <Askable5 meta={m.meta}>
+          <button
+            class="metric-card"
+            class:active={activeId === m.id}
+            onclick={(e) => focusEl(e.currentTarget, m.id)}
+            type="button"
+          >
+            <span class="metric-label">{m.label}</span>
+            <span class="metric-value">{m.value}</span>
+            <span class="metric-delta" class:positive={m.positive} class:negative={!m.positive}>
+              {m.delta}
+            </span>
+          </button>
+        </Askable5>
+      {/each}
+    </section>
+
+    <!-- Deals Table -->
+    <section class="table-section">
+      <h2>Priority Pipeline</h2>
+      <table class="deals-table">
+        <thead>
+          <tr>
+            <th>Company</th>
+            <th>Stage</th>
+            <th>Value</th>
+            <th>Owner</th>
+            <th>Risk</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each deals as deal (deal.id)}
+            <tr
+              class="deal-row"
+              class:active={activeId === deal.id}
+              onclick={(e) => focusEl(e.currentTarget, deal.id)}
+              tabindex="0"
+              onkeydown={(e) => e.key === 'Enter' && focusEl(e.currentTarget, deal.id)}
+              data-askable={JSON.stringify({ company: deal.company, stage: deal.stage, value: deal.value, owner: deal.owner, risk: deal.risk })}
+            >
+              <td class="company">{deal.company}</td>
+              <td>{deal.stage}</td>
+              <td class="value">{deal.value}</td>
+              <td>{deal.owner}</td>
+              <td>
+                <span class="risk-badge" style="color: {riskColor[deal.risk]}">
+                  {deal.risk}
+                </span>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </section>
+
+    <div class="tip">
+      <strong>Try it:</strong> Click any card or row, then ask the AI assistant about what you see.
+    </div>
+  </main>
+
+  <!-- Right: AI Panel -->
+  <aside class="ai-panel">
+    <!-- Context viewer -->
+    <div class="context-box">
+      <div class="context-header">
+        <span class="context-label">What the AI sees</span>
+        {#if askable.promptContext}
+          <button class="btn-copy" onclick={copyContext} type="button">copy</button>
+        {/if}
+      </div>
+      <pre class="context-pre">{askable.promptContext || '— nothing focused yet —'}</pre>
+    </div>
+
+    <!-- Chat -->
+    <div class="chat">
+      <div class="chat-messages">
+        {#each chatMessages as msg (msg)}
+          <div class="message" class:user={msg.role === 'user'} class:ai={msg.role === 'ai'}>
+            <span class="msg-role">{msg.role === 'ai' ? '🤖 AI' : 'You'}</span>
+            <p class="msg-text">{msg.text}</p>
+          </div>
+        {/each}
+        {#if sending}
+          <div class="message ai">
+            <span class="msg-role">🤖 AI</span>
+            <p class="msg-text typing">thinking…</p>
+          </div>
+        {/if}
+      </div>
+
+      <div class="chat-input-row">
+        <textarea
+          bind:value={chatInput}
+          onkeydown={handleKeydown}
+          placeholder="Ask about the focused element…"
+          rows="2"
+          disabled={sending}
+        ></textarea>
+        <button class="btn-send" onclick={sendMessage} disabled={sending} type="button">
+          Send
+        </button>
+      </div>
+    </div>
+  </aside>
+</div>
+
+<style>
+  /* Import from style.css via main.ts */
+</style>

--- a/examples/svelte-dashboard/src/main.ts
+++ b/examples/svelte-dashboard/src/main.ts
@@ -1,0 +1,7 @@
+import { mount } from 'svelte';
+import './style.css';
+import App from './App.svelte';
+
+const app = mount(App, { target: document.getElementById('app')! });
+
+export default app;

--- a/examples/svelte-dashboard/src/style.css
+++ b/examples/svelte-dashboard/src/style.css
@@ -1,0 +1,292 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --accent: #7c3aed;
+  --accent-light: #ede9fe;
+  --surface: #ffffff;
+  --bg: #f4f6fa;
+  --border: rgba(0,0,0,0.08);
+  --ink-1: #111317;
+  --ink-2: #6b7280;
+  --ink-3: #9ca3af;
+  --radius: 12px;
+  --shadow: 0 2px 12px rgba(0,0,0,0.06);
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--ink-1);
+  min-height: 100vh;
+}
+
+#app { height: 100vh; }
+
+.app {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ── Dashboard ── */
+.dashboard {
+  overflow-y: auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.dash-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dash-header h1 { font-size: 1.5rem; font-weight: 700; }
+
+.subtitle { font-size: .85rem; color: var(--ink-2); margin-top: .25rem; }
+.subtitle code { font-size: .8rem; background: var(--accent-light); color: var(--accent); padding: 0 .35em; border-radius: 4px; }
+
+.btn-clear {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: .35rem .75rem;
+  font-size: .8rem;
+  color: var(--ink-2);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn-clear:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ── Metrics Grid ── */
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.metric-card {
+  background: var(--surface);
+  border: 2px solid transparent;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1.25rem;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  transition: border-color .15s, box-shadow .15s;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.metric-card:hover { border-color: var(--accent); box-shadow: 0 4px 20px rgba(124,58,237,.12); }
+.metric-card.active { border-color: var(--accent); background: var(--accent-light); box-shadow: 0 4px 20px rgba(124,58,237,.18); }
+
+.metric-label { font-size: .78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--ink-2); }
+.metric-value { font-size: 2rem; font-weight: 700; color: var(--ink-1); line-height: 1; }
+.metric-delta { font-size: .82rem; font-weight: 500; }
+.metric-delta.positive { color: #16a34a; }
+.metric-delta.negative { color: #dc2626; }
+
+/* ── Table ── */
+.table-section h2 { font-size: 1.1rem; font-weight: 700; margin-bottom: .9rem; }
+
+.deals-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.deals-table th {
+  font-size: .72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--ink-2);
+  padding: .75rem 1rem;
+  text-align: left;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.deal-row td {
+  padding: .85rem 1rem;
+  font-size: .9rem;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.deal-row:last-child td { border-bottom: none; }
+
+.deal-row:hover td { background: #f9f5ff; }
+.deal-row.active td { background: var(--accent-light); }
+
+.company { font-weight: 600; }
+.value { font-variant-numeric: tabular-nums; font-weight: 600; }
+
+.risk-badge {
+  font-size: .75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+/* ── Tip ── */
+.tip {
+  font-size: .84rem;
+  color: var(--ink-2);
+  padding: .85rem 1.1rem;
+  background: #fffbeb;
+  border: 1px solid #fef3c7;
+  border-radius: var(--radius);
+}
+
+/* ── AI Panel ── */
+.ai-panel {
+  border-left: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Context box */
+.context-box {
+  border-bottom: 1px solid var(--border);
+  padding: 1rem;
+  flex-shrink: 0;
+}
+
+.context-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: .6rem;
+}
+
+.context-label {
+  font-size: .72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--accent);
+}
+
+.btn-copy {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: .2rem .55rem;
+  font-size: .75rem;
+  cursor: pointer;
+  color: var(--ink-2);
+}
+.btn-copy:hover { border-color: var(--accent); color: var(--accent); }
+
+.context-pre {
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;
+  font-size: .72rem;
+  line-height: 1.6;
+  color: var(--ink-1);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 180px;
+  overflow-y: auto;
+  background: var(--bg);
+  border-radius: 8px;
+  padding: .75rem;
+}
+
+/* Chat */
+.chat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: .85rem;
+}
+
+.message { display: flex; flex-direction: column; gap: .3rem; }
+
+.msg-role {
+  font-size: .7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--ink-3);
+}
+
+.msg-text {
+  font-size: .88rem;
+  line-height: 1.55;
+  color: var(--ink-1);
+  background: var(--bg);
+  border-radius: 10px;
+  padding: .65rem .85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message.user .msg-text { background: var(--accent-light); color: var(--accent); }
+.message.user .msg-role { color: var(--accent); }
+.typing { color: var(--ink-3) !important; }
+
+.chat-input-row {
+  border-top: 1px solid var(--border);
+  padding: .85rem;
+  display: flex;
+  gap: .6rem;
+  align-items: flex-end;
+}
+
+.chat-input-row textarea {
+  flex: 1;
+  resize: none;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: .6rem .8rem;
+  font-size: .88rem;
+  font-family: inherit;
+  line-height: 1.45;
+  color: var(--ink-1);
+  background: var(--bg);
+  outline: none;
+}
+.chat-input-row textarea:focus { border-color: var(--accent); }
+.chat-input-row textarea:disabled { opacity: .5; }
+
+.btn-send {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: .6rem 1rem;
+  font-size: .88rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn-send:hover:not(:disabled) { background: #6d28d9; }
+.btn-send:disabled { opacity: .5; cursor: not-allowed; }
+
+@media (max-width: 900px) {
+  .app { grid-template-columns: 1fr; grid-template-rows: 1fr auto; }
+  .ai-panel { height: 360px; border-left: none; border-top: 1px solid var(--border); }
+  .metrics-grid { grid-template-columns: 1fr; }
+}

--- a/examples/svelte-dashboard/svelte.config.js
+++ b/examples/svelte-dashboard/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/examples/svelte-dashboard/vite.config.ts
+++ b/examples/svelte-dashboard/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+});

--- a/examples/vanilla-chat/README.md
+++ b/examples/vanilla-chat/README.md
@@ -1,0 +1,85 @@
+# askable-ui — Zero-Install Vanilla JS Demo
+
+A fully self-contained HTML file that demonstrates the core askable-ui concept with **no build step, no install, no server**.
+
+## Running
+
+```bash
+# Option 1: just open in a browser
+open examples/vanilla-chat/index.html
+
+# Option 2: serve it
+npx serve examples/vanilla-chat
+```
+
+Or [open it directly on GitHub](./index.html) — it loads `@askable-ui/core` from the CDN automatically.
+
+## What it shows
+
+| Feature | How |
+|---|---|
+| `data-askable` annotation | Every KPI card and deal row has structured JSON metadata |
+| Focus tracking | Click any element — the "What the AI sees" panel updates instantly |
+| Real context string | Shows the actual `toContext()` output that you'd pass to an LLM |
+| Context-accurate AI | Mock responses use the real data from `data-askable` attributes |
+| Copy context | One click copies the context string for pasting into any AI chat |
+
+## How it works (the interesting part)
+
+```html
+<!-- This is all you need to annotate an element -->
+<div data-askable='{"metric":"net revenue retention","value":"118%","delta":"+6pp QoQ"}'>
+  <h2>118%</h2>
+  <p>Net Revenue Retention</p>
+</div>
+```
+
+```js
+// Load from CDN — same package as npm install @askable-ui/core
+import { createAskableContext } from 'https://esm.sh/@askable-ui/core';
+
+const ctx = createAskableContext();
+ctx.observe(document.body);
+
+// When the user clicks the card above, this fires:
+ctx.on('focus', () => {
+  console.log(ctx.toContext());
+  // → "User is focused on: metric=net revenue retention, value=118%, delta=+6pp QoQ"
+});
+```
+
+That string is what you inject into your LLM's system prompt.
+
+## Connecting to a real LLM
+
+Replace the mock response handler with a real fetch:
+
+```js
+async function handleSend() {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${YOUR_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'system',
+          content: `You are a helpful analytics assistant.\n\n${currentContext}`,
+        },
+        { role: 'user', content: userQuestion },
+      ],
+    }),
+  });
+  const data = await response.json();
+  return data.choices[0].message.content;
+}
+```
+
+## Related
+
+- [React + CopilotKit starter](../../packages/create-askable-app/) — `npm create @askable-ui/app`
+- [Vue 3 example](../vue-dashboard/)
+- [Full docs](https://askable-ui.com/docs/)

--- a/examples/vanilla-chat/index.html
+++ b/examples/vanilla-chat/index.html
@@ -1,0 +1,835 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>askable-ui — Vanilla JS Demo</title>
+  <style>
+    :root {
+      --bg: #07111f;
+      --surface: #0e1f35;
+      --surface-2: #152843;
+      --border: rgba(99, 179, 237, 0.12);
+      --accent: #4f46e5;
+      --accent-glow: rgba(79, 70, 229, 0.25);
+      --text: #e5eefb;
+      --text-muted: #7ba3c8;
+      --text-dim: #4a7a9b;
+      --green: #34d399;
+      --red: #f87171;
+      --yellow: #fbbf24;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+      color-scheme: dark;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      grid-template-columns: 1fr 380px;
+      grid-template-rows: auto 1fr;
+    }
+
+    header {
+      grid-column: 1 / -1;
+      padding: 14px 24px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      background: rgba(7, 17, 31, 0.8);
+      backdrop-filter: blur(12px);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    header .logo {
+      font-weight: 700;
+      font-size: 15px;
+      color: var(--text);
+    }
+
+    header .badge {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 99px;
+      background: var(--accent-glow);
+      color: #a5b4fc;
+      border: 1px solid rgba(99, 102, 241, 0.3);
+      letter-spacing: 0.02em;
+    }
+
+    header .header-hint {
+      margin-left: auto;
+      font-size: 12px;
+      color: var(--text-dim);
+    }
+
+    header .header-hint strong {
+      color: var(--text-muted);
+    }
+
+    main {
+      padding: 24px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .section-label {
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+      margin-bottom: 8px;
+      font-weight: 600;
+    }
+
+    /* KPI grid */
+    .kpi-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+    }
+
+    .kpi-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 18px;
+      cursor: pointer;
+      transition: border-color 0.15s, box-shadow 0.15s, transform 0.1s;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .kpi-card::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, var(--accent-glow) 0%, transparent 60%);
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+
+    .kpi-card:hover, .kpi-card.active {
+      border-color: rgba(99, 102, 241, 0.5);
+      box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.15), 0 4px 24px rgba(0,0,0,0.4);
+    }
+
+    .kpi-card:hover::before, .kpi-card.active::before { opacity: 1; }
+    .kpi-card.active { border-color: #6366f1; }
+
+    .kpi-card .label {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-bottom: 10px;
+      letter-spacing: 0.02em;
+    }
+
+    .kpi-card .value {
+      font-size: 26px;
+      font-weight: 700;
+      color: var(--text);
+      line-height: 1;
+      margin-bottom: 8px;
+      position: relative;
+    }
+
+    .kpi-card .delta {
+      font-size: 12px;
+      font-weight: 500;
+    }
+
+    .delta.up { color: var(--green); }
+    .delta.down { color: var(--red); }
+    .delta.neutral { color: var(--yellow); }
+
+    .kpi-card .ask-hint {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: var(--accent);
+      color: white;
+      font-size: 11px;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      transition: opacity 0.15s;
+    }
+
+    .kpi-card:hover .ask-hint, .kpi-card.active .ask-hint { opacity: 1; }
+
+    /* Deals table */
+    .deals-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .deals-header {
+      padding: 16px 18px 12px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .deals-header h3 { font-size: 13px; font-weight: 600; }
+    .deals-header span { font-size: 12px; color: var(--text-muted); }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th {
+      text-align: left;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+      padding: 10px 18px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    tr.deal-row {
+      cursor: pointer;
+      transition: background 0.1s;
+    }
+
+    tr.deal-row:hover, tr.deal-row.active {
+      background: var(--surface-2);
+    }
+
+    tr.deal-row.active {
+      box-shadow: inset 3px 0 0 var(--accent);
+    }
+
+    td {
+      padding: 12px 18px;
+      font-size: 13px;
+      border-bottom: 1px solid rgba(99, 179, 237, 0.06);
+    }
+
+    td .company { font-weight: 500; }
+    td .stage { color: var(--text-muted); font-size: 12px; }
+    td .amount { font-weight: 600; color: var(--green); }
+    td .owner { color: var(--text-muted); }
+
+    /* Sidebar */
+    aside {
+      border-left: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      height: calc(100vh - 53px);
+      position: sticky;
+      top: 53px;
+    }
+
+    .context-panel {
+      flex: 1;
+      padding: 16px;
+      overflow-y: auto;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .context-panel .panel-title {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+      margin-bottom: 10px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .context-panel .panel-title .dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--text-dim);
+      transition: background 0.2s;
+    }
+
+    .context-panel .panel-title .dot.live {
+      background: var(--green);
+      box-shadow: 0 0 6px var(--green);
+      animation: pulse 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    .context-box {
+      background: rgba(0,0,0,0.3);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px;
+      font-family: 'SFMono-Regular', ui-monospace, Menlo, monospace;
+      font-size: 11.5px;
+      line-height: 1.6;
+      color: #a5d6ff;
+      white-space: pre-wrap;
+      word-break: break-word;
+      min-height: 80px;
+      transition: all 0.2s;
+    }
+
+    .context-box.empty {
+      color: var(--text-dim);
+      font-family: inherit;
+      font-size: 12px;
+      display: flex;
+      align-items: center;
+      font-style: italic;
+    }
+
+    .copy-btn {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 8px;
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text-muted);
+      font-size: 11px;
+      padding: 5px 10px;
+      cursor: pointer;
+      transition: all 0.15s;
+      width: fit-content;
+    }
+
+    .copy-btn:hover {
+      border-color: rgba(99, 179, 237, 0.3);
+      color: var(--text);
+    }
+
+    .copy-btn.copied {
+      color: var(--green);
+      border-color: rgba(52, 211, 153, 0.3);
+    }
+
+    /* Chat panel */
+    .chat-panel {
+      display: flex;
+      flex-direction: column;
+      height: 50%;
+    }
+
+    .messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .message {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+
+    .message .role {
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+      font-weight: 600;
+    }
+
+    .message.user .role { color: #818cf8; }
+    .message.ai .role { color: var(--green); }
+
+    .message .bubble {
+      font-size: 12.5px;
+      line-height: 1.6;
+      color: var(--text);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 12px;
+    }
+
+    .message.user .bubble {
+      background: rgba(79, 70, 229, 0.15);
+      border-color: rgba(99, 102, 241, 0.25);
+      color: #e0e7ff;
+    }
+
+    .message.ai .bubble strong {
+      color: #67e8f9;
+    }
+
+    .message.ai.thinking .bubble {
+      color: var(--text-dim);
+      font-style: italic;
+    }
+
+    .chat-input-area {
+      padding: 10px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      gap: 6px;
+    }
+
+    .chat-input-area input {
+      flex: 1;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      color: var(--text);
+      padding: 8px 12px;
+      font-size: 13px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+
+    .chat-input-area input:focus {
+      border-color: rgba(99, 102, 241, 0.5);
+    }
+
+    .chat-input-area input::placeholder { color: var(--text-dim); }
+
+    .chat-input-area button {
+      background: var(--accent);
+      border: none;
+      border-radius: 8px;
+      color: white;
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+
+    .chat-input-area button:hover { opacity: 0.85; }
+    .chat-input-area button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .empty-state {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 20px;
+    }
+
+    .empty-state p {
+      font-size: 12px;
+      color: var(--text-dim);
+      line-height: 1.6;
+    }
+
+    .empty-state p strong {
+      display: block;
+      color: var(--text-muted);
+      margin-bottom: 4px;
+      font-size: 13px;
+    }
+
+    .how-it-works {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px 18px;
+    }
+
+    .how-it-works h3 {
+      font-size: 13px;
+      font-weight: 600;
+      margin-bottom: 10px;
+      color: var(--text);
+    }
+
+    .how-it-works ol {
+      padding-left: 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .how-it-works li {
+      font-size: 12px;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+
+    .how-it-works code {
+      font-family: 'SFMono-Regular', ui-monospace, Menlo, monospace;
+      font-size: 11px;
+      background: rgba(0,0,0,0.3);
+      padding: 1px 5px;
+      border-radius: 3px;
+      color: #a5d6ff;
+    }
+
+    .source-link {
+      margin-top: 12px;
+      display: flex;
+      gap: 12px;
+    }
+
+    .source-link a {
+      font-size: 12px;
+      color: #818cf8;
+      text-decoration: none;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .source-link a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<header>
+  <span class="logo">askable-ui</span>
+  <span class="badge">Vanilla JS Demo</span>
+  <span class="header-hint">Click any card or row · Watch <strong>What the AI sees</strong> update · Ask a question</span>
+</header>
+
+<main>
+  <div>
+    <div class="section-label">KPI metrics · click any card</div>
+    <div class="kpi-grid" id="kpi-grid">
+      <div class="kpi-card" id="card-nrr"
+        data-askable='{"metric":"net revenue retention","value":"118%","delta":"+6pp QoQ","target":"110%","status":"above target"}'
+        tabindex="0" role="button" aria-label="Net Revenue Retention KPI card">
+        <span class="ask-hint">?</span>
+        <div class="label">Net Revenue Retention</div>
+        <div class="value">118%</div>
+        <div class="delta up">↑ +6pp quarter over quarter</div>
+      </div>
+      <div class="kpi-card" id="card-pipeline"
+        data-askable='{"metric":"pipeline coverage","value":"3.9x","delta":"+0.4x WoW","target":"3.5x","status":"above target","totalValue":"$12.3M"}'
+        tabindex="0" role="button" aria-label="Pipeline Coverage KPI card">
+        <span class="ask-hint">?</span>
+        <div class="label">Pipeline Coverage</div>
+        <div class="value">3.9x</div>
+        <div class="delta up">↑ +0.4x week over week</div>
+      </div>
+      <div class="kpi-card" id="card-backlog"
+        data-askable='{"metric":"support backlog","value":"24 tickets","delta":"-31% since Friday","sla":"<50 tickets","status":"healthy","p1Count":2}'
+        tabindex="0" role="button" aria-label="Support Backlog KPI card">
+        <span class="ask-hint">?</span>
+        <div class="label">Support Backlog</div>
+        <div class="value">24</div>
+        <div class="delta up">↓ −31% since last Friday</div>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <div class="section-label">Open deals · click any row</div>
+    <div class="deals-card">
+      <div class="deals-header">
+        <h3>Deal pipeline</h3>
+        <span>4 deals · $315k total</span>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Company</th>
+            <th>Stage</th>
+            <th>Value</th>
+            <th>Owner</th>
+          </tr>
+        </thead>
+        <tbody id="deals-tbody">
+          <tr class="deal-row" id="deal-acme"
+            data-askable='{"company":"Acme Foods","stage":"Security review","value":"$84k","owner":"Nina","daysInStage":12,"riskFlag":"procurement delay"}'
+            tabindex="0" role="button">
+            <td><span class="company">Acme Foods</span></td>
+            <td><span class="stage">Security review</span></td>
+            <td><span class="amount">$84k</span></td>
+            <td><span class="owner">Nina</span></td>
+          </tr>
+          <tr class="deal-row" id="deal-northstar"
+            data-askable='{"company":"Northstar Health","stage":"Champion identified","value":"$122k","owner":"Sam","daysInStage":5,"nextAction":"exec call this week"}'
+            tabindex="0" role="button">
+            <td><span class="company">Northstar Health</span></td>
+            <td><span class="stage">Champion identified</span></td>
+            <td><span class="amount">$122k</span></td>
+            <td><span class="owner">Sam</span></td>
+          </tr>
+          <tr class="deal-row" id="deal-lattice"
+            data-askable='{"company":"Lattice Cloud","stage":"Commercials","value":"$61k","owner":"Aria","daysInStage":8,"discount":"requested 15%"}'
+            tabindex="0" role="button">
+            <td><span class="company">Lattice Cloud</span></td>
+            <td><span class="stage">Commercials</span></td>
+            <td><span class="amount">$61k</span></td>
+            <td><span class="owner">Aria</span></td>
+          </tr>
+          <tr class="deal-row" id="deal-meridian"
+            data-askable='{"company":"Meridian Retail","stage":"Pilot live","value":"$48k","owner":"Jon","daysInStage":21,"pilotUsers":47}'
+            tabindex="0" role="button">
+            <td><span class="company">Meridian Retail</span></td>
+            <td><span class="stage">Pilot live</span></td>
+            <td><span class="amount">$48k</span></td>
+            <td><span class="owner">Jon</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="how-it-works">
+    <h3>How this demo works</h3>
+    <ol>
+      <li>Every card and row has a <code>data-askable</code> attribute with structured JSON data.</li>
+      <li><code>createAskableContext()</code> watches for focus/click events and tracks which element is active.</li>
+      <li><code>ctx.toContext()</code> serializes the focused element's metadata into a prompt-ready string.</li>
+      <li>The mock AI uses that string to answer questions about exactly what you selected.</li>
+    </ol>
+    <div class="source-link">
+      <a href="https://github.com/askable-ui/askable" target="_blank" rel="noopener">★ Star on GitHub</a>
+      <a href="https://askable-ui.com/docs/" target="_blank" rel="noopener">→ Read the docs</a>
+      <a href="https://www.npmjs.com/package/@askable-ui/core" target="_blank" rel="noopener">↓ npm install</a>
+    </div>
+  </div>
+</main>
+
+<aside>
+  <div class="context-panel">
+    <div class="panel-title">
+      <span class="dot" id="context-dot"></span>
+      What the AI sees
+    </div>
+    <div class="context-box empty" id="context-display">
+      Click any card or row above to see what the AI receives...
+    </div>
+    <button class="copy-btn" id="copy-btn" style="display:none">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+      Copy context
+    </button>
+  </div>
+
+  <div class="chat-panel">
+    <div class="messages" id="messages">
+      <div class="empty-state">
+        <p>
+          <strong>Select something first</strong>
+          Click a KPI card or deal row, then ask a question about it.
+        </p>
+      </div>
+    </div>
+    <div class="chat-input-area">
+      <input type="text" id="chat-input" placeholder="Ask about what you selected..." disabled />
+      <button id="send-btn" disabled>Ask</button>
+    </div>
+  </div>
+</aside>
+
+<script type="module">
+// ─── Load askable-ui/core from CDN ───────────────────────────────────────────
+// In a real app: import { createAskableContext } from '@askable-ui/core';
+import { createAskableContext } from 'https://esm.sh/@askable-ui/core@0.13.1';
+
+const ctx = createAskableContext();
+
+// ─── DOM refs ────────────────────────────────────────────────────────────────
+const contextDisplay = document.getElementById('context-display');
+const contextDot     = document.getElementById('context-dot');
+const copyBtn        = document.getElementById('copy-btn');
+const messages       = document.getElementById('messages');
+const chatInput      = document.getElementById('chat-input');
+const sendBtn        = document.getElementById('send-btn');
+
+let currentContext = '';
+let activeEl = null;
+
+// ─── Observe annotated elements ──────────────────────────────────────────────
+ctx.observe(document.body);
+
+// ─── Handle focus changes ────────────────────────────────────────────────────
+ctx.on('focus', () => {
+  const text = ctx.toContext();
+  if (!text) return;
+
+  currentContext = text;
+  contextDisplay.textContent = text;
+  contextDisplay.classList.remove('empty');
+  contextDot.classList.add('live');
+  copyBtn.style.display = 'flex';
+  chatInput.disabled = false;
+  sendBtn.disabled = false;
+  chatInput.placeholder = 'Ask about what you selected...';
+});
+
+// ─── Click to select ─────────────────────────────────────────────────────────
+document.querySelectorAll('[data-askable]').forEach(el => {
+  function activate() {
+    // Update active styles
+    document.querySelectorAll('.kpi-card.active, .deal-row.active').forEach(e => e.classList.remove('active'));
+    el.classList.add('active');
+    activeEl = el;
+    ctx.select(el);
+  }
+
+  el.addEventListener('click', activate);
+  el.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activate(); } });
+});
+
+// ─── Copy button ─────────────────────────────────────────────────────────────
+copyBtn.addEventListener('click', () => {
+  navigator.clipboard.writeText(currentContext).then(() => {
+    copyBtn.textContent = '✓ Copied';
+    copyBtn.classList.add('copied');
+    setTimeout(() => {
+      copyBtn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy context`;
+      copyBtn.classList.remove('copied');
+    }, 2000);
+  });
+});
+
+// ─── Mock AI responses ────────────────────────────────────────────────────────
+// In a real app, you'd pass currentContext to your LLM API.
+// This demo generates realistic responses from the actual data-askable values.
+
+function getMockResponse(question, contextText) {
+  const lower = question.toLowerCase();
+  const data = parseCurrentData();
+
+  if (!data) {
+    return "I don't have enough context. Please click a metric or deal row first.";
+  }
+
+  // NRR responses
+  if (data.metric === 'net revenue retention') {
+    if (lower.includes('why') || lower.includes('mean') || lower.includes('explain') || lower.includes('what')) {
+      return `**Net Revenue Retention at ${data.value}** means your existing customers are generating ${parseInt(data.value) - 100}% more revenue this period than last period — after accounting for any churn or downgrades.\n\nAt ${data.value}, you're well above the ${data.target || '100%'} break-even point. The **${data.delta}** improvement quarter-over-quarter suggests your expansion motion (upsells, seat growth, tier upgrades) is accelerating. Most SaaS companies target >110% NRR — you're tracking ahead of that.`;
+    }
+    if (lower.includes('good') || lower.includes('bad') || lower.includes('target')) {
+      return `${data.value} NRR is strong — your target is ${data.target || 'not set'} and you're ${data.status || 'above target'}. Industry benchmark for top-quartile SaaS is 120%+ at scale. The ${data.delta} trend is the more important signal: it means the expansion motion is improving, not just holding.`;
+    }
+  }
+
+  // Pipeline coverage responses
+  if (data.metric === 'pipeline coverage') {
+    if (lower.includes('why') || lower.includes('mean') || lower.includes('explain') || lower.includes('what')) {
+      return `**Pipeline coverage at ${data.value}** means you have ${data.value} of pipeline for every $1 of quota. With ${data.totalValue || 'significant'} total pipeline value, you have a healthy buffer above the ${data.target || '3x'} target.\n\nThe **${data.delta}** increase week-over-week is encouraging — it means more deals are entering the pipeline than are being lost or won. Watch stage distribution: coverage alone doesn't tell you if deals are bunched in early stages.`;
+    }
+    if (lower.includes('risk') || lower.includes('concern')) {
+      return `Main risk with ${data.value} coverage: stage concentration. If most of the pipeline is in early stages (prospecting, discovery), the real close-weighted coverage is lower. Ask your team for a stage-weighted view. The ${data.delta} WoW growth is healthy — just verify it's not all new pipeline with long cycles.`;
+    }
+  }
+
+  // Support backlog responses
+  if (data.metric === 'support backlog') {
+    if (lower.includes('why') || lower.includes('explain') || lower.includes('what')) {
+      return `**Support backlog at ${data.value}** is ${data.status || 'within SLA'}. The **${data.delta}** reduction means your team is clearing tickets faster than new ones arrive — likely from the self-serve and routing improvements.\n\n${data.p1Count ? `There are ${data.p1Count} P1 tickets in the queue — those need same-day response regardless of overall backlog health.` : ''}`;
+    }
+    if (lower.includes('good') || lower.includes('target') || lower.includes('sla')) {
+      return `${data.value} is ${data.status || 'healthy'} — SLA is ${data.sla || '<50 tickets'}. The ${data.delta} improvement is significant. If this trend holds another week, you'll be at or below the 15-ticket target from last sprint's OKR. Main watch-out: make sure the reduction is from resolution, not from tickets being closed prematurely.`;
+    }
+  }
+
+  // Deal responses
+  if (data.company) {
+    if (lower.includes('risk') || lower.includes('concern') || lower.includes('worried')) {
+      const risks = [];
+      if (data.riskFlag) risks.push(data.riskFlag);
+      if (data.daysInStage > 14) risks.push(`${data.daysInStage} days in ${data.stage} — longer than typical`);
+      if (data.discount) risks.push(`discount request: ${data.discount}`);
+      if (risks.length === 0) risks.push('no immediate flags in the data');
+      return `**${data.company}** (${data.value}) — risk factors:\n${risks.map(r => `• ${r}`).join('\n')}\n\nStage: ${data.stage}. Owner: ${data.owner}. ${data.nextAction ? `Next action: ${data.nextAction}.` : ''}`;
+    }
+    if (lower.includes('next') || lower.includes('action') || lower.includes('do')) {
+      return `**${data.company}** is in **${data.stage}** (${data.value}, ${data.owner}).\n\n${data.nextAction ? `Next action already identified: ${data.nextAction}.` : `No next action tagged — ${data.owner} should log the next step in CRM.`}${data.daysInStage ? ` Deal has been in this stage ${data.daysInStage} days.` : ''}${data.riskFlag ? ` Watch out for: ${data.riskFlag}.` : ''}`;
+    }
+    if (lower.includes('explain') || lower.includes('tell') || lower.includes('what') || lower.includes('about')) {
+      return `**${data.company}** — ${data.value} deal owned by ${data.owner}, currently in **${data.stage}**.\n\n${data.daysInStage ? `In stage for ${data.daysInStage} days. ` : ''}${data.riskFlag ? `Risk flag: ${data.riskFlag}. ` : ''}${data.nextAction ? `Next action: ${data.nextAction}. ` : ''}${data.pilotUsers ? `${data.pilotUsers} users active in pilot. ` : ''}${data.discount ? `Discount request: ${data.discount}.` : ''}`;
+    }
+  }
+
+  // Generic fallback using whatever data we have
+  const keys = Object.entries(data).slice(0, 4).map(([k, v]) => `${k}: ${v}`).join(', ');
+  return `Based on the current context (${keys}): I can answer questions about this data — try asking about risks, next steps, what the number means, or whether it's good or bad.`;
+}
+
+function parseCurrentData() {
+  if (!activeEl) return null;
+  try {
+    const raw = activeEl.getAttribute('data-askable');
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Chat ────────────────────────────────────────────────────────────────────
+function addMessage(role, text) {
+  // Remove empty state
+  const emptyState = messages.querySelector('.empty-state');
+  if (emptyState) emptyState.remove();
+
+  const div = document.createElement('div');
+  div.className = `message ${role}`;
+
+  const roleLabel = document.createElement('div');
+  roleLabel.className = 'role';
+  roleLabel.textContent = role === 'user' ? 'You' : 'AI (using your context)';
+
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
+
+  // Render **bold** markdown
+  bubble.innerHTML = text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>').replace(/\n/g, '<br>');
+
+  div.appendChild(roleLabel);
+  div.appendChild(bubble);
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+  return div;
+}
+
+async function handleSend() {
+  const q = chatInput.value.trim();
+  if (!q || !currentContext) return;
+
+  chatInput.value = '';
+  sendBtn.disabled = true;
+  chatInput.disabled = true;
+
+  addMessage('user', q);
+
+  const thinking = addMessage('ai thinking', 'Reading context...');
+
+  // Simulate LLM latency
+  await new Promise(r => setTimeout(r, 600 + Math.random() * 400));
+
+  thinking.remove();
+
+  const response = getMockResponse(q, currentContext);
+  addMessage('ai', response);
+
+  sendBtn.disabled = false;
+  chatInput.disabled = false;
+  chatInput.focus();
+}
+
+sendBtn.addEventListener('click', handleSend);
+chatInput.addEventListener('keydown', e => { if (e.key === 'Enter') handleSend(); });
+</script>
+</body>
+</html>

--- a/examples/vue-dashboard/README.md
+++ b/examples/vue-dashboard/README.md
@@ -1,0 +1,80 @@
+# askable-ui — Vue 3 Dashboard Example
+
+A minimal analytics dashboard showing the core askable-ui pattern in Vue 3.
+
+## What it demonstrates
+
+1. **`<Askable :meta="...">`** — wraps any element; keeps `data-askable` in sync with reactive props
+2. **`useAskable()`** — one composable call; returns `promptContext` that updates automatically
+3. **Live context panel** — shows exactly what the AI would receive as a string
+4. **Mock chat** — demonstrates how `promptContext` makes AI responses specific and accurate
+
+## Running
+
+```bash
+npm install
+npm run dev
+```
+
+Then open http://localhost:5173, click any KPI card or deal row, and watch the "What the AI sees" panel update in real time.
+
+## The core pattern
+
+```vue
+<script setup>
+import { Askable, useAskable } from '@askable-ui/vue';
+
+const { promptContext } = useAskable();
+// promptContext is a ref<string> that updates automatically on click/focus
+</script>
+
+<template>
+  <Askable :meta="{ metric: 'NRR', value: '118%', delta: '+6pp' }">
+    <MetricCard :data="kpi" />
+  </Askable>
+
+  <!-- Pass promptContext to any LLM -->
+  <AIChat :system-context="promptContext" />
+</template>
+```
+
+## Connecting to a real LLM
+
+Replace the mock `sendMessage()` function with a real API call:
+
+```ts
+async function sendMessage() {
+  const response = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      context: promptContext.value, // ← inject into system prompt
+      message: chatInput.value,
+    }),
+  });
+  // ...
+}
+```
+
+Server-side (e.g. Express):
+
+```ts
+app.post('/api/chat', async (req, res) => {
+  const { context, message } = req.body;
+  const result = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [
+      { role: 'system', content: `You are a helpful analytics assistant.\n\n${context}` },
+      { role: 'user', content: message },
+    ],
+  });
+  res.json({ reply: result.choices[0].message.content });
+});
+```
+
+## Related
+
+- [Vue package docs](https://askable-ui.com/docs/guide/vue)
+- [React example](../analytics-dashboard-react/)
+- [Vanilla JS example](../vanilla-chat/)
+- [Full starter app](../../packages/create-askable-app/)

--- a/examples/vue-dashboard/index.html
+++ b/examples/vue-dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>askable-ui — Vue 3 Dashboard</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/vue-dashboard/package.json
+++ b/examples/vue-dashboard/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vue-dashboard-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "askable-ui Vue 3 example — analytics dashboard with live AI context",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@askable-ui/vue": "^0.13.1",
+    "vue": "^3.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/vue-dashboard/package.json
+++ b/examples/vue-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/vue": "^0.13.1",
+    "@askable-ui/vue": "^0.14.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {

--- a/examples/vue-dashboard/src/App.vue
+++ b/examples/vue-dashboard/src/App.vue
@@ -1,0 +1,559 @@
+<script setup lang="ts">
+/**
+ * askable-ui Vue 3 Dashboard Example
+ *
+ * This example shows the core pattern:
+ * 1. Wrap elements with <Askable :meta="..."> — the same data your chart renders
+ * 2. useAskable() gives you promptContext — updates automatically on focus/click
+ * 3. Pass promptContext to any LLM — the AI knows exactly what the user sees
+ */
+
+import { ref, computed } from 'vue';
+import { Askable, useAskable } from '@askable-ui/vue';
+
+// ── useAskable() wires the DOM listener. One call, zero config. ──────────────
+const { ctx, promptContext } = useAskable();
+
+// ── Your data ────────────────────────────────────────────────────────────────
+const metrics = [
+  { id: 'nrr',      label: 'Net Revenue Retention', value: '118%',      delta: '+6pp QoQ',      up: true,  meta: { metric: 'net revenue retention', value: '118%', delta: '+6pp QoQ', target: '110%', status: 'above target' } },
+  { id: 'pipeline', label: 'Pipeline Coverage',      value: '3.9x',      delta: '+0.4x WoW',     up: true,  meta: { metric: 'pipeline coverage',      value: '3.9x', delta: '+0.4x WoW', target: '3.5x', totalValue: '$12.3M' } },
+  { id: 'backlog',  label: 'Support Backlog',         value: '24 tickets', delta: '−31% vs Friday', up: true,  meta: { metric: 'support backlog',         value: '24 tickets', delta: '-31% since Friday', sla: '<50 tickets', p1Count: 2 } },
+];
+
+const deals = [
+  { id: 'acme',      company: 'Acme Foods',       stage: 'Security review',       value: '$84k',  owner: 'Nina', meta: { company: 'Acme Foods',       stage: 'Security review',       value: '$84k',  owner: 'Nina', daysInStage: 12, riskFlag: 'procurement delay' } },
+  { id: 'northstar', company: 'Northstar Health',  stage: 'Champion identified',   value: '$122k', owner: 'Sam',  meta: { company: 'Northstar Health',  stage: 'Champion identified',   value: '$122k', owner: 'Sam',  nextAction: 'exec call this week' } },
+  { id: 'lattice',   company: 'Lattice Cloud',     stage: 'Commercials',           value: '$61k',  owner: 'Aria', meta: { company: 'Lattice Cloud',     stage: 'Commercials',           value: '$61k',  owner: 'Aria', discount: 'requested 15%' } },
+  { id: 'meridian',  company: 'Meridian Retail',   stage: 'Pilot live',            value: '$48k',  owner: 'Jon',  meta: { company: 'Meridian Retail',   stage: 'Pilot live',            value: '$48k',  owner: 'Jon',  pilotUsers: 47 } },
+];
+
+// ── Track which element is active ────────────────────────────────────────────
+const activeId = ref<string | null>(null);
+
+function focusElement(el: HTMLElement | null, id: string) {
+  if (!el) return;
+  activeId.value = id;
+  ctx.select(el);
+}
+
+// ── Chat ─────────────────────────────────────────────────────────────────────
+interface Message { role: 'user' | 'ai'; text: string }
+const messages = ref<Message[]>([]);
+const chatInput = ref('');
+const thinking = ref(false);
+
+const canChat = computed(() => !!promptContext.value && !thinking.value);
+
+function mockResponse(question: string): string {
+  const q = question.toLowerCase();
+  const ctx_text = promptContext.value;
+
+  // Parse the active element's meta from the context string
+  if (ctx_text.includes('net revenue retention')) {
+    if (q.includes('why') || q.includes('mean') || q.includes('explain') || q.includes('what'))
+      return 'NRR at 118% means your existing customers are generating 18% more revenue this period than last — after accounting for churn and downgrades. The +6pp QoQ improvement shows the expansion motion is accelerating, not just holding. Target is 110%, so you\'re 8pp ahead.';
+    if (q.includes('good') || q.includes('target') || q.includes('benchmark'))
+      return 'Strong. Industry benchmark for top-quartile SaaS is 120%+ at scale. You\'re at 118%, 8pp above your own 110% target. The trend matters most — +6pp QoQ means this is improving, not plateauing.';
+  }
+  if (ctx_text.includes('pipeline coverage')) {
+    if (q.includes('why') || q.includes('mean') || q.includes('explain') || q.includes('what'))
+      return 'Pipeline coverage at 3.9x means you have $3.90 of pipeline for every $1 of quota. Total value is $12.3M. The +0.4x WoW increase means more deals are entering than being closed or lost. Target is 3.5x — you\'re 0.4x above it.';
+    if (q.includes('risk') || q.includes('concern'))
+      return 'Main risk: stage concentration. 3.9x coverage is healthy, but check whether it\'s weighted toward late stages (good) or early discovery (less reliable). Ask for a stage-weighted view before the QBR.';
+  }
+  if (ctx_text.includes('support backlog')) {
+    if (q.includes('why') || q.includes('mean') || q.includes('explain') || q.includes('what'))
+      return 'Support backlog at 24 tickets is healthy — SLA is <50. The −31% since Friday means your team is clearing tickets faster than new ones arrive, likely from the self-serve billing improvements. 2 P1 tickets in queue need same-day attention regardless.';
+  }
+  // Deal responses
+  for (const deal of deals) {
+    if (ctx_text.includes(deal.company)) {
+      if (q.includes('risk') || q.includes('concern'))
+        return `${deal.company} (${deal.value}): ${deal.meta.riskFlag ? `Risk flag — ${deal.meta.riskFlag}. ` : ''}${(deal.meta.daysInStage || 0) > 14 ? `${deal.meta.daysInStage} days in ${deal.stage} is longer than typical. ` : ''}${deal.meta.discount ? `Discount request: ${deal.meta.discount}. ` : ''}Owner: ${deal.owner}.`;
+      return `${deal.company} is in **${deal.stage}** (${deal.value}, owned by ${deal.owner}). ${deal.meta.nextAction ? `Next action: ${deal.meta.nextAction}.` : ''}${deal.meta.pilotUsers ? ` ${deal.meta.pilotUsers} users active in pilot.` : ''}`;
+    }
+  }
+  return `Based on the current context: ${ctx_text.slice(0, 120)}... Try asking "what does this mean?", "is this good?", or "what are the risks?"`;
+}
+
+async function sendMessage() {
+  const q = chatInput.value.trim();
+  if (!q || !canChat.value) return;
+
+  chatInput.value = '';
+  messages.value.push({ role: 'user', text: q });
+  thinking.value = true;
+
+  await new Promise(r => setTimeout(r, 500 + Math.random() * 400));
+  messages.value.push({ role: 'ai', text: mockResponse(q) });
+  thinking.value = false;
+}
+</script>
+
+<template>
+  <div class="shell">
+    <!-- Header -->
+    <header class="header">
+      <span class="logo">askable-ui <span class="badge">Vue 3 Example</span></span>
+      <span class="hint">Click any card or row to update AI context</span>
+    </header>
+
+    <!-- Dashboard -->
+    <main class="main">
+      <!-- KPI cards -->
+      <section>
+        <p class="section-label">KPI metrics</p>
+        <div class="kpi-grid">
+          <!--
+            <Askable :meta="m.meta"> keeps data-askable in sync with the component's
+            reactive props. The ctx ref from useAskable() is the observer instance.
+          -->
+          <Askable
+            v-for="m in metrics"
+            :key="m.id"
+            :meta="m.meta"
+            :ctx="ctx"
+            v-slot="{ el }"
+          >
+            <div
+              class="kpi-card"
+              :class="{ active: activeId === m.id }"
+              tabindex="0"
+              role="button"
+              :aria-label="`${m.label} KPI card`"
+              @click="focusElement(el, m.id)"
+              @keydown.enter.space.prevent="focusElement(el, m.id)"
+            >
+              <div class="kpi-label">{{ m.label }}</div>
+              <div class="kpi-value">{{ m.value }}</div>
+              <div class="kpi-delta" :class="m.up ? 'up' : 'down'">
+                {{ m.up ? '↑' : '↓' }} {{ m.delta }}
+              </div>
+            </div>
+          </Askable>
+        </div>
+      </section>
+
+      <!-- Deals table -->
+      <section>
+        <p class="section-label">Open deals</p>
+        <div class="table-card">
+          <table>
+            <thead>
+              <tr>
+                <th>Company</th><th>Stage</th><th>Value</th><th>Owner</th>
+              </tr>
+            </thead>
+            <tbody>
+              <Askable
+                v-for="d in deals"
+                :key="d.id"
+                :meta="d.meta"
+                :ctx="ctx"
+                tag="tr"
+                v-slot="{ el }"
+              >
+                <tr
+                  class="deal-row"
+                  :class="{ active: activeId === d.id }"
+                  tabindex="0"
+                  role="button"
+                  @click="focusElement(el, d.id)"
+                  @keydown.enter.space.prevent="focusElement(el, d.id)"
+                >
+                  <td class="company">{{ d.company }}</td>
+                  <td class="stage">{{ d.stage }}</td>
+                  <td class="amount">{{ d.value }}</td>
+                  <td class="owner">{{ d.owner }}</td>
+                </tr>
+              </Askable>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- How it works explainer -->
+      <section class="how-it-works">
+        <p class="section-label" style="text-align:left;margin-bottom:.5rem">How this example works</p>
+        <pre class="code-snippet">// 1. Install
+npm install @askable-ui/vue
+
+// 2. Wrap any element
+&lt;Askable :meta="{ metric: 'NRR', value: '118%', delta: '+6pp' }"&gt;
+  &lt;MetricCard /&gt;
+&lt;/Askable&gt;
+
+// 3. Get live context — updates on every click
+const { promptContext } = useAskable();
+
+// 4. Pass to any LLM
+const result = await openai.chat.completions.create({
+  model: 'gpt-4o',
+  messages: [
+    { role: 'system', content: promptContext.value },
+    { role: 'user',   content: userMessage },
+  ],
+});</pre>
+        <div class="links">
+          <a href="https://github.com/askable-ui/askable" target="_blank" rel="noopener">★ GitHub</a>
+          <a href="https://askable-ui.com/docs/guide/vue" target="_blank" rel="noopener">Vue docs →</a>
+          <a href="https://www.npmjs.com/package/@askable-ui/vue" target="_blank" rel="noopener">npm →</a>
+        </div>
+      </section>
+    </main>
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <!-- Context panel -->
+      <div class="context-panel">
+        <div class="panel-title">
+          <span class="dot" :class="{ live: !!promptContext }"></span>
+          What the AI sees
+        </div>
+        <div class="context-box" :class="{ empty: !promptContext }">
+          {{ promptContext || 'Click any card or row above...' }}
+        </div>
+        <button
+          v-if="promptContext"
+          class="copy-btn"
+          @click="navigator.clipboard.writeText(promptContext)"
+        >
+          Copy context
+        </button>
+      </div>
+
+      <!-- Chat panel -->
+      <div class="chat-panel">
+        <div class="messages" ref="messagesEl">
+          <div v-if="messages.length === 0" class="chat-empty">
+            <p>Select a metric or deal, then ask a question about it.</p>
+          </div>
+          <div
+            v-for="(m, i) in messages"
+            :key="i"
+            class="message"
+            :class="m.role"
+          >
+            <div class="role">{{ m.role === 'user' ? 'You' : 'AI (mock)' }}</div>
+            <div class="bubble">{{ m.text }}</div>
+          </div>
+          <div v-if="thinking" class="message ai">
+            <div class="role">AI (mock)</div>
+            <div class="bubble thinking">Reading context...</div>
+          </div>
+        </div>
+        <div class="chat-input-row">
+          <input
+            v-model="chatInput"
+            :placeholder="promptContext ? 'Ask about what you selected...' : 'Select something first...'"
+            :disabled="!promptContext"
+            @keydown.enter="sendMessage"
+          />
+          <button :disabled="!canChat" @click="sendMessage">Ask</button>
+        </div>
+      </div>
+    </aside>
+  </div>
+</template>
+
+<style scoped>
+.shell {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+.header {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 24px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(7, 17, 31, 0.85);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.logo { font-weight: 700; font-size: 15px; }
+.badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  background: var(--accent-glow);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+}
+.hint { margin-left: auto; font-size: 12px; color: var(--text-dim); }
+
+.main {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+}
+
+.section-label {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.kpi-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.kpi-card:hover, .kpi-card.active {
+  border-color: rgba(99, 102, 241, 0.5);
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.15), 0 4px 20px rgba(0,0,0,0.35);
+}
+
+.kpi-card.active { border-color: #6366f1; }
+
+.kpi-label { font-size: 11px; color: var(--text-muted); margin-bottom: 8px; letter-spacing: 0.02em; }
+.kpi-value { font-size: 26px; font-weight: 700; margin-bottom: 6px; line-height: 1; }
+.kpi-delta { font-size: 12px; font-weight: 500; }
+.kpi-delta.up { color: var(--green); }
+.kpi-delta.down { color: var(--red); }
+
+.table-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+table { width: 100%; border-collapse: collapse; }
+
+th {
+  text-align: left;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.deal-row {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.deal-row:hover, .deal-row.active { background: var(--surface-2); }
+.deal-row.active { box-shadow: inset 3px 0 0 var(--accent); }
+
+td { padding: 12px 16px; font-size: 13px; border-bottom: 1px solid rgba(99, 179, 237, 0.05); }
+.company { font-weight: 500; }
+.stage { color: var(--text-muted); }
+.amount { font-weight: 600; color: var(--green); }
+.owner { color: var(--text-muted); }
+
+.how-it-works {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.code-snippet {
+  background: rgba(0,0,0,0.3);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  font-size: 12px;
+  line-height: 1.65;
+  color: #a5d6ff;
+  white-space: pre;
+  overflow-x: auto;
+  margin-top: 8px;
+}
+
+.links { display: flex; gap: 16px; margin-top: 12px; }
+.links a { font-size: 12px; color: #818cf8; text-decoration: none; }
+.links a:hover { text-decoration: underline; }
+
+/* Sidebar */
+.sidebar {
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 53px);
+  position: sticky;
+  top: 53px;
+}
+
+.context-panel {
+  flex: 0 0 auto;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 10px;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+.dot.live {
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+
+.context-box {
+  background: rgba(0,0,0,0.3);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: #a5d6ff;
+  font-family: 'SFMono-Regular', ui-monospace, Menlo, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 70px;
+}
+
+.context-box.empty {
+  color: var(--text-dim);
+  font-family: inherit;
+  font-style: italic;
+}
+
+.copy-btn {
+  margin-top: 8px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.copy-btn:hover { border-color: rgba(99, 179, 237, 0.3); color: var(--text); }
+
+.chat-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 20px;
+}
+
+.chat-empty p { font-size: 12px; color: var(--text-dim); line-height: 1.6; }
+
+.message { display: flex; flex-direction: column; gap: 3px; }
+.role { font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; }
+.message.user .role { color: #818cf8; }
+.message.ai .role { color: var(--green); }
+
+.bubble {
+  font-size: 12.5px;
+  line-height: 1.6;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.message.user .bubble {
+  background: rgba(79, 70, 229, 0.15);
+  border-color: rgba(99, 102, 241, 0.25);
+  color: #e0e7ff;
+}
+
+.bubble.thinking { color: var(--text-dim); font-style: italic; }
+
+.chat-input-row {
+  display: flex;
+  gap: 6px;
+  padding: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.chat-input-row input {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  padding: 8px 12px;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.chat-input-row input:focus { border-color: rgba(99, 102, 241, 0.5); }
+.chat-input-row input::placeholder { color: var(--text-dim); }
+.chat-input-row input:disabled { opacity: 0.5; }
+
+.chat-input-row button {
+  background: var(--accent);
+  border: none;
+  border-radius: 8px;
+  color: white;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.chat-input-row button:disabled { opacity: 0.4; cursor: not-allowed; }
+.chat-input-row button:not(:disabled):hover { opacity: 0.85; }
+</style>

--- a/examples/vue-dashboard/src/main.ts
+++ b/examples/vue-dashboard/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './style.css';
+
+createApp(App).mount('#app');

--- a/examples/vue-dashboard/src/style.css
+++ b/examples/vue-dashboard/src/style.css
@@ -1,0 +1,30 @@
+:root {
+  --bg: #07111f;
+  --surface: #0e1f35;
+  --surface-2: #152843;
+  --border: rgba(99, 179, 237, 0.12);
+  --accent: #4f46e5;
+  --accent-glow: rgba(79, 70, 229, 0.18);
+  --text: #e5eefb;
+  --text-muted: #7ba3c8;
+  --text-dim: #4a7a9b;
+  --green: #34d399;
+  --red: #f87171;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color-scheme: dark;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+}
+
+code, pre {
+  font-family: 'SFMono-Regular', ui-monospace, Menlo, monospace;
+}
+
+button, input { font: inherit; }

--- a/examples/vue-dashboard/vite.config.ts
+++ b/examples/vue-dashboard/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+});

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -280,7 +280,13 @@ export function createAskableRegionCapture(
     const wasActive = Boolean(overlay);
     removeOverlay();
     removeAffordance();
-    if (wasActive) options.onCancel?.();
+    if (wasActive) {
+      try {
+        options.onCancel?.();
+      } catch (err) {
+        console.error('[askable] onCancel callback threw:', err);
+      }
+    }
   };
 
   const ensureOverlay = () => {
@@ -460,7 +466,11 @@ export function createAskableRegionCapture(
     const nextSelection: AskableRegionCaptureState = { packet, selection };
     renderSelectionAffordance(packet, selection, nextSelection);
     setCurrentSelection(nextSelection);
-    options.onCapture?.(packet, selection);
+    try {
+      options.onCapture?.(packet, selection);
+    } catch (err) {
+      console.error('[askable] onCapture callback threw:', err);
+    }
   }
 
   function onPointerCancel() {
@@ -654,7 +664,11 @@ export function createAskableRegionCapture(
       event.preventDefault();
       const question = input.value.trim();
       if (!question) return;
-      prompt.onSubmit?.(question, packet, selection);
+      try {
+        prompt.onSubmit?.(question, packet, selection);
+      } catch (err) {
+        console.error('[askable] onSubmit callback threw:', err);
+      }
       input.value = '';
     });
     return form;

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -493,6 +493,8 @@ export function createAskableRegionCapture(
     if (!selectionAffordance || selectionAffordance.persist === false) return;
     removeAffordance(false);
 
+    removeAffordance();
+
     const custom = selectionAffordance.render?.(packet, selection);
     if (custom instanceof HTMLElement) {
       custom.id = custom.id || AFFORDANCE_ID;

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -503,7 +503,12 @@ export function createAskableRegionCapture(
     if (!selectionAffordance || selectionAffordance.persist === false) return;
     removeAffordance(false);
 
-    const custom = selectionAffordance.render?.(packet, selection);
+    let custom: HTMLElement | null | undefined | void;
+    try {
+      custom = selectionAffordance.render?.(packet, selection);
+    } catch (err) {
+      console.error('[askable] selectionAffordance.render callback threw:', err);
+    }
     if (custom instanceof HTMLElement) {
       custom.id = custom.id || AFFORDANCE_ID;
       custom.setAttribute(AFFORDANCE_ATTR, selection.shape);

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -493,8 +493,6 @@ export function createAskableRegionCapture(
     if (!selectionAffordance || selectionAffordance.persist === false) return;
     removeAffordance(false);
 
-    removeAffordance();
-
     const custom = selectionAffordance.render?.(packet, selection);
     if (custom instanceof HTMLElement) {
       custom.id = custom.id || AFFORDANCE_ID;

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -625,7 +625,11 @@ export class AskableContextImpl implements AskableContext {
       if (!active) return;
       const focus = this.currentFocus;
       const scopedFocus = this.matchesScope(focus, contextOptions.scope) ? focus : null;
-      callback(this.toContext(contextOptions), scopedFocus);
+      try {
+        callback(this.toContext(contextOptions), scopedFocus);
+      } catch (err) {
+        console.error('[askable] subscribe callback threw:', err);
+      }
     };
 
     const schedule = () => {

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -336,7 +336,13 @@ export function createAskableTextSelectionCapture(
   function cancel() {
     const wasActive = active;
     destroy();
-    if (wasActive) options.onCancel?.();
+    if (wasActive) {
+      try {
+        options.onCancel?.();
+      } catch (err) {
+        console.error('[askable] onCancel callback threw:', err);
+      }
+    }
   }
 
   return {

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -259,8 +259,12 @@ export function createAskableTextSelectionCapture(
     const nextSelection: AskableTextSelectionCaptureState = { packet, selection };
     renderSelectionAffordance(packet, selection, nextSelection);
     setCurrentSelection(nextSelection, currentOptions.onSelectionChange);
-    currentOptions.onCapture?.(packet, selection);
     if (currentOnce) stopListening();
+    try {
+      currentOptions.onCapture?.(packet, selection);
+    } catch (err) {
+      console.error('[askable] onCapture callback threw:', err);
+    }
     return packet;
   };
 

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -257,6 +257,52 @@ describe('createAskableMcpServer', () => {
   });
 });
 
+describe('requireRedacted option', () => {
+  function getToolHandlerStrict(provider: AskableMcpContextProvider, toolName: string): McpToolHandler {
+    const server = createAskableMcpServer({ provider, requireRedacted: true });
+    const tools = (server as unknown as { _registeredTools: Record<string, { handler: McpToolHandler }> })._registeredTools;
+    const tool = tools[toolName];
+    if (!tool) throw new Error(`Tool ${toolName} not registered`);
+    return tool.handler;
+  }
+
+  it('blocks get_current_context when packet is not redacted', async () => {
+    const packet = createWebContextPacket({ capture: { mode: 'element-focus' } });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const handler = getToolHandlerStrict(provider, 'get_current_context');
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not been redacted');
+  });
+
+  it('blocks format_context_for_prompt when packet is not redacted', async () => {
+    const packet = createWebContextPacket({ capture: { mode: 'element-focus' } });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const handler = getToolHandlerStrict(provider, 'format_context_for_prompt');
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not been redacted');
+  });
+
+  it('allows forwarding when packet is explicitly marked redacted', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'element-focus' },
+      privacy: { consent: 'explicit', redacted: true },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const handler = getToolHandlerStrict(provider, 'get_current_context');
+    const result = await handler({});
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('element-focus');
+  });
+});
+
 describe('createAskableMcpWebHandler', () => {
   it('handles stateless Streamable HTTP tool calls', async () => {
     const packet = createWebContextPacket({

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -37,6 +37,13 @@ export interface AskableMcpServerOptions {
   name?: string;
   version?: string;
   provider: AskableMcpContextProvider;
+  /**
+   * When `true`, tool calls that return a packet with `privacy.redacted === false`
+   * will fail with an error instead of forwarding potentially-unredacted data to
+   * the MCP client. Defaults to `false` for backwards compatibility — set to `true`
+   * when your app captures user-entered or sensitive content in `data-askable` attributes.
+   */
+  requireRedacted?: boolean;
 }
 
 export type AskableMcpStatelessTransportOptions = Omit<
@@ -304,6 +311,13 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
     async (args) => {
       try {
         const packet = await options.provider.getContext(args);
+        if (options.requireRedacted && packet.privacy?.redacted === false) {
+          console.warn('[askable-mcp] get_current_context blocked: packet has privacy.redacted=false');
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'Context packet has not been redacted. Configure a sanitizer or set requireRedacted: false.' }],
+          };
+        }
         return {
           content: [
             {
@@ -351,6 +365,13 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
     async (args) => {
       try {
         const packet = await options.provider.getContext(args);
+        if (options.requireRedacted && packet.privacy?.redacted === false) {
+          console.warn('[askable-mcp] format_context_for_prompt blocked: packet has privacy.redacted=false');
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'Context packet has not been redacted. Configure a sanitizer or set requireRedacted: false.' }],
+          };
+        }
         const text = options.provider.formatContextForPrompt
           ? await options.provider.formatContextForPrompt(packet, args)
           : defaultPromptFormatter(packet);

--- a/packages/react-native/src/useAskableScrollView.ts
+++ b/packages/react-native/src/useAskableScrollView.ts
@@ -120,13 +120,26 @@ export function useAskableScrollView<Item = unknown>(
         viewportBottom,
       }));
 
-    const selected = selectVisible(visibleItems);
+    let selected: ReturnType<typeof selectVisible>;
+    try {
+      selected = selectVisible(visibleItems);
+    } catch {
+      return;
+    }
     if (!selected) {
       clearVisibleItem();
       return;
     }
 
-    scrollCtx.push(getMeta(selected.item, selected), getText?.(selected.item, selected) ?? '');
+    let meta: ReturnType<typeof getMeta>;
+    let text: string;
+    try {
+      meta = getMeta(selected.item, selected);
+      text = getText?.(selected.item, selected) ?? '';
+    } catch {
+      return;
+    }
+    scrollCtx.push(meta, text);
   }, [active, clearVisibleItem, getMeta, getText, scrollCtx, selectVisible]);
 
   const onScroll = useCallback(

--- a/site/www/index.html
+++ b/site/www/index.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>askable-ui — UI context your model can actually use</title>
-  <meta name="description" content="Mark UI, regions, circles, lasso selections, and highlighted text as usable AI context. React, Vue, Svelte, or plain HTML." />
+  <title>askable-ui — Your LLM doesn't know what the user is looking at. Fix that.</title>
+  <meta name="description" content="One HTML attribute. Your AI knows exactly what the user sees — no screenshots, no prompt engineering. Works with Claude Desktop, Cursor, CopilotKit, Vercel AI SDK, and any LLM. React, Vue, Svelte, Vanilla JS." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://askable-ui.com/" />
-  <meta property="og:title" content="askable-ui — UI context your model can actually use" />
-  <meta property="og:description" content="Mark UI, regions, circles, lasso selections, and highlighted text as usable AI context. React, Vue, Svelte, or plain HTML." />
+  <meta property="og:title" content="askable-ui — Your LLM doesn't know what the user is looking at. Fix that." />
+  <meta property="og:description" content="One HTML attribute. Your AI knows exactly what the user sees — no screenshots, no prompt engineering. Works with Claude Desktop, Cursor, CopilotKit, Vercel AI SDK, and any LLM." />
   <meta property="og:image" content="https://askable-ui.com/social.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="askable-ui — UI context your model can actually use" />
-  <meta name="twitter:description" content="Element focus, region capture, lasso, circle, and selected text as context your model can use." />
+  <meta name="twitter:title" content="askable-ui — Your LLM doesn't know what the user is looking at. Fix that." />
+  <meta name="twitter:description" content="One HTML attribute gives your AI real-time UI context. Works with Claude Desktop, Cursor, CopilotKit, and any LLM. No screenshots. No prompt engineering." />
   <meta name="twitter:image" content="https://askable-ui.com/social.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -840,7 +840,7 @@
     <div class="nav-links">
       <a href="#demo" class="nav-link">Demo</a>
       <a href="#patterns" class="nav-link">Patterns</a>
-      <a href="#integrations" class="nav-link">MCP</a>
+      <a href="#mcp" class="nav-link">MCP</a>
       <a href="#packages" class="nav-link">Packages</a>
       <a href="https://askable-ui.com/docs/" target="_blank" rel="noopener noreferrer" class="nav-link">Docs</a>
       <a href="https://github.com/askable-ui/askable" target="_blank" rel="noopener noreferrer" class="nav-gh" aria-label="GitHub repository" title="GitHub repository">
@@ -854,12 +854,12 @@
   <main class="page-shell">
     <section class="hero">
       <div class="hero-copy">
-        <div class="eyebrow"><span class="spark">✦</span> Context for AI-native interfaces</div>
+        <div class="eyebrow"><span class="spark">✦</span> Claude Desktop · Cursor · CopilotKit · any LLM</div>
         <h1>Your model knows what <em>the user means.</em></h1>
         <p>
-          Mark a clicked element, drawn region, circled anomaly, lassoed area, or highlighted text,
-          then package the user's question with <code>askable.toAgentRequest()</code> at the AI boundary.
-          The assistant gets explicit user intent instead of guessing from the whole page.
+          Your AI copilot can't tell which metric the user is looking at, which row triggered the question,
+          or what they highlighted. askable-ui fixes that with one attribute — no screenshots, no stale system
+          prompts, no guessing. The AI gets the exact data the user sees, updated on every interaction.
         </p>
         <div class="hero-patterns" aria-label="Supported interaction patterns">
           <span class="hero-pattern-pill">Click</span>
@@ -1250,8 +1250,18 @@ ctx.push(meta, text);</pre>
     <section id="integrations" class="section">
       <p class="section-label">Integrations</p>
       <h2 class="section-title">Plugs into your AI layer.</h2>
-      <p class="section-sub"><code>toAgentRequest()</code> returns a JSON-ready request with prompt text, packet data, selected source context, and tracing metadata.</p>
-      <div class="pkg-grid" style="grid-template-columns: repeat(4, minmax(0, 1fr));">
+      <p class="section-sub"><code>toPromptContext()</code> returns a plain string. Pass it to any LLM framework or API — no adapter needed.</p>
+      <div class="pkg-grid" style="grid-template-columns: repeat(5, minmax(0, 1fr));">
+        <div class="pkg-card" style="cursor:default;">
+          <div class="pkg-badge">MCP client</div>
+          <div class="pkg-name">Claude Desktop</div>
+          <div class="pkg-desc">Claude sees exactly what the user sees. Ask about the focused element without screenshots.</div>
+        </div>
+        <div class="pkg-card" style="cursor:default;">
+          <div class="pkg-badge">MCP client</div>
+          <div class="pkg-name">Cursor</div>
+          <div class="pkg-desc">Your IDE agent reads live UI context via the askable MCP server. Accurate, no manual description.</div>
+        </div>
         <div class="pkg-card" style="cursor:default;">
           <div class="pkg-badge">Framework</div>
           <div class="pkg-name">CopilotKit</div>
@@ -1263,14 +1273,9 @@ ctx.push(meta, text);</pre>
           <div class="pkg-desc">Inject into the system message or tool context for streaming chat UIs.</div>
         </div>
         <div class="pkg-card" style="cursor:default;">
-          <div class="pkg-badge">Framework</div>
-          <div class="pkg-name">LangChain</div>
-          <div class="pkg-desc">Drop into a prompt template variable or tool description for context-aware agents.</div>
-        </div>
-        <div class="pkg-card" style="cursor:default;">
           <div class="pkg-badge">Any LLM API</div>
-          <div class="pkg-name">Direct API</div>
-          <div class="pkg-desc">Append the string to your system or user message. Works with OpenAI, Anthropic, or any provider.</div>
+          <div class="pkg-name">OpenAI · Anthropic</div>
+          <div class="pkg-desc">Append the string to your system or user message. Works with any provider.</div>
         </div>
       </div>
 
@@ -1333,18 +1338,70 @@ ctx.push(meta, text);</pre>
       </div>
     </section>
 
+    <section id="mcp" class="section">
+      <p class="section-label">MCP — Model Context Protocol</p>
+      <h2 class="section-title">Give Claude Desktop eyes into your app.</h2>
+      <p class="section-sub">Expose your app's live UI context as an MCP server. Claude, Cursor, and any MCP client can call <code>get_current_context</code> to see exactly what the user is looking at — no screenshots, no description needed.</p>
+      <div class="pattern-shell">
+        <article class="pattern-copy">
+          <div>
+            <h3>Three lines to an MCP server.</h3>
+            <p>Any page annotated with <code>data-askable</code> instantly becomes queryable by AI agents. The MCP bridge translates live DOM state into structured Context packets that agents can read and reason about.</p>
+          </div>
+          <pre class="step-code" style="font-size:.78rem;line-height:1.65;background:#f4f6fa;border:1px solid rgba(0,0,0,0.07);border-radius:12px;padding:1rem;overflow-x:auto;white-space:pre">import { createAskableMcpServer } from '@askable-ui/mcp';
+
+const server = createAskableMcpServer({ provider });
+server.connect(transport); // stdio, SSE, or WebSocket</pre>
+        </article>
+        <div class="pattern-stack">
+          <article class="pattern-card">
+            <div class="pattern-icon">↗</div>
+            <h4>get_current_context</h4>
+            <p>Returns the focused element's structured metadata, surrounding context, and interaction history as a typed JSON packet.</p>
+          </article>
+          <article class="pattern-card">
+            <div class="pattern-icon">T</div>
+            <h4>format_context_for_prompt</h4>
+            <p>Returns a prompt-ready text rendering of the current context — drop it directly into any system message.</p>
+          </article>
+          <article class="pattern-card">
+            <div class="pattern-icon">🔒</div>
+            <h4>Privacy gate built in</h4>
+            <p>Set <code>requireRedacted: true</code> to block unredacted packets from leaving the page. PII stays in your app.</p>
+          </article>
+          <article class="pattern-card">
+            <div class="pattern-icon">◇</div>
+            <h4>Schema resource</h4>
+            <p>The MCP server exposes the full Context packet JSON Schema so agents can self-document and validate responses.</p>
+          </article>
+        </div>
+      </div>
+      <div style="margin-top:1.5rem;background:#f9fafb;border:1px solid rgba(0,0,0,0.07);border-radius:16px;padding:1.25rem 1.5rem;">
+        <p style="font-size:.78rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-3);margin-bottom:.75rem;">claude_desktop_config.json</p>
+        <pre style="font-size:.8rem;line-height:1.65;color:#374151;font-family:ui-monospace,'SF Mono',SFMono-Regular,Menlo,monospace;overflow-x:auto;white-space:pre">{
+  "mcpServers": {
+    "my-app": {
+      "command": "node",
+      "args": ["./mcp-server.js"]
+    }
+  }
+}</pre>
+        <p style="margin-top:.85rem;font-size:.84rem;color:var(--ink-2)">→ <a href="https://askable-ui.com/docs/guide/mcp" style="color:var(--accent);text-decoration:none;font-weight:600">Full MCP integration guide</a></p>
+      </div>
+    </section>
+
     <div class="cta-section">
       <div class="cta-card">
-        <h2>Start with one attribute.</h2>
-        <p>Drop <code style="color:rgba(255,255,255,0.75);background:rgba(255,255,255,0.1)">data-askable</code> on your most important element. Working context in under five minutes.</p>
+        <h2>Your AI. Your UI. Finally connected.</h2>
+        <p>Drop <code style="color:rgba(255,255,255,0.75);background:rgba(255,255,255,0.1)">data-askable</code> on your most important element. Working context in under five minutes — or scaffold a full copilot app in one command.</p>
         <div class="cta-actions">
           <a href="https://askable-ui.com/docs/" target="_blank" rel="noopener noreferrer" class="btn btn-inverse">Read the docs</a>
-          <a href="https://github.com/askable-ui/askable" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-white btn-icon" aria-label="GitHub repository" title="GitHub repository">
+          <a href="https://askable-mu.vercel.app/" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-white">Live demo ↗</a>
+          <a href="https://github.com/askable-ui/askable" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-white btn-icon" aria-label="GitHub repository" title="Star on GitHub">
             <svg class="github-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path d="M12 2C6.48 2 2 6.59 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.09.68-.22.68-.49 0-.24-.01-1.05-.01-1.9-2.51.47-3.16-.63-3.36-1.21-.11-.3-.6-1.21-1.03-1.46-.35-.19-.85-.66-.01-.67.79-.01 1.35.74 1.54 1.05.9 1.55 2.34 1.11 2.91.85.09-.67.35-1.11.64-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.71 0 0 .84-.28 2.75 1.05A9.28 9.28 0 0 1 12 6.98c.85 0 1.71.12 2.51.35 1.91-1.33 2.75-1.05 2.75-1.05.55 1.4.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.8-4.57 5.06.36.32.68.93.68 1.89 0 1.36-.01 2.46-.01 2.8 0 .27.18.59.69.49A10.12 10.12 0 0 0 22 12.25C22 6.59 17.52 2 12 2Z"/>
             </svg>
           </a>
-          <a href="https://www.npmjs.com/package/@askable-ui/core" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-white">npm install</a>
         </div>
       </div>
     </div>
@@ -1353,6 +1410,8 @@ ctx.push(meta, text);</pre>
       <span>askable-ui — context that feels native to the UI</span>
       <div style="display:flex;gap:1rem;flex-wrap:wrap">
         <a href="https://askable-ui.com/docs/" target="_blank" rel="noopener noreferrer">Docs</a>
+        <a href="https://askable-ui.com/docs/guide/mcp" target="_blank" rel="noopener noreferrer">MCP guide</a>
+        <a href="https://askable-mu.vercel.app/" target="_blank" rel="noopener noreferrer">Live demo</a>
         <a href="https://github.com/askable-ui/askable" target="_blank" rel="noopener noreferrer">GitHub</a>
         <a href="https://www.npmjs.com/org/askable-ui" target="_blank" rel="noopener noreferrer">npm</a>
         <a href="https://github.com/askable-ui/askable/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>


### PR DESCRIPTION
## Summary

### Viral growth features

- **README.md — full rewrite** with problem-first framing, before/after comparison, prominent MCP section, and links to all demos
- **`examples/vanilla-chat/index.html`** — zero-install single-file demo: open in any browser, no build step. Loads `@askable-ui/core` from CDN, has a full analytics dashboard (3 KPIs + 4 deals) with real-time "What the AI sees" panel and mock AI chat that gives context-accurate responses
- **`examples/vue-dashboard/`** — Vue 3 + Vite dashboard example targeting the Vue community. Same data, idiomatic `<Askable>` + `useAskable()` pattern, live context panel, mock chat
- **`site/www/index.html` — website improvements:**
  - Updated page title and OG/Twitter meta tags with sharper, viral copy
  - Hero eyebrow: now calls out "Claude Desktop · Cursor · CopilotKit · any LLM"
  - Hero body paragraph: problem-first framing ("no screenshots, no guessing")
  - Nav: MCP link added
  - Integrations section: Claude Desktop and Cursor added as MCP client cards (5 total)
  - New dedicated MCP section with code example, Claude Desktop config JSON, and 4 feature cards
  - CTA: "Your AI. Your UI. Finally connected." + Live demo link
  - Footer: MCP guide and Live demo links

### Security hardening (7 commits)

- `mcp/index.ts`: generic error messages (no raw exception leakage); `requireRedacted` option blocks forwarding non-redacted packets to MCP clients
- `observer.ts`: querySelector wrapped in try/catch; parseMeta validates JSON is a plain object before casting
- `context.ts`: querySelector try/catch; sync `subscribe()` callback now guarded to match `subscribeAsync()`
- `capture.ts`: `onCapture`, `onCancel`, `onSubmit`, and `selectionAffordance.render` all wrapped; duplicate `removeAffordance()` call removed
- `selection.ts`: `onCapture` and `onCancel` wrapped; `destroy()` moved before `onCapture` so listeners can't leak if callback throws
- `useAskableTextSelectionCapture.ts` (React): stale closure fix — uses `optionsRef.current` instead of closure snapshot
- `useAskableScrollView.ts` (React Native): `selectVisible`/`getMeta`/`getText` callbacks wrapped
- `scaffold.js`: path traversal guard (`targetDir.startsWith(cwd)`)

## Test plan

- [ ] `cd packages/core && npx vitest run` — 225 tests pass
- [ ] `cd packages/mcp && npx vitest run` — 13 tests pass (includes 3 new `requireRedacted` tests)
- [ ] `cd packages/react && npx vitest run` — 58 tests pass (includes stale closure test)
- [ ] Open `examples/vanilla-chat/index.html` in a browser — click KPI cards, see context update, chat works
- [ ] `cd examples/vue-dashboard && npm install && npm run dev` — dashboard loads, context panel updates on click

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_