### PR TITLE
feat(mcp): add live askable://current resource and list_context_sources tool

### DIFF
--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -1260,3 +1260,89 @@ describe('createAskableMcpRemoteProvider', () => {
     await expect(provider.getContext()).rejects.toThrow(/503/);
   });
 });
+
+type ResourceReader = (uri: URL) => Promise<{ contents: Array<{ uri: string; mimeType?: string; text: string }> }>;
+
+function getResourceReader(provider: AskableMcpContextProvider, uri: string, requireRedacted = false): ResourceReader {
+  const server = createAskableMcpServer({ provider, requireRedacted });
+  const resources = (server as unknown as {
+    _registeredResources: Record<string, { readCallback: ResourceReader }>;
+  })._registeredResources;
+  const resource = resources[uri];
+  if (!resource) throw new Error(`Resource ${uri} not registered`);
+  return resource.readCallback;
+}
+
+describe('createAskableMcpServer — current_context resource', () => {
+  it('serves the current packet as a resource at askable://current', async () => {
+    const packet = createWebContextPacket({ capture: { mode: 'region' } });
+    const provider: AskableMcpContextProvider = { getContext: vi.fn().mockResolvedValue(packet) };
+
+    const read = getResourceReader(provider, ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI);
+    const result = await read(new URL(ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI));
+
+    expect(result.contents[0].mimeType).toBe('application/json');
+    expect(JSON.parse(result.contents[0].text)).toEqual(packet);
+  });
+
+  it('throws when requireRedacted is set and the packet is unredacted', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'region' },
+      privacy: { redacted: false, consent: 'implicit' },
+    });
+    const provider: AskableMcpContextProvider = { getContext: vi.fn().mockResolvedValue(packet) };
+
+    const read = getResourceReader(provider, ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI, true);
+
+    await expect(read(new URL(ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI))).rejects.toThrow(/redacted/);
+  });
+});
+
+describe('createAskableMcpServer — list_context_sources tool', () => {
+  it('returns the sources from the current packet', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'semantic' },
+      surrounding: {
+        sources: [
+          { label: 'accounts', role: 'collection', metadata: { total: 12 } },
+          { label: 'cart', role: 'cart', metadata: { itemCount: 3 } },
+        ],
+      },
+    });
+    const provider: AskableMcpContextProvider = { getContext: vi.fn().mockResolvedValue(packet) };
+
+    const handler = getToolHandler(provider, 'list_context_sources');
+    const result = await handler({});
+
+    expect(result.isError).toBeFalsy();
+    const sources = JSON.parse(result.content[0].text);
+    expect(sources).toHaveLength(2);
+    expect(sources[0].label).toBe('accounts');
+  });
+
+  it('returns an empty list when the packet has no sources', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(createWebContextPacket({ capture: { mode: 'element-focus' } })),
+    };
+
+    const handler = getToolHandler(provider, 'list_context_sources');
+    const result = await handler({});
+
+    expect(JSON.parse(result.content[0].text)).toEqual([]);
+  });
+
+  it('blocks unredacted packets when requireRedacted is set', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'region' },
+      privacy: { redacted: false, consent: 'implicit' },
+    });
+    const server = createAskableMcpServer({
+      provider: { getContext: vi.fn().mockResolvedValue(packet) },
+      requireRedacted: true,
+    });
+    const tools = (server as unknown as { _registeredTools: Record<string, { handler: McpToolHandler }> })._registeredTools;
+    const result = await tools['list_context_sources'].handler({});
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -338,6 +338,31 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
     }),
   );
 
+  server.registerResource(
+    'current_context',
+    ASKABLE_MCP_CURRENT_CONTEXT_RESOURCE_URI,
+    {
+      title: 'Current Askable context',
+      description: 'The current selected, focused, or visible Context packet from the active app.',
+      mimeType: 'application/json',
+    },
+    async (uri) => {
+      const packet = await options.provider.getContext();
+      if (options.requireRedacted && packet.privacy?.redacted === false) {
+        throw new Error('Context packet has not been redacted. Set requireRedacted: false to allow, or redact the packet before serving.');
+      }
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: 'application/json',
+            text: JSON.stringify(packet, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
   server.registerTool(
     'get_current_context',
     {
@@ -369,6 +394,43 @@ export function createAskableMcpServer(options: AskableMcpServerOptions): McpSer
         return {
           isError: true,
           content: [{ type: 'text', text: 'Failed to get context. Check server logs for details.' }],
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    'list_context_sources',
+    {
+      title: 'List app context sources',
+      description: 'List the app-owned context sources currently available (label, role, and metadata) so the agent can decide which to request.',
+      inputSchema: contextOptionsShape,
+    },
+    async (args) => {
+      try {
+        const packet = await options.provider.getContext(args);
+        if (options.requireRedacted && packet.privacy?.redacted === false) {
+          console.warn('[askable-mcp] list_context_sources blocked: packet has privacy.redacted=false');
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'Context packet has not been redacted. Configure a sanitizer or set requireRedacted: false.' }],
+          };
+        }
+        const sources = packet.surrounding?.sources ?? [];
+        return {
+          content: [
+            {
+              type: 'text',
+              mimeType: 'application/json',
+              text: JSON.stringify(sources, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error('[askable-mcp] list_context_sources failed:', err);
+        return {
+          isError: true,
+          content: [{ type: 'text', text: 'Failed to list context sources. Check server logs for details.' }],
         };
       }
     },

--- a/site/docs/guide/mcp.md
+++ b/site/docs/guide/mcp.md
@@ -186,19 +186,23 @@ Your app just needs to expose a `GET` endpoint that returns the latest packet (e
 
 The same remote provider is available programmatically via `createAskableMcpRemoteProvider({ url, headers })`, which you can pass to `createAskableMcpServer`.
 
-## MCP tools exposed
+## MCP tools and resources exposed
 
-The MCP server exposes a single tool:
+`createAskableMcpServer` (and therefore the web handler and stdio CLI built on it) registers these tools:
 
 | Tool | Description |
 |---|---|
-| `read_current_resource` | Returns the current UI context as a `WebContextPacket` or prompt string |
+| `get_current_context` | Returns the current UI context as a `WebContextPacket` |
+| `format_context_for_prompt` | Returns a prompt-ready text rendering of the current context |
+| `list_context_sources` | Lists the app-owned context sources currently available (label, role, metadata) so the agent can decide which to request |
+| `get_context_schema` | Returns the JSON Schema for Context packets |
 
-And a resource:
+And these resources:
 
 | Resource | URI | Description |
 |---|---|---|
-| Current context | `askable://current` | Structured JSON packet of the focused UI element and active sources |
+| Current context | `askable://current` | The current Context packet as JSON — read it via `resources/read` instead of calling a tool |
+| Context schema | `context://schema` | The JSON Schema for Context packets |
 
 ## createAskableMcpServer (embedding MCP in-process)
 


### PR DESCRIPTION
## Summary

Closes a server-vs-bridge asymmetry: the page bridge exposes `read_current_resource` at `askable://current`, but `createAskableMcpServer` registered only the static `context://schema` resource — so MCP clients that use the `resources/read` model could not read the *current* packet, only the `get_current_context` tool could.

## What's added

- **Live `askable://current` resource** on the server, returning the current `WebContextPacket` as JSON — symmetric with the page bridge. Gated by `requireRedacted` (throws on unredacted packets when enabled).
- **`list_context_sources` tool** — surfaces `packet.surrounding.sources` (label / role / metadata) so an agent can discover which app-owned sources exist before requesting them. Also `requireRedacted`-gated.
- Updated the MCP guide's tools/resources table, which previously listed a non-existent `read_current_resource` **server** tool (that's a page-bridge message type) and omitted the real tools.

Both additions reuse the existing `provider` and the already-present `@modelcontextprotocol/sdk` — **no new dependencies**.

## Test plan

- [x] mcp `50/50` tests (5 new: resource serve + redaction gate; `list_context_sources` populated / empty / blocked)
- [x] full workspace `tsc` build clean
- [x] docs build clean
- [ ] CI typecheck-and-build + static/quality green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_