### PR TITLE
ci(dependabot): keep major dev-dependency updates out of the grouped PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,14 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      # Only bundle non-breaking dev-dependency updates. Major bumps come as
+      # individual PRs so a breaking upgrade (e.g. an Angular major) can't be
+      # silently merged inside a routine group.
       dev-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

The `dev-dependencies` Dependabot group bundled **every** dev-dependency update, including major version jumps. That's how PR #346 ended up silently containing an **Angular 19 → 22 major** (plus `zone.js`, `@analogjs/*`, TypeScript 6) alongside routine bumps — and that Angular major breaks the directive's change detection.

## Fix

Restrict the group to `minor` + `patch`:

```yaml
groups:
  dev-dependencies:
    dependency-type: "development"
    update-types:
      - "minor"
      - "patch"
```

Now every **major** dev bump surfaces as its own standalone PR (clearly a major, reviewed on its own), while safe minor/patch updates still group together. This is generic — it protects against any future breaking major hidden in the group, not just Angular.

## Follow-up

Once this is merged, **#346 should be closed** — Dependabot will regenerate the grouped PR (minor/patch only) on its next run, and the Angular major will come as a separate PR that can be handled deliberately (it needs zoneless-safe change-detection work in the Angular directive).

## Test plan

- [x] `dependabot.yml` is valid YAML
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_