### PR TITLE
feat(qwik): major expansion + Angular in getting-started guide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "workspaces": [
         "packages/*"
       ],
@@ -5287,9 +5287,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -8738,10 +8738,10 @@
     },
     "packages/angular": {
       "name": "@askable-ui/angular",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@analogjs/vite-plugin-angular": "^1.18.3",
@@ -10087,7 +10087,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -10096,10 +10096,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.14.0"
+        "@askable-ui/context": "^0.15.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -10109,7 +10109,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -10117,11 +10117,11 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.14.0",
-        "@askable-ui/core": "^0.14.0",
+        "@askable-ui/context": "^0.15.0",
+        "@askable-ui/core": "^0.15.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -10132,10 +10132,10 @@
     },
     "packages/qwik": {
       "name": "@askable-ui/qwik",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@builder.io/qwik": "^1.14.1",
@@ -10757,10 +10757,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -10780,10 +10780,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.17",
@@ -10837,10 +10837,10 @@
     },
     "packages/solid": {
       "name": "@askable-ui/solid",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@solidjs/testing-library": "^0.8.10",
@@ -10856,10 +10856,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -10875,10 +10875,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "@vue/test-utils": "^2.4.11",
@@ -10893,10 +10893,10 @@
     },
     "packages/web-component": {
       "name": "@askable-ui/web-component",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -1,9 +1,50 @@
 export { Askable } from './Askable.js';
+export type { AskableProps } from './Askable.js';
+
 export { useAskable } from './useAskable.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
+
+export { useAskableSource } from './useAskableSource.js';
+export type { UseAskableSourceOptions, UseAskableSourceResult } from './useAskableSource.js';
+
 export { useAskableAgent } from './useAskableAgent.js';
 export type { AskableAgentStatus, UseAskableAgentOptions, UseAskableAgentResult } from './useAskableAgent.js';
-export type { AskableProps } from './Askable.js';
+
+export { useAskableStream } from './useAskableStream.js';
+export type { AskableStreamStatus, AskableStreamHandler, UseAskableStreamOptions, UseAskableStreamResult } from './useAskableStream.js';
+
+export { useAskableChat } from './useAskableChat.js';
+export type { AskableChatRole, AskableChatMessage, AskableChatStatus, AskableChatStreamHandler, UseAskableChatOptions, UseAskableChatResult } from './useAskableChat.js';
+
+export { useAskableHistory } from './useAskableHistory.js';
+export type { UseAskableHistoryOptions, UseAskableHistoryResult } from './useAskableHistory.js';
+
+export { useAskablePageSource } from './useAskablePageSource.js';
+export type { UseAskablePageSourceOptions, UseAskablePageSourceResult } from './useAskablePageSource.js';
+
+export { useAskableNavigationSource } from './useAskableNavigationSource.js';
+export type { UseAskableNavigationSourceOptions, UseAskableNavigationSourceResult, AskableNavigationEntry } from './useAskableNavigationSource.js';
+
+export { useAskableFormSource } from './useAskableFormSource.js';
+export type { UseAskableFormSourceOptions, UseAskableFormSourceResult } from './useAskableFormSource.js';
+
+export { useAskableTableSource } from './useAskableTableSource.js';
+export type { UseAskableTableSourceOptions, UseAskableTableSourceResult } from './useAskableTableSource.js';
+
+export { useAskableUserSource } from './useAskableUserSource.js';
+export type { UseAskableUserSourceOptions, UseAskableUserSourceResult } from './useAskableUserSource.js';
+
+export { useAskableErrorSource } from './useAskableErrorSource.js';
+export type { UseAskableErrorSourceOptions, UseAskableErrorSourceResult } from './useAskableErrorSource.js';
+
+export { useAskableNotificationSource } from './useAskableNotificationSource.js';
+export type { UseAskableNotificationSourceOptions, UseAskableNotificationSourceResult, AskableNotification, AskableNotificationSeverity } from './useAskableNotificationSource.js';
+
+export { useAskableCartSource } from './useAskableCartSource.js';
+export type { UseAskableCartSourceOptions, UseAskableCartSourceResult, AskableCartItem, AskableCartSourceSnapshot, AskableCartTotals } from './useAskableCartSource.js';
+
+export { useAskableMultistepSource } from './useAskableMultistepSource.js';
+export type { UseAskableMultistepSourceOptions, UseAskableMultistepSourceResult, AskableMultistepStep, AskableMultistepSourceSnapshot } from './useAskableMultistepSource.js';
 
 // Re-export typed meta utility from core for convenience
 export { asMeta } from '@askable-ui/core';

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -32,10 +32,10 @@ export { useAskableTableSource } from './useAskableTableSource.js';
 export type { UseAskableTableSourceOptions, UseAskableTableSourceResult } from './useAskableTableSource.js';
 
 export { useAskableUserSource } from './useAskableUserSource.js';
-export type { UseAskableUserSourceOptions, UseAskableUserSourceResult } from './useAskableUserSource.js';
+export type { UseAskableUserSourceOptions, UseAskableUserSourceResult, AskableUserProfile } from './useAskableUserSource.js';
 
 export { useAskableErrorSource } from './useAskableErrorSource.js';
-export type { UseAskableErrorSourceOptions, UseAskableErrorSourceResult } from './useAskableErrorSource.js';
+export type { UseAskableErrorSourceOptions, UseAskableErrorSourceResult, AskableErrorEntry } from './useAskableErrorSource.js';
 
 export { useAskableNotificationSource } from './useAskableNotificationSource.js';
 export type { UseAskableNotificationSourceOptions, UseAskableNotificationSourceResult, AskableNotification, AskableNotificationSeverity } from './useAskableNotificationSource.js';

--- a/packages/qwik/src/useAskable.ts
+++ b/packages/qwik/src/useAskable.ts
@@ -1,4 +1,4 @@
-import { useSignal, useVisibleTask$, useTask$ } from '@builder.io/qwik';
+import { useSignal, useVisibleTask$ } from '@builder.io/qwik';
 import { createAskableContext } from '@askable-ui/core';
 import type { AskableContext, AskableContextOptions, AskableEvent, AskableFocus } from '@askable-ui/core';
 
@@ -15,9 +15,43 @@ export interface UseAskableResult {
 
 const DEFAULT_EVENTS: AskableEvent[] = ['click', 'hover', 'focus'];
 
+// Module-level cache so all hooks in the same page share one default context
+const globalCtxByKey = new Map<string, AskableContext>();
+const globalRefCount = new Map<string, number>();
+
+function sharedKey(options?: UseAskableOptions): string {
+  const name = options?.name?.trim() ? `name:${options.name.trim()}` : 'global';
+  const evts = (options?.events ?? DEFAULT_EVENTS).slice().sort().join('|');
+  return `${name}::${evts}`;
+}
+
+function retainCtx(key: string, options?: UseAskableOptions): AskableContext {
+  const existing = globalCtxByKey.get(key);
+  if (existing) {
+    globalRefCount.set(key, (globalRefCount.get(key) ?? 0) + 1);
+    return existing;
+  }
+  const ctx = createAskableContext(options);
+  globalCtxByKey.set(key, ctx);
+  globalRefCount.set(key, 1);
+  ctx.observe(document, { events: options?.events ?? DEFAULT_EVENTS });
+  return ctx;
+}
+
+function releaseCtx(key: string): void {
+  const count = (globalRefCount.get(key) ?? 1) - 1;
+  if (count > 0) { globalRefCount.set(key, count); return; }
+  globalRefCount.delete(key);
+  globalCtxByKey.get(key)?.destroy();
+  globalCtxByKey.delete(key);
+}
+
 /**
- * Qwik hook that creates an AskableContext, observes the document, and
- * returns reactive signals for the current focus and prompt context.
+ * Qwik hook that creates (or shares) an AskableContext and returns reactive
+ * signals for the current focus and prompt context.
+ *
+ * Multiple calls with the same options share a single context instance so all
+ * source hooks on the page read from the same focus stream.
  *
  * @example
  * ```tsx
@@ -33,17 +67,14 @@ const DEFAULT_EVENTS: AskableEvent[] = ['click', 'hover', 'focus'];
 export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const focus = useSignal<AskableFocus | null>(null);
   const promptContext = useSignal<string>('');
+  const usesProvidedCtx = Boolean(options?.ctx);
 
-  // ctx lives outside signals — it's imperatively managed
   let ctx: AskableContext | null = null;
+  const key = sharedKey(options);
 
   // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(({ cleanup }) => {
-    ctx = options?.ctx ?? createAskableContext(options);
-
-    if (!options?.ctx) {
-      ctx.observe(document, { events: options?.events ?? DEFAULT_EVENTS });
-    }
+    ctx = usesProvidedCtx ? options!.ctx! : retainCtx(key, options);
 
     const handleFocus = (f: AskableFocus) => {
       focus.value = f;
@@ -60,7 +91,7 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
     cleanup(() => {
       ctx!.off('focus', handleFocus);
       ctx!.off('clear', handleClear);
-      if (!options?.ctx) ctx!.destroy();
+      if (!usesProvidedCtx) releaseCtx(key);
       ctx = null;
     });
   });

--- a/packages/qwik/src/useAskableCartSource.ts
+++ b/packages/qwik/src/useAskableCartSource.ts
@@ -1,0 +1,100 @@
+import { useSignal } from '@builder.io/qwik';
+import { createAskableCartSource, buildCartSnapshot } from '@askable-ui/core';
+import type {
+  AskableCreateCartSourceOptions,
+  AskableCartItem,
+  AskableCartSourceSnapshot,
+  AskableCartTotals,
+} from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export type { AskableCartItem, AskableCartSourceSnapshot, AskableCartTotals };
+
+export interface UseAskableCartSourceOptions
+  extends UseAskableSourceOptions,
+    Omit<AskableCreateCartSourceOptions, 'getSnapshot'> {
+  id?: string;
+  items?: AskableCartItem[];
+  totals?: AskableCartTotals;
+}
+
+export interface UseAskableCartSourceResult extends UseAskableSourceResult {
+  snapshot: ReturnType<typeof useSignal<AskableCartSourceSnapshot | null>>;
+  addItem(item: AskableCartItem): void;
+  removeItem(id: string): void;
+  updateQuantity(id: string, quantity: number): void;
+  setItems(items: AskableCartItem[]): void;
+  setTotals(totals: AskableCartTotals): void;
+  clearCart(): void;
+}
+
+/**
+ * Qwik hook that tracks shopping cart state and exposes it to AI assistants.
+ *
+ * ```tsx
+ * export const CartWidget = component$(() => {
+ *   const { snapshot, addItem } = useAskableCartSource({
+ *     items: [], totals: { currency: 'USD' },
+ *   });
+ *   return <p>{snapshot.value?.itemCount} items</p>;
+ * });
+ * ```
+ */
+export function useAskableCartSource(options: UseAskableCartSourceOptions = {}): UseAskableCartSourceResult {
+  const { id = 'cart', items: initialItems = [], totals: initialTotals = {}, describe, kind, enabled, ctx, name, events } = options;
+
+  const snapshot = useSignal<AskableCartSourceSnapshot | null>(
+    buildCartSnapshot(initialItems, initialTotals, new Date().toISOString()),
+  );
+
+  const source = createAskableCartSource({ describe, kind, getSnapshot: () => snapshot.value });
+  const result = useAskableSource(id, source, { enabled, ctx, name, events });
+
+  function getTotals(): AskableCartTotals {
+    const s = snapshot.value;
+    return s ? { discount: s.discount, tax: s.tax, shipping: s.shipping, currency: s.currency, couponCode: s.couponCode } : {};
+  }
+
+  function addItem(item: AskableCartItem): void {
+    const prev = snapshot.value;
+    if (!prev) return;
+    const idx = prev.items.findIndex((i) => i.id === item.id);
+    const items = idx >= 0 ? prev.items.map((i, k) => (k === idx ? item : i)) : [...prev.items, item];
+    snapshot.value = buildCartSnapshot(items, getTotals(), new Date().toISOString());
+    result.notifyChanged();
+  }
+
+  function removeItem(id: string): void {
+    if (!snapshot.value) return;
+    snapshot.value = buildCartSnapshot(snapshot.value.items.filter((i) => i.id !== id), getTotals(), new Date().toISOString());
+    result.notifyChanged();
+  }
+
+  function updateQuantity(id: string, quantity: number): void {
+    if (!snapshot.value) return;
+    const items = quantity <= 0
+      ? snapshot.value.items.filter((i) => i.id !== id)
+      : snapshot.value.items.map((i) => (i.id === id ? { ...i, quantity } : i));
+    snapshot.value = buildCartSnapshot(items, getTotals(), new Date().toISOString());
+    result.notifyChanged();
+  }
+
+  function setItems(items: AskableCartItem[]): void {
+    snapshot.value = buildCartSnapshot(items, getTotals(), new Date().toISOString());
+    result.notifyChanged();
+  }
+
+  function setTotals(totals: AskableCartTotals): void {
+    if (!snapshot.value) return;
+    snapshot.value = buildCartSnapshot(snapshot.value.items, totals, new Date().toISOString());
+    result.notifyChanged();
+  }
+
+  function clearCart(): void {
+    const currency = snapshot.value?.currency ?? 'USD';
+    snapshot.value = buildCartSnapshot([], { discount: 0, tax: 0, shipping: 0, currency, couponCode: null }, new Date().toISOString());
+    result.notifyChanged();
+  }
+
+  return { ...result, snapshot, addItem, removeItem, updateQuantity, setItems, setTotals, clearCart };
+}

--- a/packages/qwik/src/useAskableChat.ts
+++ b/packages/qwik/src/useAskableChat.ts
@@ -110,7 +110,7 @@ export function useAskableChat(options: UseAskableChatOptions = {}): UseAskableC
 
     if (systemPrompt) {
       const sys = typeof systemPrompt === 'function' ? systemPrompt(ctx.toPromptContext()) : systemPrompt;
-      req = { ...req, systemPrompt: sys };
+      req = { ...req, metadata: { ...req.metadata, systemPrompt: sys } };
     }
 
     const assistantId = nextId();

--- a/packages/qwik/src/useAskableChat.ts
+++ b/packages/qwik/src/useAskableChat.ts
@@ -1,0 +1,150 @@
+import { useSignal } from '@builder.io/qwik';
+import type { AskableAgentRequest, AskableAgentRequestOptions, AskableContext } from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export type AskableChatRole = 'user' | 'assistant' | 'system';
+
+export interface AskableChatMessage {
+  id: string;
+  role: AskableChatRole;
+  content: string;
+  request?: AskableAgentRequest;
+  createdAt: number;
+}
+
+export type AskableChatStatus = 'idle' | 'streaming' | 'error';
+
+export type AskableChatStreamHandler = (
+  request: AskableAgentRequest,
+  messages: AskableChatMessage[],
+  emit: (chunk: string) => void,
+) => Promise<void>;
+
+export interface UseAskableChatOptions extends Omit<UseAskableOptions, 'inspector'> {
+  initialMessages?: AskableChatMessage[];
+  systemPrompt?: string | ((context: string) => string);
+  onChunk?: (chunk: string) => void;
+  onFinish?: (message: AskableChatMessage) => void;
+  onError?: (error: unknown) => void;
+  requestOptions?: AskableAgentRequestOptions;
+  ctx?: AskableContext;
+}
+
+export interface UseAskableChatResult {
+  messages: ReturnType<typeof useSignal<AskableChatMessage[]>>;
+  status: ReturnType<typeof useSignal<AskableChatStatus>>;
+  error: ReturnType<typeof useSignal<unknown>>;
+  isStreaming: ReturnType<typeof useSignal<boolean>>;
+  append(content: string, handler: AskableChatStreamHandler): Promise<void>;
+  clearMessages(): void;
+  abort(): void;
+  ctx: AskableContext;
+}
+
+let idCounter = 0;
+function nextId() { return `msg-${Date.now()}-${++idCounter}`; }
+
+/**
+ * Qwik hook for multi-turn AI chat. Injects the current UI context into every
+ * turn automatically.
+ *
+ * ```tsx
+ * export const ChatPanel = component$(() => {
+ *   const { messages, append, isStreaming } = useAskableChat({
+ *     systemPrompt: (ctx) => `You are helpful.\n\n${ctx}`,
+ *   });
+ *
+ *   return (
+ *     <>
+ *       {messages.value.map((m) => (
+ *         <p key={m.id} class={m.role}>{m.content}</p>
+ *       ))}
+ *       <button onClick$={() => append('Explain this', async (req, msgs, emit) => {
+ *         const res = await fetch('/api/chat', { method: 'POST', body: JSON.stringify(req) });
+ *         const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+ *         while (true) {
+ *           const { done, value } = await reader.read();
+ *           if (done) break;
+ *           emit(value);
+ *         }
+ *       })}>Send</button>
+ *     </>
+ *   );
+ * });
+ * ```
+ */
+export function useAskableChat(options: UseAskableChatOptions = {}): UseAskableChatResult {
+  const { initialMessages = [], systemPrompt, onChunk, onFinish, onError, requestOptions, ...askableOptions } = options;
+  const { ctx } = useAskable(askableOptions);
+
+  const messages = useSignal<AskableChatMessage[]>([...initialMessages]);
+  const status = useSignal<AskableChatStatus>('idle');
+  const error = useSignal<unknown>(null);
+  const isStreaming = useSignal(false);
+
+  let currentAc: AbortController | null = null;
+  let contentAccum = '';
+
+  function abort(): void {
+    currentAc?.abort();
+    currentAc = null;
+    isStreaming.value = false;
+    status.value = 'idle';
+  }
+
+  function clearMessages(): void {
+    messages.value = [];
+    status.value = 'idle';
+    error.value = null;
+    isStreaming.value = false;
+  }
+
+  async function append(content: string, handler: AskableChatStreamHandler): Promise<void> {
+    abort();
+    currentAc = new AbortController();
+
+    const userMsg: AskableChatMessage = { id: nextId(), role: 'user', content, createdAt: Date.now() };
+    messages.value = [...messages.value, userMsg];
+
+    let req = await ctx.toAgentRequest(content, requestOptions);
+
+    if (systemPrompt) {
+      const sys = typeof systemPrompt === 'function' ? systemPrompt(ctx.toPromptContext()) : systemPrompt;
+      req = { ...req, systemPrompt: sys };
+    }
+
+    const assistantId = nextId();
+    contentAccum = '';
+    const assistantMsg: AskableChatMessage = { id: assistantId, role: 'assistant', content: '', request: req, createdAt: Date.now() };
+    messages.value = [...messages.value, assistantMsg];
+
+    status.value = 'streaming';
+    isStreaming.value = true;
+    error.value = null;
+
+    try {
+      await handler(req, messages.value.slice(0, -1), (chunk) => {
+        contentAccum += chunk;
+        messages.value = messages.value.map((m) =>
+          m.id === assistantId ? { ...m, content: contentAccum } : m,
+        );
+        onChunk?.(chunk);
+      });
+
+      const finished = messages.value.find((m) => m.id === assistantId)!;
+      onFinish?.(finished);
+      status.value = 'idle';
+    } catch (e) {
+      if ((e as Error)?.name !== 'AbortError') {
+        error.value = e;
+        status.value = 'error';
+        onError?.(e);
+      }
+    } finally {
+      isStreaming.value = false;
+      currentAc = null;
+    }
+  }
+
+  return { messages, status, error, isStreaming, append, clearMessages, abort, get ctx() { return ctx; } };
+}

--- a/packages/qwik/src/useAskableErrorSource.ts
+++ b/packages/qwik/src/useAskableErrorSource.ts
@@ -1,0 +1,26 @@
+import { createAskableErrorSource } from '@askable-ui/core';
+import type { AskableCreateErrorSourceOptions } from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export interface UseAskableErrorSourceOptions
+  extends UseAskableSourceOptions,
+    AskableCreateErrorSourceOptions {
+  id?: string;
+}
+
+export type UseAskableErrorSourceResult = UseAskableSourceResult;
+
+/**
+ * Registers an error source that captures recent application errors
+ * so the AI can reference them in responses.
+ *
+ * ```tsx
+ * const { notifyChanged } = useAskableErrorSource();
+ * // call notifyChanged() after catching an error
+ * ```
+ */
+export function useAskableErrorSource(options: UseAskableErrorSourceOptions = {}): UseAskableErrorSourceResult {
+  const { id = 'errors', enabled, ctx, name, events, ...sourceOptions } = options;
+  const source = createAskableErrorSource(sourceOptions);
+  return useAskableSource(id, source, { enabled, ctx, name, events });
+}

--- a/packages/qwik/src/useAskableErrorSource.ts
+++ b/packages/qwik/src/useAskableErrorSource.ts
@@ -1,26 +1,63 @@
+import { useSignal } from '@builder.io/qwik';
 import { createAskableErrorSource } from '@askable-ui/core';
-import type { AskableCreateErrorSourceOptions } from '@askable-ui/core';
+import type { AskableCreateErrorSourceOptions, AskableErrorEntry } from '@askable-ui/core';
 import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export type { AskableErrorEntry };
 
 export interface UseAskableErrorSourceOptions
   extends UseAskableSourceOptions,
-    AskableCreateErrorSourceOptions {
+    Omit<AskableCreateErrorSourceOptions, 'getErrors'> {
   id?: string;
+  /** Initial list of errors. Pass `getErrors` for dynamic sources. */
+  initialErrors?: AskableErrorEntry[];
+  /** Override the error getter with a custom async function. */
+  getErrors?: AskableCreateErrorSourceOptions['getErrors'];
 }
 
-export type UseAskableErrorSourceResult = UseAskableSourceResult;
+export interface UseAskableErrorSourceResult extends UseAskableSourceResult {
+  errors: ReturnType<typeof useSignal<AskableErrorEntry[]>>;
+  addError(entry: AskableErrorEntry): void;
+  removeError(key: string): void;
+  clearErrors(): void;
+}
 
 /**
- * Registers an error source that captures recent application errors
- * so the AI can reference them in responses.
+ * Registers an error source that captures recent application errors so the AI
+ * can reference them. Errors are managed reactively via `addError`/`removeError`.
  *
  * ```tsx
- * const { notifyChanged } = useAskableErrorSource();
- * // call notifyChanged() after catching an error
+ * const { addError } = useAskableErrorSource();
+ * // On catch: addError({ key: 'submit', message: 'Network timeout', severity: 'error' });
  * ```
  */
 export function useAskableErrorSource(options: UseAskableErrorSourceOptions = {}): UseAskableErrorSourceResult {
-  const { id = 'errors', enabled, ctx, name, events, ...sourceOptions } = options;
-  const source = createAskableErrorSource(sourceOptions);
-  return useAskableSource(id, source, { enabled, ctx, name, events });
+  const { id = 'errors', enabled, ctx, name, events, describe, kind, initialErrors = [], getErrors: customGetErrors } = options;
+
+  const errors = useSignal<AskableErrorEntry[]>(initialErrors);
+
+  const source = createAskableErrorSource({
+    describe,
+    kind,
+    getErrors: customGetErrors ?? (() => errors.value),
+  });
+
+  const result = useAskableSource(id, source, { enabled, ctx, name, events });
+
+  function addError(entry: AskableErrorEntry): void {
+    errors.value = [entry, ...errors.value.filter((e) => e.key !== entry.key)];
+    result.notifyChanged();
+  }
+
+  function removeError(key: string): void {
+    errors.value = errors.value.filter((e) => e.key !== key);
+    result.notifyChanged();
+  }
+
+  function clearErrors(): void {
+    errors.value = [];
+    result.notifyChanged();
+  }
+
+  return { ...result, errors, addError, removeError, clearErrors };
 }

--- a/packages/qwik/src/useAskableFormSource.ts
+++ b/packages/qwik/src/useAskableFormSource.ts
@@ -1,0 +1,28 @@
+import { createAskableFormSource } from '@askable-ui/core';
+import type { AskableCreateFormSourceOptions } from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export interface UseAskableFormSourceOptions
+  extends UseAskableSourceOptions,
+    AskableCreateFormSourceOptions {
+  id?: string;
+}
+
+export type UseAskableFormSourceResult = UseAskableSourceResult;
+
+/**
+ * Registers a form source that serializes field values and validation state
+ * for a given `<form>` element.
+ *
+ * ```tsx
+ * export const ContactForm = component$(() => {
+ *   useAskableFormSource({ selector: '#contact-form' });
+ *   // ...
+ * });
+ * ```
+ */
+export function useAskableFormSource(options: UseAskableFormSourceOptions = {}): UseAskableFormSourceResult {
+  const { id = 'form', enabled, ctx, name, events, ...sourceOptions } = options;
+  const source = createAskableFormSource(sourceOptions);
+  return useAskableSource(id, source, { enabled, ctx, name, events });
+}

--- a/packages/qwik/src/useAskableHistory.ts
+++ b/packages/qwik/src/useAskableHistory.ts
@@ -1,0 +1,62 @@
+import { useSignal, useVisibleTask$, useComputed$ } from '@builder.io/qwik';
+import type { AskableContext, AskableFocus } from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export interface UseAskableHistoryOptions extends UseAskableOptions {
+  maxEntries?: number;
+  dedupe?: boolean;
+}
+
+export interface UseAskableHistoryResult {
+  history: ReturnType<typeof useSignal<AskableFocus[]>>;
+  current: ReturnType<typeof useSignal<AskableFocus | null>>;
+  ctx: AskableContext;
+}
+
+/**
+ * Qwik hook that maintains a history of recent focus events. Useful for
+ * building AI chat that can reference what the user was looking at previously.
+ *
+ * ```tsx
+ * export const AskHistory = component$(() => {
+ *   const { history } = useAskableHistory({ maxEntries: 5 });
+ *   return (
+ *     <ul>
+ *       {history.value.map((f, i) => (
+ *         <li key={i}>{JSON.stringify(f.meta)}</li>
+ *       ))}
+ *     </ul>
+ *   );
+ * });
+ * ```
+ */
+export function useAskableHistory(options?: UseAskableHistoryOptions): UseAskableHistoryResult {
+  const maxEntries = options?.maxEntries ?? 10;
+  const dedupe = options?.dedupe ?? true;
+
+  const { ctx } = useAskable(options);
+  const history = useSignal<AskableFocus[]>([]);
+  const current = useSignal<AskableFocus | null>(null);
+
+  // eslint-disable-next-line qwik/no-use-visible-task
+  useVisibleTask$(({ cleanup }) => {
+    const handleFocus = (f: AskableFocus) => {
+      current.value = f;
+      const prev = history.value;
+      if (dedupe && prev.length > 0 && JSON.stringify(prev[0].meta) === JSON.stringify(f.meta)) return;
+      const next = [f, ...prev];
+      history.value = next.length > maxEntries ? next.slice(0, maxEntries) : next;
+    };
+    const handleClear = (_: null) => { current.value = null; };
+
+    ctx.on('focus', handleFocus);
+    ctx.on('clear', handleClear);
+
+    cleanup(() => {
+      ctx.off('focus', handleFocus);
+      ctx.off('clear', handleClear);
+    });
+  });
+
+  return { history, current, ctx };
+}

--- a/packages/qwik/src/useAskableMultistepSource.ts
+++ b/packages/qwik/src/useAskableMultistepSource.ts
@@ -26,8 +26,7 @@ export interface UseAskableMultistepSourceResult extends UseAskableSourceResult 
 }
 
 /**
- * Qwik hook that tracks wizard / stepper / checkout flow progress and exposes
- * it to AI assistants.
+ * Qwik hook that tracks wizard / stepper / checkout flow progress.
  *
  * ```tsx
  * export const Checkout = component$(() => {
@@ -50,54 +49,50 @@ export interface UseAskableMultistepSourceResult extends UseAskableSourceResult 
 export function useAskableMultistepSource(options: UseAskableMultistepSourceOptions = {}): UseAskableMultistepSourceResult {
   const { id = 'multistep', steps: initialSteps = [], initialStep = 0, describe, kind, enabled, ctx, name, events } = options;
 
-  const fullSteps: AskableMultistepStep[] = initialSteps.map((s, i) => ({
-    ...s,
-    index: i,
-    isComplete: false,
-    isActive: i === initialStep,
-    isCurrent: i === initialStep,
-  }));
+  function makeSteps(defs: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[], activeIdx: number): AskableMultistepStep[] {
+    return defs.map((s, i) => ({
+      id: s.id,
+      label: s.label,
+      description: s.description,
+      optional: s.optional,
+      completed: i < activeIdx,
+      active: i === activeIdx,
+    }));
+  }
 
   const snapshot = useSignal<AskableMultistepSourceSnapshot | null>(
-    fullSteps.length > 0 ? buildMultistepSnapshot(fullSteps, initialStep, new Date().toISOString()) : null,
+    initialSteps.length > 0 ? buildMultistepSnapshot(makeSteps(initialSteps, initialStep)) : null,
   );
 
   const source = createAskableMultistepSource({ describe, kind, getSnapshot: () => snapshot.value });
   const result = useAskableSource(id, source, { enabled, ctx, name, events });
 
-  function currentSteps(): AskableMultistepStep[] {
-    return snapshot.value?.steps ?? fullSteps;
+  function currentDefs(): Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[] {
+    return snapshot.value?.steps.map((s) => ({ id: s.id, label: s.label, description: s.description, optional: s.optional })) ?? initialSteps;
   }
 
   function currentIndex(): number {
     return snapshot.value?.currentIndex ?? initialStep;
   }
 
-  function applyIndex(idx: number): void {
-    const steps = currentSteps();
-    if (idx < 0 || idx >= steps.length) return;
-    snapshot.value = buildMultistepSnapshot(steps, idx, new Date().toISOString());
+  function applyIndex(defs: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[], idx: number): void {
+    if (idx < 0 || idx >= defs.length) return;
+    snapshot.value = buildMultistepSnapshot(makeSteps(defs, idx));
     result.notifyChanged();
   }
 
-  function next(): void { applyIndex(currentIndex() + 1); }
-  function prev(): void { applyIndex(currentIndex() - 1); }
+  function next(): void { applyIndex(currentDefs(), currentIndex() + 1); }
+  function prev(): void { applyIndex(currentDefs(), currentIndex() - 1); }
 
   function goTo(indexOrId: number | string): void {
-    if (typeof indexOrId === 'number') { applyIndex(indexOrId); return; }
-    const idx = currentSteps().findIndex((s) => s.id === indexOrId);
-    if (idx >= 0) applyIndex(idx);
+    const defs = currentDefs();
+    if (typeof indexOrId === 'number') { applyIndex(defs, indexOrId); return; }
+    const idx = defs.findIndex((s) => s.id === indexOrId);
+    if (idx >= 0) applyIndex(defs, idx);
   }
 
   function setSteps(steps: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[]): void {
-    const full: AskableMultistepStep[] = steps.map((s, i) => ({
-      ...s,
-      index: i,
-      isComplete: false,
-      isActive: i === 0,
-      isCurrent: i === 0,
-    }));
-    snapshot.value = buildMultistepSnapshot(full, 0, new Date().toISOString());
+    snapshot.value = buildMultistepSnapshot(makeSteps(steps, 0));
     result.notifyChanged();
   }
 

--- a/packages/qwik/src/useAskableMultistepSource.ts
+++ b/packages/qwik/src/useAskableMultistepSource.ts
@@ -1,0 +1,105 @@
+import { useSignal } from '@builder.io/qwik';
+import { createAskableMultistepSource, buildMultistepSnapshot } from '@askable-ui/core';
+import type {
+  AskableCreateMultistepSourceOptions,
+  AskableMultistepStep,
+  AskableMultistepSourceSnapshot,
+} from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export type { AskableMultistepStep, AskableMultistepSourceSnapshot };
+
+export interface UseAskableMultistepSourceOptions
+  extends UseAskableSourceOptions,
+    Omit<AskableCreateMultistepSourceOptions, 'getSnapshot'> {
+  id?: string;
+  steps?: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[];
+  initialStep?: number;
+}
+
+export interface UseAskableMultistepSourceResult extends UseAskableSourceResult {
+  snapshot: ReturnType<typeof useSignal<AskableMultistepSourceSnapshot | null>>;
+  next(): void;
+  prev(): void;
+  goTo(indexOrId: number | string): void;
+  setSteps(steps: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[]): void;
+}
+
+/**
+ * Qwik hook that tracks wizard / stepper / checkout flow progress and exposes
+ * it to AI assistants.
+ *
+ * ```tsx
+ * export const Checkout = component$(() => {
+ *   const wizard = useAskableMultistepSource({
+ *     steps: [
+ *       { id: 'cart', label: 'Cart' },
+ *       { id: 'shipping', label: 'Shipping' },
+ *       { id: 'payment', label: 'Payment' },
+ *     ],
+ *   });
+ *   return (
+ *     <div>
+ *       <p>Step {wizard.snapshot.value?.currentIndex + 1}</p>
+ *       <button onClick$={() => wizard.next()}>Next</button>
+ *     </div>
+ *   );
+ * });
+ * ```
+ */
+export function useAskableMultistepSource(options: UseAskableMultistepSourceOptions = {}): UseAskableMultistepSourceResult {
+  const { id = 'multistep', steps: initialSteps = [], initialStep = 0, describe, kind, enabled, ctx, name, events } = options;
+
+  const fullSteps: AskableMultistepStep[] = initialSteps.map((s, i) => ({
+    ...s,
+    index: i,
+    isComplete: false,
+    isActive: i === initialStep,
+    isCurrent: i === initialStep,
+  }));
+
+  const snapshot = useSignal<AskableMultistepSourceSnapshot | null>(
+    fullSteps.length > 0 ? buildMultistepSnapshot(fullSteps, initialStep, new Date().toISOString()) : null,
+  );
+
+  const source = createAskableMultistepSource({ describe, kind, getSnapshot: () => snapshot.value });
+  const result = useAskableSource(id, source, { enabled, ctx, name, events });
+
+  function currentSteps(): AskableMultistepStep[] {
+    return snapshot.value?.steps ?? fullSteps;
+  }
+
+  function currentIndex(): number {
+    return snapshot.value?.currentIndex ?? initialStep;
+  }
+
+  function applyIndex(idx: number): void {
+    const steps = currentSteps();
+    if (idx < 0 || idx >= steps.length) return;
+    snapshot.value = buildMultistepSnapshot(steps, idx, new Date().toISOString());
+    result.notifyChanged();
+  }
+
+  function next(): void { applyIndex(currentIndex() + 1); }
+  function prev(): void { applyIndex(currentIndex() - 1); }
+
+  function goTo(indexOrId: number | string): void {
+    if (typeof indexOrId === 'number') { applyIndex(indexOrId); return; }
+    const idx = currentSteps().findIndex((s) => s.id === indexOrId);
+    if (idx >= 0) applyIndex(idx);
+  }
+
+  function setSteps(steps: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[]): void {
+    const full: AskableMultistepStep[] = steps.map((s, i) => ({
+      ...s,
+      index: i,
+      isComplete: false,
+      isActive: i === 0,
+      isCurrent: i === 0,
+    }));
+    snapshot.value = buildMultistepSnapshot(full, 0, new Date().toISOString());
+    result.notifyChanged();
+  }
+
+  return { ...result, snapshot, next, prev, goTo, setSteps };
+}

--- a/packages/qwik/src/useAskableNavigationSource.ts
+++ b/packages/qwik/src/useAskableNavigationSource.ts
@@ -1,0 +1,26 @@
+import { createAskableNavigationSource } from '@askable-ui/core';
+import type { AskableCreateNavigationSourceOptions, AskableNavigationEntry } from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export type { AskableNavigationEntry };
+
+export interface UseAskableNavigationSourceOptions
+  extends UseAskableSourceOptions,
+    AskableCreateNavigationSourceOptions {
+  id?: string;
+}
+
+export type UseAskableNavigationSourceResult = UseAskableSourceResult;
+
+/**
+ * Registers a navigation source that tracks page route history.
+ *
+ * ```tsx
+ * useAskableNavigationSource({ maxEntries: 5 });
+ * ```
+ */
+export function useAskableNavigationSource(options: UseAskableNavigationSourceOptions = {}): UseAskableNavigationSourceResult {
+  const { id = 'navigation', enabled, ctx, name, events, ...sourceOptions } = options;
+  const source = createAskableNavigationSource(sourceOptions);
+  return useAskableSource(id, source, { enabled, ctx, name, events });
+}

--- a/packages/qwik/src/useAskableNotificationSource.ts
+++ b/packages/qwik/src/useAskableNotificationSource.ts
@@ -1,0 +1,64 @@
+import { useSignal, useVisibleTask$ } from '@builder.io/qwik';
+import { createAskableNotificationSource } from '@askable-ui/core';
+import type {
+  AskableCreateNotificationSourceOptions,
+  AskableNotification,
+  AskableNotificationSeverity,
+} from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export type { AskableNotification, AskableNotificationSeverity };
+
+export interface UseAskableNotificationSourceOptions
+  extends UseAskableSourceOptions,
+    Omit<AskableCreateNotificationSourceOptions, 'getSnapshot'> {
+  id?: string;
+  maxEntries?: number;
+}
+
+export interface UseAskableNotificationSourceResult extends UseAskableSourceResult {
+  push(notification: Omit<AskableNotification, 'id' | 'timestamp'>): void;
+  dismiss(id: string): void;
+  clear(): void;
+}
+
+/**
+ * Registers a notification source that tracks active toasts, alerts, and
+ * banners so the AI can reference them.
+ *
+ * ```tsx
+ * const notifs = useAskableNotificationSource();
+ * notifs.push({ message: 'Order placed!', severity: 'success' });
+ * ```
+ */
+export function useAskableNotificationSource(
+  options: UseAskableNotificationSourceOptions = {},
+): UseAskableNotificationSourceResult {
+  const { id = 'notifications', enabled, ctx, name, events, maxEntries = 20, describe, kind } = options;
+
+  const items = useSignal<AskableNotification[]>([]);
+  let nextId = 1;
+
+  function push(notification: Omit<AskableNotification, 'id' | 'timestamp'>): void {
+    const entry: AskableNotification = {
+      ...notification,
+      id: String(nextId++),
+      timestamp: new Date().toISOString(),
+    };
+    const next = [entry, ...items.value];
+    items.value = next.length > maxEntries ? next.slice(0, maxEntries) : next;
+  }
+
+  function dismiss(id: string): void {
+    items.value = items.value.filter((n) => n.id !== id);
+  }
+
+  function clear(): void {
+    items.value = [];
+  }
+
+  const source = createAskableNotificationSource({ describe, kind, getSnapshot: () => ({ notifications: items.value, count: items.value.length }) });
+  const result = useAskableSource(id, source, { enabled, ctx, name, events });
+
+  return { ...result, push, dismiss, clear };
+}

--- a/packages/qwik/src/useAskableNotificationSource.ts
+++ b/packages/qwik/src/useAskableNotificationSource.ts
@@ -1,4 +1,4 @@
-import { useSignal, useVisibleTask$ } from '@builder.io/qwik';
+import { useSignal } from '@builder.io/qwik';
 import { createAskableNotificationSource } from '@askable-ui/core';
 import type {
   AskableCreateNotificationSourceOptions,
@@ -11,12 +11,13 @@ export type { AskableNotification, AskableNotificationSeverity };
 
 export interface UseAskableNotificationSourceOptions
   extends UseAskableSourceOptions,
-    Omit<AskableCreateNotificationSourceOptions, 'getSnapshot'> {
+    Pick<AskableCreateNotificationSourceOptions, 'describe' | 'kind'> {
   id?: string;
   maxEntries?: number;
 }
 
 export interface UseAskableNotificationSourceResult extends UseAskableSourceResult {
+  notifications: ReturnType<typeof useSignal<AskableNotification[]>>;
   push(notification: Omit<AskableNotification, 'id' | 'timestamp'>): void;
   dismiss(id: string): void;
   clear(): void;
@@ -27,8 +28,8 @@ export interface UseAskableNotificationSourceResult extends UseAskableSourceResu
  * banners so the AI can reference them.
  *
  * ```tsx
- * const notifs = useAskableNotificationSource();
- * notifs.push({ message: 'Order placed!', severity: 'success' });
+ * const { push, dismiss } = useAskableNotificationSource();
+ * push({ message: 'Order placed!', severity: 'success' });
  * ```
  */
 export function useAskableNotificationSource(
@@ -36,8 +37,15 @@ export function useAskableNotificationSource(
 ): UseAskableNotificationSourceResult {
   const { id = 'notifications', enabled, ctx, name, events, maxEntries = 20, describe, kind } = options;
 
-  const items = useSignal<AskableNotification[]>([]);
+  const notifications = useSignal<AskableNotification[]>([]);
   let nextId = 1;
+
+  const source = createAskableNotificationSource({
+    describe,
+    kind,
+    getNotifications: () => notifications.value,
+  });
+  const result = useAskableSource(id, source, { enabled, ctx, name, events });
 
   function push(notification: Omit<AskableNotification, 'id' | 'timestamp'>): void {
     const entry: AskableNotification = {
@@ -45,20 +53,20 @@ export function useAskableNotificationSource(
       id: String(nextId++),
       timestamp: new Date().toISOString(),
     };
-    const next = [entry, ...items.value];
-    items.value = next.length > maxEntries ? next.slice(0, maxEntries) : next;
+    const next = [entry, ...notifications.value];
+    notifications.value = next.length > maxEntries ? next.slice(0, maxEntries) : next;
+    result.notifyChanged();
   }
 
   function dismiss(id: string): void {
-    items.value = items.value.filter((n) => n.id !== id);
+    notifications.value = notifications.value.filter((n) => n.id !== id);
+    result.notifyChanged();
   }
 
   function clear(): void {
-    items.value = [];
+    notifications.value = [];
+    result.notifyChanged();
   }
 
-  const source = createAskableNotificationSource({ describe, kind, getSnapshot: () => ({ notifications: items.value, count: items.value.length }) });
-  const result = useAskableSource(id, source, { enabled, ctx, name, events });
-
-  return { ...result, push, dismiss, clear };
+  return { ...result, notifications, push, dismiss, clear };
 }

--- a/packages/qwik/src/useAskablePageSource.ts
+++ b/packages/qwik/src/useAskablePageSource.ts
@@ -3,7 +3,7 @@ import type { AskableCreatePageSourceOptions } from '@askable-ui/core';
 import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
 
 export interface UseAskablePageSourceOptions
-  extends UseAskableSourceOptions,
+  extends Omit<UseAskableSourceOptions, 'textExtractor'>,
     AskableCreatePageSourceOptions {
   id?: string;
 }

--- a/packages/qwik/src/useAskablePageSource.ts
+++ b/packages/qwik/src/useAskablePageSource.ts
@@ -1,0 +1,28 @@
+import { createAskablePageSource } from '@askable-ui/core';
+import type { AskableCreatePageSourceOptions } from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export interface UseAskablePageSourceOptions
+  extends UseAskableSourceOptions,
+    AskableCreatePageSourceOptions {
+  id?: string;
+}
+
+export type UseAskablePageSourceResult = UseAskableSourceResult;
+
+/**
+ * Registers a page source that captures the current document title, URL,
+ * meta description, headings, and optionally links.
+ *
+ * ```tsx
+ * export const Layout = component$(() => {
+ *   useAskablePageSource();
+ *   return <Slot />;
+ * });
+ * ```
+ */
+export function useAskablePageSource(options: UseAskablePageSourceOptions = {}): UseAskablePageSourceResult {
+  const { id = 'page', enabled, ctx, name, events, describe, kind, root, includeLinks, maxLinks, maxHeadings, maxTextLength, textExtractor, sanitizeText } = options;
+  const source = createAskablePageSource({ describe, kind, root, includeLinks, maxLinks, maxHeadings, maxTextLength, textExtractor, sanitizeText });
+  return useAskableSource(id, source, { enabled, ctx, name, events });
+}

--- a/packages/qwik/src/useAskableSource.ts
+++ b/packages/qwik/src/useAskableSource.ts
@@ -1,0 +1,70 @@
+import { useVisibleTask$ } from '@builder.io/qwik';
+import type {
+  AskableAsyncPromptContextOptions,
+  AskableContext,
+  AskableContextSource,
+  AskableContextSourceHandle,
+  AskableContextSourceRequest,
+  AskableResolvedContextSource,
+} from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export interface UseAskableSourceOptions extends Omit<UseAskableOptions, never> {
+  enabled?: boolean;
+}
+
+export interface UseAskableSourceResult {
+  ctx: AskableContext;
+  sourceId: string;
+  resolve(request?: Omit<AskableContextSourceRequest, 'id'>): Promise<AskableResolvedContextSource>;
+  toPromptContext(
+    options?: Omit<AskableAsyncPromptContextOptions, 'sources'>
+      & { source?: Omit<AskableContextSourceRequest, 'id'> },
+  ): Promise<string>;
+  notifyChanged(): void;
+  unregister(): void;
+}
+
+/**
+ * Qwik hook that registers an arbitrary context source on the shared
+ * AskableContext. The source is registered once the component mounts in the
+ * browser and unregistered on cleanup.
+ */
+export function useAskableSource(
+  id: string,
+  source: AskableContextSource,
+  options: UseAskableSourceOptions = {},
+): UseAskableSourceResult {
+  const { enabled = true, ...askableOptions } = options;
+  const { ctx: _ctxRef } = useAskable(askableOptions);
+
+  let handle: AskableContextSourceHandle | null = null;
+
+  // eslint-disable-next-line qwik/no-use-visible-task
+  useVisibleTask$(({ cleanup }) => {
+    const ctx = _ctxRef;
+    if (!ctx || !enabled || !id.trim()) return;
+
+    handle = ctx.registerSource(id.trim(), source);
+
+    cleanup(() => {
+      handle?.unregister();
+      handle = null;
+    });
+  });
+
+  return {
+    get ctx() { return _ctxRef; },
+    sourceId: id,
+    resolve: (request?) => _ctxRef.resolveSource(id, request),
+    toPromptContext: (opts?) => {
+      const { source: sourceRequest, ...rest } = opts ?? {};
+      return _ctxRef.toPromptContextAsync({
+        ...rest,
+        sources: [{ id, ...sourceRequest }],
+      });
+    },
+    notifyChanged: () => handle?.notifyChanged(),
+    unregister: () => { handle?.unregister(); handle = null; },
+  };
+}

--- a/packages/qwik/src/useAskableStream.ts
+++ b/packages/qwik/src/useAskableStream.ts
@@ -1,0 +1,141 @@
+import { useSignal } from '@builder.io/qwik';
+import type { AskableAgentRequest, AskableAgentRequestOptions, AskableContext } from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
+
+export type AskableStreamStatus = 'idle' | 'streaming' | 'success' | 'error';
+
+export type AskableStreamHandler = (
+  request: AskableAgentRequest,
+  emit: (chunk: string) => void,
+) => Promise<void>;
+
+export interface UseAskableStreamOptions extends Omit<UseAskableOptions, 'inspector'> {
+  onRequest?: (request: AskableAgentRequest) => AskableAgentRequest | void | undefined;
+  onChunk?: (chunk: string, content: string) => void;
+  onSuccess?: (content: string, request: AskableAgentRequest) => void;
+  onError?: (error: unknown, request: AskableAgentRequest) => void;
+  requestOptions?: AskableAgentRequestOptions;
+  ctx?: AskableContext;
+}
+
+export interface UseAskableStreamResult {
+  stream(question: string, handler: AskableStreamHandler): Promise<string | undefined>;
+  streamFrom(question: string, source: ReadableStream<string> | AsyncIterable<string>): Promise<string | undefined>;
+  status: ReturnType<typeof useSignal<AskableStreamStatus>>;
+  content: ReturnType<typeof useSignal<string>>;
+  error: ReturnType<typeof useSignal<unknown>>;
+  lastRequest: ReturnType<typeof useSignal<AskableAgentRequest | null>>;
+  isStreaming: ReturnType<typeof useSignal<boolean>>;
+  reset(): void;
+  abort(): void;
+  ctx: AskableContext;
+}
+
+/**
+ * Qwik hook for streaming LLM responses. Reactive `content.value` updates as
+ * each chunk arrives, driving progressive rendering.
+ *
+ * ```tsx
+ * export const Chat = component$(() => {
+ *   const { stream, content, isStreaming } = useAskableStream();
+ *   return (
+ *     <>
+ *       {isStreaming.value && <span>Thinking…</span>}
+ *       <p>{content.value}</p>
+ *       <button onClick$={() =>
+ *         stream('Explain this chart', async (req, emit) => {
+ *           const res = await fetch('/api/chat', { method: 'POST', body: JSON.stringify(req) });
+ *           const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+ *           while (true) {
+ *             const { done, value } = await reader.read();
+ *             if (done) break;
+ *             emit(value);
+ *           }
+ *         })
+ *       }>Ask AI</button>
+ *     </>
+ *   );
+ * });
+ * ```
+ */
+export function useAskableStream(options: UseAskableStreamOptions = {}): UseAskableStreamResult {
+  const { onRequest, onChunk, onSuccess, onError, requestOptions, ...askableOptions } = options;
+  const { ctx } = useAskable(askableOptions);
+
+  const status = useSignal<AskableStreamStatus>('idle');
+  const content = useSignal('');
+  const error = useSignal<unknown>(null);
+  const lastRequest = useSignal<AskableAgentRequest | null>(null);
+  const isStreaming = useSignal(false);
+
+  let abortController: AbortController | null = null;
+
+  function reset(): void {
+    status.value = 'idle';
+    content.value = '';
+    error.value = null;
+    lastRequest.value = null;
+    isStreaming.value = false;
+  }
+
+  function abort(): void {
+    abortController?.abort();
+    abortController = null;
+    isStreaming.value = false;
+    status.value = 'idle';
+  }
+
+  async function stream(question: string, handler: AskableStreamHandler): Promise<string | undefined> {
+    abort();
+    abortController = new AbortController();
+    let req = await ctx.toAgentRequest(question, requestOptions);
+    if (onRequest) { const override = onRequest(req); if (override) req = override; }
+
+    lastRequest.value = req;
+    status.value = 'streaming';
+    isStreaming.value = true;
+    content.value = '';
+    error.value = null;
+
+    try {
+      await handler(req, (chunk) => {
+        content.value += chunk;
+        onChunk?.(chunk, content.value);
+      });
+      status.value = 'success';
+      onSuccess?.(content.value, req);
+      return content.value;
+    } catch (e) {
+      if ((e as Error)?.name !== 'AbortError') {
+        error.value = e;
+        status.value = 'error';
+        onError?.(e, req);
+      }
+      return undefined;
+    } finally {
+      isStreaming.value = false;
+      abortController = null;
+    }
+  }
+
+  async function streamFrom(question: string, source: ReadableStream<string> | AsyncIterable<string>): Promise<string | undefined> {
+    return stream(question, async (_req, emit) => {
+      if (source instanceof ReadableStream) {
+        const reader = source.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            emit(value);
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      } else {
+        for await (const chunk of source) emit(chunk);
+      }
+    });
+  }
+
+  return { stream, streamFrom, status, content, error, lastRequest, isStreaming, reset, abort, get ctx() { return ctx; } };
+}

--- a/packages/qwik/src/useAskableTableSource.ts
+++ b/packages/qwik/src/useAskableTableSource.ts
@@ -1,25 +1,94 @@
-import { createAskableTableSource } from '@askable-ui/core';
-import type { AskableCreateTableSourceOptions } from '@askable-ui/core';
+import { createAskableCollectionSource } from '@askable-ui/core';
+import type {
+  AskableCreateCollectionSourceOptions,
+  AskableContextSourceMode,
+} from '@askable-ui/core';
 import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
 
-export interface UseAskableTableSourceOptions
-  extends UseAskableSourceOptions,
-    AskableCreateTableSourceOptions {
+export interface UseAskableTableSourceOptions<TRow = unknown, TState = unknown>
+  extends UseAskableSourceOptions {
   id?: string;
+  /** Function returning all rows. */
+  rows?: () => readonly TRow[];
+  /** Function returning rows visible on screen. */
+  visibleRows?: () => readonly TRow[];
+  /** Function returning selected rows. */
+  selectedRows?: () => readonly TRow[];
+  /** Function returning table state (filters, sort, page, search). */
+  state?: () => TState;
+  /** Stable row identifier. */
+  getRowId?: AskableCreateCollectionSourceOptions<TRow, TState>['getItemId'];
+  /** Summary override. Computed from rows when omitted. */
+  getSummary?: () => unknown;
+  /** Maximum rows included in resolutions. Defaults to 100. */
+  maxRows?: number;
+  /** Redact or transform each row before serialization. */
+  sanitizeRow?: (row: TRow) => unknown;
+  /** Human-readable description. Defaults to "Data table". */
+  describe?: string | (() => string | Promise<string>);
+  /** Source category. Defaults to "table". */
+  kind?: string;
+  /** Additional modes to advertise. */
+  advertisedModes?: readonly AskableContextSourceMode[];
 }
 
 export type UseAskableTableSourceResult = UseAskableSourceResult;
 
 /**
- * Registers a table source that serializes visible rows, columns, sort state,
- * filters, and selection for a data grid element.
+ * Registers a table (collection) source so AI assistants can see rows,
+ * selections, filters, sort state, and summary statistics.
  *
  * ```tsx
- * useAskableTableSource({ selector: '#data-table', maxRows: 50 });
+ * const rows = useSignal(allOrders);
+ *
+ * useAskableTableSource({
+ *   id: 'orders',
+ *   rows: () => rows.value,
+ *   sanitizeRow: ({ id, date, amount }) => ({ id, date, amount }),
+ * });
  * ```
  */
-export function useAskableTableSource(options: UseAskableTableSourceOptions = {}): UseAskableTableSourceResult {
-  const { id = 'table', enabled, ctx, name, events, ...sourceOptions } = options;
-  const source = createAskableTableSource(sourceOptions);
+export function useAskableTableSource<TRow = unknown, TState = unknown>(
+  options: UseAskableTableSourceOptions<TRow, TState> = {},
+): UseAskableTableSourceResult {
+  const {
+    id = 'table',
+    rows,
+    visibleRows,
+    selectedRows,
+    state,
+    getRowId,
+    getSummary,
+    maxRows = 100,
+    sanitizeRow,
+    describe = 'Data table',
+    kind = 'table',
+    advertisedModes,
+    enabled,
+    ctx,
+    name,
+    events,
+  } = options;
+
+  const source = createAskableCollectionSource<TRow, TState>({
+    kind,
+    describe,
+    advertisedModes,
+    maxItems: maxRows,
+    getState: state,
+    getItems: rows,
+    getVisibleItems: visibleRows,
+    getSelectedItems: selectedRows,
+    getItemId: getRowId,
+    getSummary: getSummary ?? (rows
+      ? () => ({
+          totalRows: rows().length,
+          visibleRows: visibleRows?.().length,
+          selectedRows: selectedRows?.().length,
+        })
+      : undefined),
+    sanitizeItem: sanitizeRow ? (row) => sanitizeRow(row) : undefined,
+  });
+
   return useAskableSource(id, source, { enabled, ctx, name, events });
 }

--- a/packages/qwik/src/useAskableTableSource.ts
+++ b/packages/qwik/src/useAskableTableSource.ts
@@ -1,0 +1,25 @@
+import { createAskableTableSource } from '@askable-ui/core';
+import type { AskableCreateTableSourceOptions } from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export interface UseAskableTableSourceOptions
+  extends UseAskableSourceOptions,
+    AskableCreateTableSourceOptions {
+  id?: string;
+}
+
+export type UseAskableTableSourceResult = UseAskableSourceResult;
+
+/**
+ * Registers a table source that serializes visible rows, columns, sort state,
+ * filters, and selection for a data grid element.
+ *
+ * ```tsx
+ * useAskableTableSource({ selector: '#data-table', maxRows: 50 });
+ * ```
+ */
+export function useAskableTableSource(options: UseAskableTableSourceOptions = {}): UseAskableTableSourceResult {
+  const { id = 'table', enabled, ctx, name, events, ...sourceOptions } = options;
+  const source = createAskableTableSource(sourceOptions);
+  return useAskableSource(id, source, { enabled, ctx, name, events });
+}

--- a/packages/qwik/src/useAskableUserSource.ts
+++ b/packages/qwik/src/useAskableUserSource.ts
@@ -1,0 +1,25 @@
+import { createAskableUserSource } from '@askable-ui/core';
+import type { AskableCreateUserSourceOptions } from '@askable-ui/core';
+import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export interface UseAskableUserSourceOptions
+  extends UseAskableSourceOptions,
+    AskableCreateUserSourceOptions {
+  id?: string;
+}
+
+export type UseAskableUserSourceResult = UseAskableSourceResult;
+
+/**
+ * Registers a user source that exposes authenticated user identity
+ * (name, email, roles, preferences) to the AI.
+ *
+ * ```tsx
+ * useAskableUserSource({ getUser: () => session.user });
+ * ```
+ */
+export function useAskableUserSource(options: UseAskableUserSourceOptions = {}): UseAskableUserSourceResult {
+  const { id = 'user', enabled, ctx, name, events, ...sourceOptions } = options;
+  const source = createAskableUserSource(sourceOptions);
+  return useAskableSource(id, source, { enabled, ctx, name, events });
+}

--- a/packages/qwik/src/useAskableUserSource.ts
+++ b/packages/qwik/src/useAskableUserSource.ts
@@ -1,6 +1,8 @@
 import { createAskableUserSource } from '@askable-ui/core';
-import type { AskableCreateUserSourceOptions } from '@askable-ui/core';
+import type { AskableCreateUserSourceOptions, AskableUserProfile } from '@askable-ui/core';
 import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+
+export type { AskableUserProfile };
 
 export interface UseAskableUserSourceOptions
   extends UseAskableSourceOptions,
@@ -15,10 +17,11 @@ export type UseAskableUserSourceResult = UseAskableSourceResult;
  * (name, email, roles, preferences) to the AI.
  *
  * ```tsx
- * useAskableUserSource({ getUser: () => session.user });
+ * // In your root component (after auth resolves):
+ * useAskableUserSource({ getUser: () => session.value?.user ?? null });
  * ```
  */
-export function useAskableUserSource(options: UseAskableUserSourceOptions = {}): UseAskableUserSourceResult {
+export function useAskableUserSource(options: UseAskableUserSourceOptions): UseAskableUserSourceResult {
   const { id = 'user', enabled, ctx, name, events, ...sourceOptions } = options;
   const source = createAskableUserSource(sourceOptions);
   return useAskableSource(id, source, { enabled, ctx, name, events });

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -63,6 +63,8 @@ export default defineConfig({
             { text: 'Vue', link: '/guide/vue' },
             { text: 'Svelte', link: '/guide/svelte' },
             { text: 'Angular', link: '/guide/angular' },
+            { text: 'SolidJS', link: '/guide/solid' },
+            { text: 'Qwik', link: '/guide/qwik' },
             { text: 'Plain JS / HTML', link: '/guide/vanilla' },
           ],
         },

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -37,6 +37,10 @@ npm install @askable-ui/vue @askable-ui/core
 npm install @askable-ui/svelte @askable-ui/core
 ```
 
+```bash [Angular]
+npm install @askable-ui/angular @askable-ui/core
+```
+
 ```bash [Plain JS]
 npm install @askable-ui/core
 ```
@@ -98,6 +102,13 @@ function RevenueCard() {
 </Askable>
 ```
 
+```html [Angular]
+<!-- app.component.html -->
+<div [askable]="{ metric: 'revenue', delta: '-12%', period: 'Q3' }">
+  <revenue-chart />
+</div>
+```
+
 :::
 
 ## Step 2 — Observe the page
@@ -133,6 +144,15 @@ import { createAskableStore } from '@askable-ui/svelte';
 
 const { promptContext, destroy } = createAskableStore();
 onDestroy(destroy);
+```
+
+```ts [Angular]
+import { inject } from '@angular/core';
+import { AskableService } from '@askable-ui/angular';
+
+// In your component:
+private readonly askable = inject(AskableService); // starts observing automatically
+// this.askable.promptContext() — Signal<string>
 ```
 
 ```ts [Plain JS]

--- a/site/docs/guide/qwik.md
+++ b/site/docs/guide/qwik.md
@@ -1,0 +1,304 @@
+# Qwik Guide
+
+## Install
+
+```bash
+npm install @askable-ui/qwik @askable-ui/core
+```
+
+## Quick start
+
+```tsx
+// src/routes/index.tsx
+import { component$ } from '@builder.io/qwik';
+import { Askable, useAskable } from '@askable-ui/qwik';
+
+export default component$(() => {
+  const { promptContext } = useAskable();
+
+  return (
+    <>
+      <Askable meta={{ metric: 'revenue', value: '$128k', period: 'Q3' }}>
+        <article>$128k</article>
+      </Askable>
+
+      <p>Context: {promptContext.value}</p>
+    </>
+  );
+});
+```
+
+## `<Askable>`
+
+Renders a `div` (or any element via `as`) annotated with `data-askable`.
+
+```tsx
+// Object meta — recommended for structured data
+<Askable meta={{ widget: 'churn-rate', value: '4.2%' }} scope="dashboard">
+  <ChurnChart />
+</Askable>
+
+// String meta — fine for simple labels
+<Askable meta="main navigation">
+  <nav>...</nav>
+</Askable>
+```
+
+## `useAskable(options?)`
+
+Creates (or shares) a context and returns reactive Qwik signals.
+
+```tsx
+const { focus, promptContext, ctx } = useAskable();
+
+// focus.value — current AskableFocus | null (signal)
+// promptContext.value — serialized string (signal)
+// ctx — raw AskableContext for advanced usage
+```
+
+All hooks in the same Qwik app share a single context instance by default (matched by name + events key), so source hooks automatically connect to the same focus stream.
+
+## Sources
+
+Sources expose app state to the AI. Register them once in a layout or root component and they're available in every AI handler.
+
+### Page source
+
+```tsx
+import { component$, Slot } from '@builder.io/qwik';
+import { useAskablePageSource } from '@askable-ui/qwik';
+
+export default component$(() => {
+  useAskablePageSource({ includeLinks: false });
+  return <Slot />;
+});
+```
+
+### Cart source
+
+```tsx
+import { component$ } from '@builder.io/qwik';
+import { useAskableCartSource } from '@askable-ui/qwik';
+import type { AskableCartItem } from '@askable-ui/qwik';
+
+export const CartWidget = component$(() => {
+  const { snapshot, addItem, removeItem, clearCart } = useAskableCartSource({
+    items: [],
+    totals: { currency: 'USD' },
+  });
+
+  return (
+    <div>
+      <p>{snapshot.value?.itemCount} items — {snapshot.value?.total}</p>
+      <button onClick$={() => clearCart()}>Clear</button>
+    </div>
+  );
+});
+```
+
+### Multistep / wizard source
+
+```tsx
+import { component$ } from '@builder.io/qwik';
+import { useAskableMultistepSource } from '@askable-ui/qwik';
+
+export const Checkout = component$(() => {
+  const wizard = useAskableMultistepSource({
+    steps: [
+      { id: 'cart',     label: 'Cart' },
+      { id: 'shipping', label: 'Shipping' },
+      { id: 'payment',  label: 'Payment' },
+      { id: 'confirm',  label: 'Confirm' },
+    ],
+  });
+
+  return (
+    <div>
+      <p>Step {(wizard.snapshot.value?.currentIndex ?? 0) + 1} of {wizard.snapshot.value?.totalSteps}</p>
+      <button onClick$={() => wizard.next()}>Next</button>
+      <button onClick$={() => wizard.prev()}>Back</button>
+    </div>
+  );
+});
+```
+
+### Notification source
+
+```tsx
+import { component$ } from '@builder.io/qwik';
+import { useAskableNotificationSource } from '@askable-ui/qwik';
+
+export const ToastManager = component$(() => {
+  const { push, dismiss, notifications } = useAskableNotificationSource();
+
+  return (
+    <div>
+      {notifications.value.map((n) => (
+        <div key={n.id}>
+          {n.message}
+          <button onClick$={() => dismiss(n.id)}>×</button>
+        </div>
+      ))}
+    </div>
+  );
+});
+```
+
+### Error source
+
+```tsx
+import { useAskableErrorSource } from '@askable-ui/qwik';
+
+// In your error boundary or try/catch:
+const { addError, clearErrors } = useAskableErrorSource();
+
+try {
+  await submitOrder();
+} catch (e) {
+  addError({ key: 'submit', message: (e as Error).message, severity: 'error' });
+}
+```
+
+### Other sources
+
+| Hook | Default id | Description |
+|---|---|---|
+| `useAskablePageSource` | `page` | Document title, URL, headings |
+| `useAskableNavigationSource` | `navigation` | Route history |
+| `useAskableFormSource` | `form` | Form field values and validation |
+| `useAskableTableSource` | `table` | Data grid rows, columns, selection |
+| `useAskableUserSource` | `user` | Authenticated user identity |
+| `useAskableErrorSource` | `errors` | Recent application errors |
+| `useAskableNotificationSource` | `notifications` | Active toasts and alerts |
+| `useAskableCartSource` | `cart` | Shopping cart state |
+| `useAskableMultistepSource` | `multistep` | Wizard/stepper progress |
+
+## Streaming and chat
+
+### `useAskableStream`
+
+```tsx
+import { component$ } from '@builder.io/qwik';
+import { useAskableStream } from '@askable-ui/qwik';
+
+export const AskButton = component$(() => {
+  const { stream, content, isStreaming, status } = useAskableStream();
+
+  return (
+    <>
+      {isStreaming.value && <span>Thinking…</span>}
+      {content.value && <p>{content.value}</p>}
+      <button
+        disabled={isStreaming.value}
+        onClick$={() =>
+          stream('Explain what I am looking at', async (req, emit) => {
+            const res = await fetch('/api/chat', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(req),
+            });
+            const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              emit(value);
+            }
+          })
+        }
+      >
+        Ask AI
+      </button>
+    </>
+  );
+});
+```
+
+### `useAskableChat`
+
+```tsx
+import { component$ } from '@builder.io/qwik';
+import { useAskableChat } from '@askable-ui/qwik';
+
+export const ChatPanel = component$(() => {
+  const { messages, append, isStreaming, clearMessages } = useAskableChat({
+    systemPrompt: (ctx) => `You are a helpful UI assistant.\n\nCurrent UI context:\n${ctx}`,
+  });
+
+  return (
+    <div>
+      <div>
+        {messages.value.map((m) => (
+          <div key={m.id} class={m.role}>
+            {m.content}
+          </div>
+        ))}
+      </div>
+
+      <button
+        disabled={isStreaming.value}
+        onClick$={() =>
+          append('What is this page about?', async (req, _msgs, emit) => {
+            const res = await fetch('/api/chat', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(req),
+            });
+            const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              emit(value);
+            }
+          })
+        }
+      >
+        Ask
+      </button>
+      <button onClick$={() => clearMessages()}>Clear</button>
+    </div>
+  );
+});
+```
+
+## Focus history
+
+```tsx
+import { component$ } from '@builder.io/qwik';
+import { useAskableHistory } from '@askable-ui/qwik';
+
+export const HistoryPanel = component$(() => {
+  const { history } = useAskableHistory({ maxEntries: 5 });
+
+  return (
+    <ul>
+      {history.value.map((f, i) => (
+        <li key={i}>{JSON.stringify(f.meta)}</li>
+      ))}
+    </ul>
+  );
+});
+```
+
+## Server-side rendering
+
+`useAskable` returns empty signals on the server — `focus.value` is `null` and `promptContext.value` is `''`. All DOM observation and source registration happens inside `useVisibleTask$`, which is browser-only. Qwik City apps with SSR are safe to use with any askable-ui hook.
+
+## Agent requests
+
+```tsx
+import { useAskable } from '@askable-ui/qwik';
+
+const { ctx } = useAskable();
+
+// Build a structured request with context, focus, and optional packet
+const req = await ctx.toAgentRequest('Why is revenue dropping?', {
+  history: 3,
+  packet: true,
+});
+
+await fetch('/api/chat', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(req),
+});
+```

--- a/site/docs/guide/solid.md
+++ b/site/docs/guide/solid.md
@@ -1,0 +1,381 @@
+# SolidJS Guide
+
+## Install
+
+```bash
+npm install @askable-ui/solid @askable-ui/core
+```
+
+## Quick start
+
+```tsx
+// src/App.tsx
+import { Askable, useAskable } from '@askable-ui/solid';
+
+export function App() {
+  const { promptContext } = useAskable();
+
+  return (
+    <>
+      <Askable meta={{ metric: 'revenue', value: '$128k', period: 'Q3' }}>
+        <article>$128k</article>
+      </Askable>
+
+      <p>Context: {promptContext()}</p>
+    </>
+  );
+}
+```
+
+## `<Askable>`
+
+Renders a `div` (or any element via `as`) annotated with `data-askable`.
+
+```tsx
+// Object meta — recommended for structured data
+<Askable meta={{ widget: 'churn-rate', value: '4.2%' }} scope="dashboard">
+  <ChurnChart />
+</Askable>
+
+// String meta — fine for simple labels
+<Askable meta="main navigation">
+  <nav>...</nav>
+</Askable>
+```
+
+## `useAskable(options?)`
+
+Creates (or shares) a context and returns reactive accessor functions.
+
+```tsx
+const { focus, promptContext, ctx } = useAskable();
+
+// focus()       — current AskableFocus | null (accessor)
+// promptContext() — serialized string (accessor)
+// ctx           — raw AskableContext for advanced usage
+```
+
+All hooks in the same SolidJS app share a single context instance by default (matched by name + events key), so source hooks connect automatically without passing `ctx` around.
+
+## Sources
+
+Sources expose app state to the AI. Register them once in a layout or root component and they're available everywhere.
+
+### Page source
+
+```tsx
+import { useAskablePageSource } from '@askable-ui/solid';
+
+function Root() {
+  useAskablePageSource({ includeLinks: false });
+  // ...
+}
+```
+
+### Cart source
+
+```tsx
+import { useAskableCartSource } from '@askable-ui/solid';
+import type { AskableCartItem } from '@askable-ui/solid';
+
+export function CartWidget() {
+  const { snapshot, addItem, removeItem, updateQuantity, clearCart } = useAskableCartSource({
+    items: [],
+    totals: { currency: 'USD' },
+  });
+
+  return (
+    <div>
+      <p>{snapshot()?.itemCount} items — {snapshot()?.total}</p>
+      <button onClick={() => clearCart()}>Clear</button>
+    </div>
+  );
+}
+```
+
+### Multistep / wizard source
+
+```tsx
+import { useAskableMultistepSource } from '@askable-ui/solid';
+
+export function Checkout() {
+  const wizard = useAskableMultistepSource({
+    steps: [
+      { id: 'cart',     label: 'Cart' },
+      { id: 'shipping', label: 'Shipping' },
+      { id: 'payment',  label: 'Payment' },
+      { id: 'confirm',  label: 'Confirm' },
+    ],
+  });
+
+  return (
+    <div>
+      <p>
+        Step {(wizard.snapshot()?.currentIndex ?? 0) + 1} of{' '}
+        {wizard.snapshot()?.totalSteps}
+      </p>
+      <button onClick={() => wizard.next()}>Next</button>
+      <button onClick={() => wizard.prev()}>Back</button>
+    </div>
+  );
+}
+```
+
+### Notification source
+
+```tsx
+import { createSignal } from 'solid-js';
+import { useAskableNotificationSource } from '@askable-ui/solid';
+import type { AskableNotification } from '@askable-ui/solid';
+
+export function ToastManager() {
+  const [toasts, setToasts] = createSignal<AskableNotification[]>([]);
+  useAskableNotificationSource({ notifications: toasts });
+
+  return (
+    <For each={toasts()}>
+      {(n) => (
+        <div>
+          {n.message}
+          <button onClick={() => setToasts((t) => t.filter((x) => x.id !== n.id))}>×</button>
+        </div>
+      )}
+    </For>
+  );
+}
+```
+
+### Error source
+
+```tsx
+import { useAskableErrorSource } from '@askable-ui/solid';
+
+// In your error boundary or try/catch:
+const { addError, clearErrors } = useAskableErrorSource();
+
+try {
+  await submitOrder();
+} catch (e) {
+  addError({ key: 'submit', message: (e as Error).message, severity: 'error' });
+}
+```
+
+### Other sources
+
+| Hook | Default id | Description |
+|---|---|---|
+| `useAskablePageSource` | `page` | Document title, URL, headings |
+| `useAskableNavigationSource` | `navigation` | Route history |
+| `useAskableFormSource` | `form` | Form field values and validation |
+| `useAskableTableSource` | `table` | Data grid rows, columns, selection |
+| `useAskableUserSource` | `user` | Authenticated user identity |
+| `useAskableErrorSource` | `errors` | Recent application errors |
+| `useAskableNotificationSource` | `notifications` | Active toasts and alerts |
+| `useAskableCartSource` | `cart` | Shopping cart state |
+| `useAskableMultistepSource` | `multistep` | Wizard/stepper progress |
+| `useAskableMediaSource` | `media` | Audio/video playback state |
+| `useAskableScrollSource` | `scroll` | Scroll position and direction |
+| `useAskableNetworkSource` | `network` | Connection type and online status |
+| `useAskableThemeSource` | `theme` | Color scheme, motion, contrast |
+| `useAskableWindowSource` | `window` | Viewport size and device category |
+| `useAskableStorageSource` | `storage` | localStorage / sessionStorage |
+| `useAskableGeolocationSource` | `geolocation` | User coordinates |
+| `useAskableBatterySource` | `battery` | Device battery level |
+| `useAskableFeatureFlagSource` | `featureFlags` | Feature flag values |
+| `useAskableAbTestSource` | `abTests` | A/B test variant assignments |
+| `useAskableAnalyticsSource` | `analytics` | Recent analytics events |
+| `useAskableLoadingSource` | `loading` | In-flight request states |
+| `useAskableIdleSource` | `idle` | User idle / active state |
+| `useAskableSearchSource` | `search` | Search query and results |
+| `useAskableTabSource` | `tabs` | Active tab and tab list |
+| `useAskablePermissionSource` | `permissions` | Browser permission states |
+| `useAskableLocaleSource` | `locale` | User locale and timezone |
+| `useAskableTimeSource` | `time` | Current time and business hours |
+| `useAskableFocusSource` | `focusedElement` | Currently focused DOM element |
+| `useAskableConnectionSource` | `connection` | WebSocket / EventSource status |
+| `useAskablePerformanceSource` | `performance` | Core Web Vitals and timing |
+| `useAskableClipboardSource` | `clipboard` | Recent clipboard entries |
+| `useAskableSelectionSource` | `selection` | Text selection |
+| `useAskableDOMSource` | `dom` | DOM structure snapshot |
+
+## Streaming and chat
+
+### `useAskableStream`
+
+```tsx
+import { useAskableStream } from '@askable-ui/solid';
+
+export function AskButton() {
+  const { stream, content, isStreaming } = useAskableStream();
+
+  return (
+    <>
+      {isStreaming() && <span>Thinking…</span>}
+      {content() && <p>{content()}</p>}
+      <button
+        disabled={isStreaming()}
+        onClick={() =>
+          stream('Explain what I am looking at', async (req, emit) => {
+            const res = await fetch('/api/chat', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(req),
+            });
+            const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              emit(value);
+            }
+          })
+        }
+      >
+        Ask AI
+      </button>
+    </>
+  );
+}
+```
+
+### `useAskableChat`
+
+```tsx
+import { For } from 'solid-js';
+import { useAskableChat } from '@askable-ui/solid';
+
+export function ChatPanel() {
+  const { messages, append, isStreaming, clearMessages } = useAskableChat({
+    systemPrompt: (ctx) => `You are a helpful UI assistant.\n\nCurrent UI context:\n${ctx}`,
+  });
+
+  return (
+    <div>
+      <For each={messages()}>
+        {(m) => <div class={m.role}>{m.content}</div>}
+      </For>
+
+      <button
+        disabled={isStreaming()}
+        onClick={() =>
+          append('What is this page about?', async (req, _msgs, emit) => {
+            const res = await fetch('/api/chat', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(req),
+            });
+            const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              emit(value);
+            }
+          })
+        }
+      >
+        Ask
+      </button>
+      <button onClick={() => clearMessages()}>Clear</button>
+    </div>
+  );
+}
+```
+
+## Focus history
+
+```tsx
+import { For } from 'solid-js';
+import { useAskableHistory } from '@askable-ui/solid';
+
+export function HistoryPanel() {
+  const { history } = useAskableHistory({ maxEntries: 5 });
+
+  return (
+    <ul>
+      <For each={history()}>
+        {(f) => <li>{JSON.stringify(f.meta)}</li>}
+      </For>
+    </ul>
+  );
+}
+```
+
+## Region and text selection capture
+
+```tsx
+import { useAskableRegionCapture, useAskableTextSelectionCapture } from '@askable-ui/solid';
+
+export function CaptureControls() {
+  const region = useAskableRegionCapture();
+  const selection = useAskableTextSelectionCapture();
+
+  return (
+    <div>
+      <button onClick={() => region.start()}>Capture region</button>
+      <button onClick={() => selection.captureNow()}>Capture selection</button>
+      {region.active() && <span>Selecting…</span>}
+    </div>
+  );
+}
+```
+
+## Keyboard shortcuts
+
+```tsx
+import { useAskableKeyboardShortcut } from '@askable-ui/solid';
+
+export function ShortcutHandler() {
+  useAskableKeyboardShortcut({
+    keys: ['Meta+k', 'Control+k'],
+    onTrigger: () => console.log('shortcut fired', ctx.toPromptContext()),
+  });
+
+  return null;
+}
+```
+
+## Agent requests
+
+```tsx
+import { useAskable } from '@askable-ui/solid';
+
+const { ctx } = useAskable();
+
+// Build a structured request with context, focus, and optional packet
+const req = await ctx.toAgentRequest('Why is revenue dropping?', {
+  history: 3,
+  packet: true,
+});
+
+await fetch('/api/chat', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(req),
+});
+```
+
+## Custom sources
+
+Use `useAskableSource` to register any arbitrary data source:
+
+```tsx
+import { createSignal, createEffect } from 'solid-js';
+import { useAskableSource } from '@askable-ui/solid';
+import { createAskableStaticSource } from '@askable-ui/core';
+
+export function CustomMetricsSource() {
+  const [metrics, setMetrics] = createSignal({ revenue: 0, users: 0 });
+  const source = createAskableStaticSource(() => metrics());
+  const { notifyChanged } = useAskableSource('metrics', source);
+
+  createEffect(() => {
+    metrics(); // track
+    notifyChanged();
+  });
+
+  return null;
+}
+```
+
+## SSR
+
+`useAskable` is safe to call during server rendering — on the server, `focus()` returns `null` and `promptContext()` returns `''`. All event listeners and DOM observation only run inside `createEffect`, which is browser-only. SolidStart apps with SSR work with any askable-ui hook without additional guards.

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -29,7 +29,7 @@ features:
 
   - icon: ⚡
     title: Framework-native bindings
-    details: First-class hooks and components for React, React Native, Vue, and Svelte. Web bindings are reactive and SSR-safe; React Native ships a focused press-driven adapter on top of @askable-ui/core.
+    details: First-class hooks and components for React, Vue, Svelte, Angular, SolidJS, Qwik, and React Native. All web bindings are reactive and SSR-safe; React Native ships a press-driven adapter on top of @askable-ui/core.
 
   - icon: 🎯
     title: Multiple interaction patterns


### PR DESCRIPTION
## Summary

- **`@askable-ui/qwik` goes from 2 hooks to 15+** — adds sources, streaming, chat, and history so Qwik apps have the same core capabilities as React/Vue/Svelte.
- **Global context caching** — `useAskable` now shares a single context instance per key (matching React/Solid behaviour) so all source hooks in the same page read from the same focus stream without requiring manual `ctx` passing.
- **Getting-started guide** — Angular install/annotate/observe tabs added alongside React/Vue/Svelte.
- **Docs homepage features** — framework list updated to name all six frameworks (React, Vue, Svelte, Angular, SolidJS, Qwik) plus React Native.

## New Qwik hooks

| Hook | Description |
|---|---|
| `useAskableSource` | Base source registration on the shared context |
| `useAskableStream` | Streaming LLM responses with reactive `content`/`status` signals |
| `useAskableChat` | Multi-turn chat — injects UI context on every turn automatically |
| `useAskableHistory` | Focus history with deduplication and configurable depth |
| `useAskablePageSource` | Document title, URL, headings, optional links |
| `useAskableNavigationSource` | Route history |
| `useAskableFormSource` | Form field values and validation state |
| `useAskableTableSource` | Data grid rows, columns, filters, selection |
| `useAskableUserSource` | Authenticated user identity |
| `useAskableErrorSource` | Recent application errors |
| `useAskableNotificationSource` | Active toasts and alerts with push/dismiss/clear |
| `useAskableCartSource` | Shopping cart with add/remove/updateQuantity/setTotals/clearCart |
| `useAskableMultistepSource` | Wizard/stepper with next/prev/goTo/setSteps |

All source hooks use `useVisibleTask$` for browser-only registration and return Qwik `useSignal` values for reactive rendering.

## Test plan

- [ ] `cd packages/qwik && npm run build` — tsc should compile without errors
- [ ] CI typecheck-and-build passes
- [ ] Getting-started guide renders Angular tabs correctly at `/guide/getting-started`
- [ ] Docs homepage features card shows correct framework list

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_