### PR TITLE
fix: Tier-1 verified bug sweep (create-app, svelte, react/vue, mcp, context)

### DIFF
--- a/packages/context/src/__tests__/packet.test.ts
+++ b/packages/context/src/__tests__/packet.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WEB_CONTEXT_PROTOCOL,
+  WEB_CONTEXT_VERSION,
+  createWebContextPacket,
+  isWebContextPacket,
+  webContextPacketSchema,
+} from '../index.js';
+
+describe('createWebContextPacket', () => {
+  it('applies protocol, version, and privacy/provenance defaults', () => {
+    const packet = createWebContextPacket({ capture: { mode: 'element-focus' } });
+    expect(packet.protocol).toBe(WEB_CONTEXT_PROTOCOL);
+    expect(packet.version).toBe(WEB_CONTEXT_VERSION);
+    expect(packet.privacy).toEqual({ redacted: false, consent: 'implicit' });
+    expect(packet.provenance).toEqual({ producer: 'askable-ui', method: 'app' });
+    expect(typeof packet.source.timestamp).toBe('string');
+  });
+
+  it('lets callers override defaults', () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'region', gesture: 'drag' },
+      privacy: { redacted: true, consent: 'explicit' },
+      provenance: { producer: 'my-app', method: 'extension' },
+    });
+    expect(packet.privacy.redacted).toBe(true);
+    expect(packet.provenance.method).toBe('extension');
+  });
+
+  it('produces packets that pass the type guard', () => {
+    const packet = createWebContextPacket({ capture: { mode: 'viewport' } });
+    expect(isWebContextPacket(packet)).toBe(true);
+  });
+});
+
+describe('isWebContextPacket', () => {
+  const base = createWebContextPacket({ capture: { mode: 'element-focus', gesture: 'click' } });
+
+  it('accepts a valid packet', () => {
+    expect(isWebContextPacket(base)).toBe(true);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isWebContextPacket(null)).toBe(false);
+    expect(isWebContextPacket('packet')).toBe(false);
+    expect(isWebContextPacket([base])).toBe(false);
+  });
+
+  it('rejects wrong protocol/version', () => {
+    expect(isWebContextPacket({ ...base, protocol: 'other' })).toBe(false);
+    expect(isWebContextPacket({ ...base, version: '9.9' })).toBe(false);
+  });
+
+  it('rejects an invalid capture.mode (enum enforced, not just typeof string)', () => {
+    expect(isWebContextPacket({ ...base, capture: { mode: 'not-a-mode' } })).toBe(false);
+  });
+
+  it('rejects an invalid capture.gesture when present', () => {
+    expect(isWebContextPacket({ ...base, capture: { mode: 'region', gesture: 'wiggle' } })).toBe(false);
+  });
+
+  it('allows a missing optional capture.gesture', () => {
+    expect(isWebContextPacket({ ...base, capture: { mode: 'region' } })).toBe(true);
+  });
+
+  it('rejects an invalid privacy.consent', () => {
+    expect(isWebContextPacket({ ...base, privacy: { redacted: false, consent: 'maybe' } })).toBe(false);
+  });
+
+  it('rejects an invalid provenance.method (enum enforced, not just typeof string)', () => {
+    expect(
+      isWebContextPacket({ ...base, provenance: { producer: 'x', method: 'telepathy' } }),
+    ).toBe(false);
+  });
+});
+
+describe('guard / schema agreement', () => {
+  it('guard enum sets are sourced from the schema', () => {
+    // Every schema-allowed capture mode must be accepted by the guard.
+    for (const mode of webContextPacketSchema.properties.capture.properties.mode.enum) {
+      const packet = createWebContextPacket({ capture: { mode } });
+      expect(isWebContextPacket(packet)).toBe(true);
+    }
+    for (const method of webContextPacketSchema.properties.provenance.properties.method.enum) {
+      const packet = createWebContextPacket({
+        capture: { mode: 'custom' },
+        provenance: { producer: 'x', method },
+      });
+      expect(isWebContextPacket(packet)).toBe(true);
+    }
+  });
+});

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -271,15 +271,27 @@ export function createWebContextPacket(options: CreateWebContextPacketOptions): 
   };
 }
 
+// Enum sets are read straight from the schema so the runtime guard and the
+// published JSON Schema can never drift apart.
+const captureModeValues = webContextPacketSchema.properties.capture.properties.mode.enum;
+const captureGestureValues = webContextPacketSchema.properties.capture.properties.gesture.enum;
+const privacyConsentValues = webContextPacketSchema.properties.privacy.properties.consent.enum;
+const provenanceMethodValues = webContextPacketSchema.properties.provenance.properties.method.enum;
+
+function isEnumMember(allowed: readonly string[], value: unknown): boolean {
+  return typeof value === 'string' && allowed.includes(value);
+}
+
 export function isWebContextPacket(value: unknown): value is WebContextPacket {
   if (!isRecord(value)) return false;
   if (value.protocol !== WEB_CONTEXT_PROTOCOL || value.version !== WEB_CONTEXT_VERSION) return false;
   if (!isRecord(value.source) || typeof value.source.timestamp !== 'string') return false;
-  if (!isRecord(value.capture) || typeof value.capture.mode !== 'string') return false;
+  if (!isRecord(value.capture) || !isEnumMember(captureModeValues, value.capture.mode)) return false;
+  if (value.capture.gesture !== undefined && !isEnumMember(captureGestureValues, value.capture.gesture)) return false;
   if (!isRecord(value.privacy) || typeof value.privacy.redacted !== 'boolean') return false;
-  if (!['explicit', 'implicit', 'none'].includes(String(value.privacy.consent))) return false;
+  if (!isEnumMember(privacyConsentValues, value.privacy.consent)) return false;
   if (!isRecord(value.provenance) || typeof value.provenance.producer !== 'string') return false;
-  return typeof value.provenance.method === 'string';
+  return isEnumMember(provenanceMethodValues, value.provenance.method);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@askable-ui/create-app",
   "version": "0.15.0",
-  "description": "Scaffold an AI-native app with askable-ui — React, Vue, Svelte, or Next.js in one command",
+  "description": "Scaffold an AI-native app with askable-ui — React, Vue, Svelte, SolidJS, or Next.js in one command",
   "type": "module",
   "bin": {
     "create-askable-app": "bin/create-askable-app.js"
@@ -12,6 +12,7 @@
     "template",
     "template-vue",
     "template-svelte",
+    "template-solid",
     "template-nextjs",
     "README.md"
   ],

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -2,14 +2,21 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ASKABLE_VERSION = '0.14.0';
+const pkg = JSON.parse(
+  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+);
+
+// Sourced from this package's own version so every scaffolded app pins the
+// current release. Never hardcode this — the integrity test asserts it matches
+// the package version, which is how the 0.14.0/0.15.0 skew is prevented.
+export const ASKABLE_VERSION = pkg.version;
 const COPILOTKIT_VERSION = '1.59.2';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const TEMPLATE_DIR = path.resolve(__dirname, '..', 'template');
 
-const TEMPLATES = {
+export const TEMPLATES = {
   react: {
     label: 'React + Vite + CopilotKit',
     dir: TEMPLATE_DIR,
@@ -102,7 +109,7 @@ export async function runCli(args) {
   if (!projectArg || projectArg === '--help' || projectArg === '-h') {
     console.log('create-askable-app\n');
     console.log('Usage:');
-    console.log('  npm create @askable-ui/app <project-name> [--template react|vue|svelte|nextjs]\n');
+    console.log(`  npm create @askable-ui/app <project-name> [--template ${Object.keys(TEMPLATES).join('|')}]\n`);
     console.log('Templates:');
     for (const [key, t] of Object.entries(TEMPLATES)) {
       console.log(`  ${key.padEnd(12)} ${t.label}`);

--- a/packages/create-askable-app/test/scaffold.test.js
+++ b/packages/create-askable-app/test/scaffold.test.js
@@ -1,9 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { isDirectoryEmpty, toPackageName, runCli } from '../src/scaffold.js';
+import { isDirectoryEmpty, toPackageName, runCli, TEMPLATES, ASKABLE_VERSION } from '../src/scaffold.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkg = JSON.parse(
+  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+);
 
 test('toPackageName normalizes generated package names', () => {
   assert.equal(toPackageName('My Askable App'), 'my-askable-app');
@@ -27,4 +32,33 @@ test('runCli rejects path traversal outside cwd', async () => {
     () => runCli(['../../malicious']),
     /Target directory must be inside the current working directory/,
   );
+});
+
+// --- Release-integrity guards ---------------------------------------------
+// These catch the class of "ships broken on npm install" bugs: a template that
+// is offered by the CLI but excluded from the published tarball, or a version
+// constant that drifts from the package version.
+
+test('scaffold version matches the package version (no hardcoded drift)', () => {
+  assert.equal(
+    ASKABLE_VERSION,
+    pkg.version,
+    `ASKABLE_VERSION (${ASKABLE_VERSION}) must equal package.json version (${pkg.version})`,
+  );
+});
+
+test('every offered template directory is published in files[]', () => {
+  const filesEntries = new Set(pkg.files);
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  for (const [key, template] of Object.entries(TEMPLATES)) {
+    const dirName = path.basename(template.dir);
+    assert.ok(
+      filesEntries.has(dirName),
+      `Template "${key}" uses directory "${dirName}" which is missing from package.json "files" — it would be offered by the CLI but excluded from the published tarball`,
+    );
+    assert.ok(
+      fs.existsSync(path.resolve(here, '..', dirName)),
+      `Template "${key}" directory "${dirName}" does not exist on disk`,
+    );
+  }
 });

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -1116,6 +1116,63 @@ describe('createAskableMcpPageBridge', () => {
     });
   });
 
+  it('blocks unredacted packets when requireRedacted is set', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'region' },
+      privacy: { redacted: false, consent: 'implicit' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    createAskableMcpPageBridge({ provider, window: fakeWindow, requireRedacted: true });
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      type: 'get_current_context',
+      requestId: 'req-redact-1',
+    });
+    await flushPageBridge();
+
+    expect(fakeWindow.posted).toHaveLength(1);
+    expect(fakeWindow.posted[0]?.message).toEqual(
+      expect.objectContaining({
+        type: 'get_current_context:error',
+        requestId: 'req-redact-1',
+      }),
+    );
+    expect(fakeWindow.posted[0]?.message).not.toHaveProperty('packet');
+  });
+
+  it('forwards redacted packets when requireRedacted is set', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'region' },
+      privacy: { redacted: true, consent: 'explicit' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const fakeWindow = new FakePageBridgeWindow();
+    createAskableMcpPageBridge({ provider, window: fakeWindow, requireRedacted: true });
+
+    fakeWindow.emit({
+      protocol: ASKABLE_MCP_PAGE_BRIDGE_PROTOCOL,
+      version: ASKABLE_MCP_PAGE_BRIDGE_VERSION,
+      type: 'get_current_context',
+      requestId: 'req-redact-2',
+    });
+    await flushPageBridge();
+
+    expect(fakeWindow.posted[0]?.message).toEqual(
+      expect.objectContaining({
+        type: 'get_current_context:result',
+        requestId: 'req-redact-2',
+        packet,
+      }),
+    );
+  });
+
   it('removes the page bridge listener on dispose', async () => {
     const provider: AskableMcpContextProvider = {
       getContext: vi.fn(),

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -207,6 +207,14 @@ export interface AskableMcpPageBridgeOptions {
   allowedOrigins?: AskableMcpPageBridgeAllowedOrigins;
   window?: AskableMcpPageBridgeWindow;
   onError?: (error: unknown, event: MessageEvent) => void;
+  /**
+   * When `true`, page-bridge requests that resolve to a packet with
+   * `privacy.redacted === false` respond with an error instead of forwarding
+   * potentially-unredacted data — matching {@link AskableMcpServerOptions.requireRedacted}.
+   * Defaults to `false` for backwards compatibility. Set to `true` when the page
+   * captures user-entered or sensitive content in `data-askable` attributes.
+   */
+  requireRedacted?: boolean;
 }
 
 export interface AskableMcpPageBridge {
@@ -535,6 +543,16 @@ async function handleAskableMcpPageBridgeMessage(
   try {
     const contextOptions = getAskableMcpPageBridgeContextOptions(request.options);
     const packet = await options.provider.getContext(contextOptions);
+
+    if (options.requireRedacted && packet.privacy?.redacted === false) {
+      bridgeWindow.postMessage({
+        ...createAskableMcpPageBridgeResponseBase(request),
+        type: `${request.type}:error`,
+        error: { message: 'Context packet has not been redacted. Set requireRedacted: false to allow, or redact the packet before sending.' },
+      }, resolveAskableMcpPageBridgeTargetOrigin(event, options));
+      return;
+    }
+
     const responseBase = createAskableMcpPageBridgeResponseBase(request);
     let response: AskableMcpPageBridgeSuccessResponse;
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -46,7 +46,14 @@ export { useAskableStream } from './useAskableStream.js';
 export { useAskableChat } from './useAskableChat.js';
 // Re-export typed meta utility from core for convenience
 export { asMeta } from '@askable-ui/core';
-export type { TypedAskableFocus } from '@askable-ui/core';
+export type {
+  TypedAskableFocus,
+  AskableTabVisibility,
+  AskableRegionCaptureSelection,
+  AskableRegionCaptureState,
+  AskableTextSelectionCaptureSelection,
+  AskableTextSelectionCaptureState,
+} from '@askable-ui/core';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
 export type {
   UseAskableSourceOptions,
@@ -98,6 +105,12 @@ export type {
   UseAskableStorageSourceResult,
   AskableStorageSourceSnapshot,
 } from './useAskableStorageSource.js';
+export type {
+  UseAskableNotificationSourceOptions,
+  UseAskableNotificationSourceResult,
+  AskableNotification,
+  AskableNotificationSeverity,
+} from './useAskableNotificationSource.js';
 export type {
   UseAskableFormSourceOptions,
   UseAskableFormSourceResult,

--- a/packages/svelte/src/Askable5.svelte
+++ b/packages/svelte/src/Askable5.svelte
@@ -4,15 +4,16 @@
   interface Props {
     meta: Record<string, unknown> | string;
     as?: string;
+    scope?: string;
     children?: Snippet;
     [key: string]: unknown;
   }
 
-  let { meta, as = 'div', children, ...rest }: Props = $props();
+  let { meta, as = 'div', scope, children, ...rest }: Props = $props();
 
   const dataAskable = $derived(typeof meta === 'string' ? meta : JSON.stringify(meta));
 </script>
 
-<svelte:element this={as} data-askable={dataAskable} {...rest}>
+<svelte:element this={as} data-askable={dataAskable} data-askable-scope={scope} {...rest}>
   {@render children?.()}
 </svelte:element>

--- a/packages/svelte/src/__tests__/component.test.ts
+++ b/packages/svelte/src/__tests__/component.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import Askable from '../Askable.svelte';
+import Askable5 from '../Askable5.svelte';
 import AskableWithContent from './AskableWithContent.svelte';
 import AskableNested from './AskableNested.svelte';
 
@@ -52,5 +53,26 @@ describe('Askable (Svelte)', () => {
     expect(nodes[0].getAttribute('data-askable')).toBe(JSON.stringify({ view: 'dashboard' }));
     expect(nodes[1].getAttribute('data-askable')).toBe(JSON.stringify({ tab: 'finance' }));
     expect(nodes[2].getAttribute('data-askable')).toBe(JSON.stringify({ metric: 'revenue' }));
+  });
+});
+
+describe('Askable5 (Svelte 5 runes)', () => {
+  it('sets data-askable attribute with stringified object meta', () => {
+    const meta = { metric: 'revenue', value: '$2.3M' };
+    const { container } = render(Askable5, { props: { meta } });
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.getAttribute('data-askable')).toBe(JSON.stringify(meta));
+  });
+
+  it('sets data-askable-scope when scope is provided (regression: prop was dropped)', () => {
+    const { container } = render(Askable5, { props: { meta: { widget: 'revenue' }, scope: 'analytics' } });
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.getAttribute('data-askable-scope')).toBe('analytics');
+  });
+
+  it('omits data-askable-scope when scope is not provided', () => {
+    const { container } = render(Askable5, { props: { meta: { widget: 'revenue' } } });
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.hasAttribute('data-askable-scope')).toBe(false);
   });
 });

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -46,7 +46,14 @@ export { useAskableStream } from './useAskableStream.js';
 export { useAskableChat } from './useAskableChat.js';
 // Re-export typed meta utility from core for convenience
 export { asMeta } from '@askable-ui/core';
-export type { TypedAskableFocus } from '@askable-ui/core';
+export type {
+  TypedAskableFocus,
+  AskableTabVisibility,
+  AskableRegionCaptureSelection,
+  AskableRegionCaptureState,
+  AskableTextSelectionCaptureSelection,
+  AskableTextSelectionCaptureState,
+} from '@askable-ui/core';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
 export type {
   UseAskableSourceOptions,


### PR DESCRIPTION
## Summary

Fixes a cluster of **verified, shipped bugs** found by auditing the monorepo against `@askable-ui/core`. Each was confirmed against source before fixing; every fix ships with tests. These are the highest-leverage items because several break real consumers on `npm install` or silently lose data.

## Fixes

### 🔴 `@askable-ui/create-app` — published-tarball breakage
- `scaffold.js` hardcoded `ASKABLE_VERSION = '0.14.0'` while the repo is `0.15.0`, pinning a **stale release into every scaffolded app**. Now derived from the package's own `version`, so it can never drift.
- `files[]` omitted `template-solid` even though the directory exists and `--template solid` is offered → the Solid template was **excluded from the published npm tarball** and broke on install. Added.
- `description` now lists SolidJS; `--help` usage derives its template list from `TEMPLATES` (can't go stale).
- **Release-integrity guard:** new tests assert (a) the scaffold version equals the package version and (b) every offered template directory is present in `files[]` — so this whole class of "ships broken" bug can't recur.

### 🔴 `@askable-ui/svelte` — silent data loss
- `Askable5.svelte` (Svelte 5 runes) dropped the `scope` prop and `data-askable-scope` attribute that the Svelte 4 component has, **silently breaking scoped annotations** for runes consumers. Restored + regression tests.

### 🟡 `@askable-ui/react` + `@askable-ui/vue` — un-nameable public types
- `react` exported `useAskableNotificationSource` but **none of its types**; added them.
- Both packages' region/text-selection capture **result types reference** `Askable{Region,TextSelection}Capture{Selection,State}`, but consumers couldn't name them — re-exported from core in both. (Note: Vue's components use `defineComponent` with inline props and have no `AskableProps`/`AskableInspectorProps` interfaces to export, unlike Solid — intentionally not invented here.)
- Both: re-export `AskableTabVisibility` (used by `AskableTabSourceSnapshot`).

### 🔴 `@askable-ui/mcp` — privacy-gate exemption
- `requireRedacted` was enforced only in the server tools, **not** in `createAskableMcpPageBridge` — the page bridge had no privacy gate and forwarded packets with `privacy.redacted === false`. Added `requireRedacted` to the bridge options and gated all three request types before forwarding. (A per-field sanitizer hook is deferred as a separate additive enhancement.)

### 🟡 `@askable-ui/context` — guard/schema divergence
- `isWebContextPacket` only checked `typeof === 'string'` for `capture.mode`/`provenance.method` and ignored `capture.gesture`, so it accepted packets the published JSON Schema rejects. Enum sets are now **read from `webContextPacketSchema`** so guard and schema cannot diverge. Adds the package's first test suite.

## Test plan
- [x] `npm run build --workspaces` — clean across all 12 packages
- [x] create-app `node --test` — 6/6 (incl. integrity guards)
- [x] context 12/12 · mcp 38/38 · react 203/203 · vue 105/105 · svelte 41/41
- [ ] CI typecheck-and-build + static/quality green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_