### PR TITLE
feat(mcp): add askable-mcp stdio CLI for command-based MCP clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3375,6 +3375,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -8049,6 +8059,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
@@ -10125,7 +10142,11 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
+      "bin": {
+        "askable-mcp": "dist/cli.js"
+      },
       "devDependencies": {
+        "@types/node": "^22.10.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
       }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -11,6 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "askable-mcp": "./dist/cli.js"
+  },
   "files": [
     "dist",
     "README.md"
@@ -49,6 +52,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/node": "^22.10.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }

--- a/packages/mcp/src/__tests__/cli.test.ts
+++ b/packages/mcp/src/__tests__/cli.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { parseHeaders, main } from '../cli.js';
+
+describe('parseHeaders', () => {
+  it('parses repeated "Key: Value" header strings', () => {
+    expect(parseHeaders(['Authorization: Bearer abc', 'X-Tenant: acme'])).toEqual({
+      Authorization: 'Bearer abc',
+      'X-Tenant': 'acme',
+    });
+  });
+
+  it('trims whitespace and tolerates colons in the value', () => {
+    expect(parseHeaders(['X-Url:  https://a.example/x  '])).toEqual({
+      'X-Url': 'https://a.example/x',
+    });
+  });
+
+  it('ignores malformed entries and an undefined list', () => {
+    expect(parseHeaders(['no-colon', ': empty-key'])).toEqual({});
+    expect(parseHeaders(undefined)).toEqual({});
+  });
+});
+
+describe('main', () => {
+  const originalExitCode = process.exitCode;
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+  });
+
+  it('errors and sets a failing exit code when no source is provided', async () => {
+    const write = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    await main([]);
+
+    expect(process.exitCode).toBe(1);
+    expect(write).toHaveBeenCalled();
+    write.mockRestore();
+  });
+
+  it('prints help without failing when --help is passed', async () => {
+    process.exitCode = 0;
+    const write = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    await main(['--help']);
+
+    expect(process.exitCode).toBe(0);
+    expect(write).toHaveBeenCalled();
+    write.mockRestore();
+  });
+});

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import {
   ASKABLE_MCP_PAGE_BRIDGE_VERSION,
   createAskableMcpContextProvider,
   createAskableMcpPageBridge,
+  createAskableMcpRemoteProvider,
   createAskableMcpServer,
   createAskableMcpWebHandler,
   defaultPromptFormatter,
@@ -1227,5 +1228,35 @@ describe('defaultPromptFormatter', () => {
       'Recent context: [{"metadata":{"metric":"pipeline"},"text":"Pipeline is $8.1M"}]',
       'Source context: [{"label":"accounts","role":"collection","metadata":{"data":{"total":12}}}]',
     ].join('\n'));
+  });
+});
+
+describe('createAskableMcpRemoteProvider', () => {
+  it('fetches the current packet from the configured url with headers', async () => {
+    const packet = createWebContextPacket({ capture: { mode: 'region' } });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(packet),
+    });
+
+    const provider = createAskableMcpRemoteProvider({
+      url: 'https://app.example/context',
+      headers: { Authorization: 'Bearer abc' },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(provider.getContext()).resolves.toEqual(packet);
+    expect(fetchMock).toHaveBeenCalledWith('https://app.example/context', {
+      headers: { Authorization: 'Bearer abc' },
+    });
+  });
+
+  it('throws when the endpoint responds with a non-ok status', async () => {
+    const provider = createAskableMcpRemoteProvider({
+      url: 'https://app.example/context',
+      fetch: vi.fn().mockResolvedValue({ ok: false, status: 503 }) as unknown as typeof fetch,
+    });
+
+    await expect(provider.getContext()).rejects.toThrow(/503/);
   });
 });

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * askable-mcp — a turnkey stdio MCP server.
+ *
+ * Spawned by MCP clients (Claude Desktop, Cursor, …) that launch a command over
+ * stdio rather than connecting to an HTTP URL. It exposes the askable context
+ * tools/resources backed by a remote endpoint that serves the current Context
+ * packet, or a static packet file.
+ *
+ * Claude Desktop (claude_desktop_config.json):
+ *   {
+ *     "mcpServers": {
+ *       "my-app": {
+ *         "command": "npx",
+ *         "args": ["-y", "@askable-ui/mcp", "--url", "http://localhost:3001/context"]
+ *       }
+ *     }
+ *   }
+ *
+ * IMPORTANT: stdout is the MCP protocol channel — all human-facing logging goes
+ * to stderr.
+ */
+import { parseArgs } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { WebContextPacket } from '@askable-ui/context';
+import {
+  createAskableMcpServer,
+  createAskableMcpRemoteProvider,
+  type AskableMcpContextProvider,
+} from './index.js';
+
+const HELP = `askable-mcp — expose your app's UI context to any MCP client over stdio
+
+Usage:
+  askable-mcp --url <endpoint> [options]
+  askable-mcp --file <path> [options]
+
+Context source (one required):
+  --url <endpoint>      HTTP(S) endpoint that returns the current Context packet as JSON on GET
+  --file <path>         Path to a static Context packet JSON file
+
+Options:
+  --header "K: V"       Extra request header for --url (repeatable), e.g. "Authorization: Bearer abc"
+  --name <name>         Server name advertised to the client (default: askable-context)
+  --require-redacted    Refuse to serve packets with privacy.redacted === false
+  -h, --help            Show this help
+
+Example (claude_desktop_config.json):
+  { "mcpServers": { "my-app": {
+      "command": "npx",
+      "args": ["-y", "@askable-ui/mcp", "--url", "http://localhost:3001/context"] } } }
+`;
+
+export function parseHeaders(raw: string[] | undefined): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const entry of raw ?? []) {
+    const idx = entry.indexOf(':');
+    if (idx === -1) continue;
+    const key = entry.slice(0, idx).trim();
+    const value = entry.slice(idx + 1).trim();
+    if (key) headers[key] = value;
+  }
+  return headers;
+}
+
+function createFileProvider(path: string): AskableMcpContextProvider {
+  return {
+    async getContext() {
+      const raw = await readFile(path, 'utf8');
+      return JSON.parse(raw) as WebContextPacket;
+    },
+  };
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      url: { type: 'string' },
+      file: { type: 'string' },
+      header: { type: 'string', multiple: true },
+      name: { type: 'string' },
+      'require-redacted': { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: false,
+  });
+
+  if (values.help) {
+    process.stderr.write(HELP);
+    return;
+  }
+
+  if (!values.url && !values.file) {
+    process.stderr.write('askable-mcp: one of --url or --file is required.\n\n');
+    process.stderr.write(HELP);
+    process.exitCode = 1;
+    return;
+  }
+
+  const provider = values.url
+    ? createAskableMcpRemoteProvider({ url: values.url, headers: parseHeaders(values.header) })
+    : createFileProvider(values.file as string);
+
+  const server = createAskableMcpServer({
+    provider,
+    name: values.name,
+    requireRedacted: values['require-redacted'],
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  const sourceLabel = values.url ?? values.file;
+  process.stderr.write(`askable-mcp: serving context from ${sourceLabel} over stdio.\n`);
+}
+
+// Run only when invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`askable-mcp: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -284,6 +284,35 @@ export function createAskableMcpContextProvider(
   };
 }
 
+export interface AskableMcpRemoteProviderOptions {
+  /** URL of an endpoint that returns the current Context packet as JSON on GET. */
+  url: string;
+  /** Extra request headers, e.g. an Authorization header. */
+  headers?: Record<string, string>;
+  /** Inject a custom fetch implementation (defaults to the global `fetch`). */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Builds an {@link AskableMcpContextProvider} that fetches the current Context
+ * packet from a remote HTTP endpoint. Useful for connecting a stdio MCP server
+ * (e.g. the `askable-mcp` CLI) to a running app that exposes its packet at a URL.
+ */
+export function createAskableMcpRemoteProvider(
+  options: AskableMcpRemoteProviderOptions,
+): AskableMcpContextProvider {
+  const doFetch = options.fetch ?? fetch;
+  return {
+    async getContext() {
+      const response = await doFetch(options.url, { headers: options.headers });
+      if (!response.ok) {
+        throw new Error(`askable-mcp: context endpoint ${options.url} returned ${response.status}`);
+      }
+      return (await response.json()) as WebContextPacket;
+    },
+  };
+}
+
 export function createAskableMcpServer(options: AskableMcpServerOptions): McpServer {
   const server = new McpServer({
     name: options.name ?? 'askable-context',

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM"],
+    "types": ["node"],
     "strict": true,
     "declaration": true,
     "declarationMap": true,

--- a/site/docs/guide/mcp.md
+++ b/site/docs/guide/mcp.md
@@ -156,6 +156,37 @@ In Claude.ai settings → Integrations, add the MCP server URL. Claude will call
 
 Point the ChatGPT connector at your `/api/mcp` endpoint. The MCP server exposes a `read_current_resource` tool that ChatGPT's function-calling layer will invoke.
 
+## Connect over stdio (CLI)
+
+Some MCP clients launch a **command over stdio** instead of connecting to a URL. The `@askable-ui/mcp` package ships an `askable-mcp` binary for exactly this — no server framework or extra dependencies required. Point it at any endpoint that returns the current Context packet as JSON:
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "npx",
+      "args": [
+        "-y", "@askable-ui/mcp",
+        "--url", "http://localhost:3001/context",
+        "--header", "Authorization: Bearer YOUR_SECRET"
+      ]
+    }
+  }
+}
+```
+
+Your app just needs to expose a `GET` endpoint that returns the latest packet (e.g. via `ctx.toContextPacket()`). Flags:
+
+| Flag | Description |
+|---|---|
+| `--url <endpoint>` | HTTP(S) endpoint returning the current Context packet as JSON |
+| `--file <path>` | Serve a static packet file instead of fetching a URL |
+| `--header "K: V"` | Extra request header for `--url` (repeatable) |
+| `--name <name>` | Server name advertised to the client |
+| `--require-redacted` | Refuse to serve packets with `privacy.redacted === false` |
+
+The same remote provider is available programmatically via `createAskableMcpRemoteProvider({ url, headers })`, which you can pass to `createAskableMcpServer`.
+
 ## MCP tools exposed
 
 The MCP server exposes a single tool:


### PR DESCRIPTION
## Summary

Adds `askable-mcp`, a turnkey **stdio MCP server** binary, so MCP clients that launch a command (Claude Desktop, Cursor) — rather than connecting to an HTTP URL — can read your app's UI context.

## Why

The existing path requires running an HTTP server (Express). Many MCP clients instead spawn a stdio command. This closes that gap with **no new runtime dependencies** — it reuses the already-present `@modelcontextprotocol/sdk` (`StdioServerTransport`) and `node:util.parseArgs` (no arg-parser, no server framework).

## What's included

- **`askable-mcp` bin** — serves the askable context tools/resources over stdio, backed by:
  - `--url <endpoint>` — fetches the current Context packet from an HTTP(S) endpoint, or
  - `--file <path>` — serves a static packet file
  - plus `--header "K: V"` (repeatable), `--name`, `--require-redacted`, `--help`
- **`createAskableMcpRemoteProvider({ url, headers })`** — exported for programmatic use (also what the CLI uses).
- MCP guide section documenting the CLI + a flag table.
- `@types/node` added **dev-only**, scoped to this package's tsconfig via `types: ["node"]` so it does not leak Node globals into the other packages' builds (verified: full 12-package build stays clean).

```json
{
  "mcpServers": {
    "my-app": {
      "command": "npx",
      "args": ["-y", "@askable-ui/mcp", "--url", "http://localhost:3001/context"]
    }
  }
}
```

Your app just needs a `GET` endpoint returning the latest packet (e.g. via `ctx.toContextPacket()`).

## Test plan

- [x] mcp `45/45` tests (7 new: remote provider success/non-ok + CLI header parsing / arg handling)
- [x] full workspace `tsc` build clean (no `@types/node` leakage)
- [x] docs build clean (no dead links)
- [x] smoke-tested: shebang, `--help`, exit-1 on missing source, stdio startup with `--file`
- [ ] CI typecheck-and-build + static/quality green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_