### PR TITLE
chore(release): bump packages to 0.15.0

### DIFF
--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.14.0",
+    "@askable-ui/react": "^0.15.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/angular-dashboard/package.json
+++ b/examples/angular-dashboard/package.json
@@ -15,7 +15,7 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
-    "@askable-ui/angular": "^0.14.0",
+    "@askable-ui/angular": "^0.15.0",
     "rxjs": "^7.8.1",
     "zone.js": "^0.15.0"
   },

--- a/examples/mcp-server/package.json
+++ b/examples/mcp-server/package.json
@@ -9,7 +9,7 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "@askable-ui/mcp": "^0.14.0",
+    "@askable-ui/mcp": "^0.15.0",
     "express": "^4.21.0"
   }
 }

--- a/examples/nextjs-app-router/package.json
+++ b/examples/nextjs-app-router/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",
-    "@askable-ui/react": "^0.14.0",
+    "@askable-ui/react": "^0.15.0",
     "ai": "^4.3.15",
     "next": "^15.3.3",
     "react": "^19.0.0",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.14.0",
-    "@askable-ui/react-native": "^0.14.0",
+    "@askable-ui/core": "^0.15.0",
+    "@askable-ui/react-native": "^0.15.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/examples/solid-dashboard/package.json
+++ b/examples/solid-dashboard/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/solid": "^0.14.0",
+    "@askable-ui/solid": "^0.15.0",
     "solid-js": "^1.9.7"
   },
   "devDependencies": {

--- a/examples/svelte-dashboard/package.json
+++ b/examples/svelte-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/svelte": "^0.14.0",
+    "@askable-ui/svelte": "^0.15.0",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/examples/vercel-ai-sdk/package.json
+++ b/examples/vercel-ai-sdk/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.14.0",
+    "@askable-ui/react": "^0.15.0",
     "ai": "^4.3.16",
     "@ai-sdk/openai": "^1.3.22",
     "next": "^15.3.3",

--- a/examples/vue-dashboard/package.json
+++ b/examples/vue-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/vue": "^0.14.0",
+    "@askable-ui/vue": "^0.15.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "workspaces": [
         "packages/*"
       ],
@@ -8738,10 +8738,10 @@
     },
     "packages/angular": {
       "name": "@askable-ui/angular",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@analogjs/vite-plugin-angular": "^1.18.3",
@@ -10087,7 +10087,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -10096,10 +10096,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.14.0"
+        "@askable-ui/context": "^0.15.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -10109,7 +10109,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -10117,11 +10117,11 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.14.0",
-        "@askable-ui/core": "^0.14.0",
+        "@askable-ui/context": "^0.15.0",
+        "@askable-ui/core": "^0.15.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -10132,10 +10132,10 @@
     },
     "packages/qwik": {
       "name": "@askable-ui/qwik",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@builder.io/qwik": "^1.14.1",
@@ -10757,10 +10757,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -10780,10 +10780,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.17",
@@ -10837,10 +10837,10 @@
     },
     "packages/solid": {
       "name": "@askable-ui/solid",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@solidjs/testing-library": "^0.8.10",
@@ -10856,10 +10856,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -10875,10 +10875,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@vue/test-utils": "^2.4.11",
@@ -10893,10 +10893,10 @@
     },
     "packages/web-component": {
       "name": "@askable-ui/web-component",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/angular",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Angular service and directive to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -47,7 +47,7 @@
     "@angular/core": ">=16.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.14.0"
+    "@askable-ui/core": "^0.15.0"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^1.18.3",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Give AI assistants real-time context about what users see and select in your UI",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.14.0"
+    "@askable-ui/context": "^0.15.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Scaffold an AI-native app with askable-ui — React, Vue, Svelte, or Next.js in one command",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.14.0';
+const ASKABLE_VERSION = '0.15.0';
 const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "MCP server and page bridge to expose UI context to Claude Desktop, Cursor, and any MCP client",
   "type": "module",
   "main": "./dist/index.js",
@@ -43,8 +43,8 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.14.0",
-    "@askable-ui/core": "^0.14.0",
+    "@askable-ui/context": "^0.15.0",
+    "@askable-ui/core": "^0.15.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/qwik",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Qwik hooks and components to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "@builder.io/qwik": ">=1.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.14.0"
+    "@askable-ui/core": "^0.15.0"
   },
   "devDependencies": {
     "@builder.io/qwik": "^1.14.1",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "React Native hooks to give AI assistants real-time scroll context for mobile apps",
   "type": "module",
   "main": "./dist/index.js",
@@ -43,7 +43,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.14.0"
+    "@askable-ui/core": "^0.15.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.17",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "React hooks to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.14.0"
+    "@askable-ui/core": "^0.15.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/solid",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "SolidJS primitives to give AI assistants real-time context about what users see and interact with",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
     "solid-js": ">=1.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.14.0"
+    "@askable-ui/core": "^0.15.0"
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Svelte 4 & 5 stores and runes to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -135,7 +135,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.14.0"
+    "@askable-ui/core": "^0.15.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Vue 3 composables to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.14.0"
+    "@askable-ui/core": "^0.15.0"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.4.11",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/web-component",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Zero-dependency custom element <askable-context> that works in any framework or vanilla HTML",
   "type": "module",
   "main": "./dist/index.js",
@@ -44,7 +44,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/core": "^0.14.0"
+    "@askable-ui/core": "^0.15.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -7,14 +7,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.14.0`
-- Versioned current docs URL: `/docs/v0.14.0/`
+- Latest stable: `v0.15.0`
+- Versioned current docs URL: `/docs/v0.15.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.14.0/` so version-specific links work before the first breaking release.
+The current release is also published at `/docs/v0.15.0/` so version-specific links work before the first breaking release.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.14.0**.
+> Current npm release: **v0.15.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,6 +1,6 @@
-# What’s New in v0.14.0
+# What’s New in v0.15.0
 
-askable-ui v0.14.0 adds browser-local MCP page resources, so trusted
+askable-ui v0.15.0 adds browser-local MCP page resources, so trusted
 extensions and local companions can read approved page context as
 `askable://current` without scraping the DOM.
 
@@ -39,7 +39,7 @@ context options.
 
 The main website navigation now uses a compact split-pill header, and the WebMCP
 section calls out `read_current_resource` alongside hosted MCP. New starter apps
-now pin Askable packages to `^0.14.0`.
+now pin Askable packages to `^0.15.0`.
 
 ## Also in v0.13.1
 
@@ -288,8 +288,8 @@ browser tools, and agent runtimes.
 
 ### Starter and docs version alignment
 
-`npm create @askable-ui/app` now scaffolds projects pinned to `^0.14.0`, and the
-versioned docs have been advanced to `/docs/v0.14.0/`.
+`npm create @askable-ui/app` now scaffolds projects pinned to `^0.15.0`, and the
+versioned docs have been advanced to `/docs/v0.15.0/`.
 
 ## Recommended next step
 
@@ -301,7 +301,7 @@ If you are integrating Askable into an AI or agent runtime, start here:
 
 ## Version note
 
-The current published docs track **v0.14.0** at both:
+The current published docs track **v0.15.0** at both:
 
 - `/docs/`
-- `/docs/v0.14.0/`
+- `/docs/v0.15.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.14.0**.
+> Current npm release: **v0.15.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,11 +59,11 @@ features:
   </video>
 </div>
 
-## Latest in v0.14.0
+## Latest in v0.15.0
 
 - browser-local MCP page resources with `read_current_resource` and `askable://current`
 - page bridge responses that return resource-shaped JSON or prompt-ready text for local companions
-- starter app dependency pins advanced to `^0.14.0`
+- starter app dependency pins advanced to `^0.15.0`
 - main website navigation and WebMCP copy aligned with the browser-local MCP flow
 
 ## Also in v0.13.1
@@ -84,7 +84,7 @@ features:
 - agent request packaging with `toAgentRequest()`
 - source-backed live subscriptions with `subscribeAsync()`
 - point-path metadata on lasso Context packets
-- starter app dependency pins advanced to `^0.14.0`
+- starter app dependency pins advanced to `^0.15.0`
 - continued support for region/circle/text capture, MCP Context packets, and framework wrappers
 
 ## Interaction patterns
@@ -105,7 +105,7 @@ Every pattern can produce a prompt string with `toPromptContext()` or a structur
 
 Start here:
 
-- [What’s New in v0.14.0](/guide/whats-new)
+- [What’s New in v0.15.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [React interaction patterns](/guide/react#region-circle-and-lasso-capture)
 - [AI SDK integration patterns](/examples/ai-sdk)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.14.0",
-    "slug": "v0.14.0"
+    "label": "v0.15.0",
+    "slug": "v0.15.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.14.0`) is built on every deploy and published to both:
+The current release (`v0.15.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.14.0/` (version-specific URL)
+- `/docs/v0.15.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- bump all 12 public packages to `0.15.0`
- align internal dependency ranges, examples, and create-app scaffolding
- advance current-version documentation to `v0.15.0`

## Verification
- `npm ci`
- `npm run build --workspaces --if-present`
- `npm run test --workspaces --if-present`
- `npm run test:e2e` (134 passed, 1 skipped)
- `npm --prefix site/docs run build`
- focused npm audits
- all 12 public packages: `npm pack --dry-run --json`

## Merge blocker
The following first-time packages must be bootstrapped on npm and configured with `publish_release.yml` as their trusted publisher before this PR merges:
- `@askable-ui/angular`
- `@askable-ui/qwik`
- `@askable-ui/solid`
- `@askable-ui/web-component`

The repository currently has no npm token secret, and npm requires a package to exist before a trusted publisher can be configured.