### PR TITLE
docs(mcp): fix page-bridge examples to match the real API

### DIFF
--- a/site/docs/guide/mcp.md
+++ b/site/docs/guide/mcp.md
@@ -22,32 +22,31 @@ The page bridge exposes a `read_current_resource` MCP tool and an `askable://cur
 ```ts
 // In your app entry point (e.g. main.ts / index.ts)
 import { createAskableContext } from '@askable-ui/core';
-import { createAskableMcpPageBridge } from '@askable-ui/mcp';
+import { createAskableMcpContextProvider, createAskableMcpPageBridge } from '@askable-ui/mcp';
 
 const ctx = createAskableContext();
 ctx.observe(document);
 
-const bridge = createAskableMcpPageBridge(ctx, {
-  resourceUri: 'askable://current',
-  name: 'My App UI Context',
+const bridge = createAskableMcpPageBridge({
+  provider: createAskableMcpContextProvider(ctx),
+  // requireRedacted: true, // refuse to serve packets with privacy.redacted === false
 });
 
 // The bridge installs a window message listener that local companions use.
-// Call bridge.destroy() when tearing down.
+// Call bridge.dispose() when tearing down.
 ```
-
-The companion receives a resource-shaped JSON object or a prompt-ready string depending on the request format.
 
 ### Prompt-ready vs structured output
 
-```ts
-// Returns a plain string like:
-// "User is focused on: metric: revenue, value: $128k, period: Q3"
-bridge.promptContext();
+A local companion posts a message and receives a response shaped by the request `type`:
 
-// Returns a structured WebContextPacket for programmatic use
-bridge.contextPacket();
-```
+| Request `type` | Response |
+|---|---|
+| `get_current_context` | The structured `WebContextPacket` |
+| `format_context_for_prompt` | A prompt-ready string |
+| `read_current_resource` | An MCP resource at `askable://current` (packet JSON or prompt text) |
+
+The packet/string is produced by the `provider` you pass — `createAskableMcpContextProvider(ctx)` wires it to your context's `toContextPacket()` / `toContext()`.
 
 ## Remote WebMCP (server-side)
 
@@ -249,16 +248,16 @@ app.post('/api/chat', async (req, res) => {
 ```tsx
 import { useEffect } from 'react';
 import { useAskable } from '@askable-ui/react';
-import { createAskableMcpPageBridge } from '@askable-ui/mcp';
+import { createAskableMcpContextProvider, createAskableMcpPageBridge } from '@askable-ui/mcp';
 
 function App() {
   const { ctx } = useAskable();
 
   useEffect(() => {
-    const bridge = createAskableMcpPageBridge(ctx, {
-      resourceUri: 'askable://current',
+    const bridge = createAskableMcpPageBridge({
+      provider: createAskableMcpContextProvider(ctx),
     });
-    return () => bridge.destroy();
+    return () => bridge.dispose();
   }, [ctx]);
 
   return <Dashboard />;


### PR DESCRIPTION
## Summary

The MCP guide's page-bridge examples document an API that **does not exist**:

```ts
// ❌ what the guide showed
const bridge = createAskableMcpPageBridge(ctx, { resourceUri: 'askable://current', name: '…' });
bridge.destroy();
bridge.promptContext();
bridge.contextPacket();
```

The real API (verified against `packages/mcp/src/index.ts`) takes a single options object with a `provider` and returns `{ dispose() }` — there is no `resourceUri`/`name` option and no `destroy()`/`promptContext()`/`contextPacket()` method.

## Fix

```ts
// ✅ corrected
const bridge = createAskableMcpPageBridge({
  provider: createAskableMcpContextProvider(ctx),
});
bridge.dispose();
```

- Fixed both the **Browser-local page bridge** example and the **React example with page bridge**.
- Replaced the bogus "prompt-ready vs structured" `bridge.promptContext()`/`contextPacket()` snippet with an accurate table of how the companion selects output via the request `type` (`get_current_context` / `format_context_for_prompt` / `read_current_resource`).
- Mentioned the `requireRedacted` option.

Docs-only; no code changes.

## Test plan

- [x] `vitepress build` clean (no dead links)
- [x] swept `site/docs/` — no remaining references to the non-existent API in source
- [ ] CI preview/build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_