### PR TITLE
feat(frameworks): re-export a11yTextExtractor for discoverability

### DIFF
--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -47,5 +47,5 @@ export { useAskableMultistepSource } from './useAskableMultistepSource.js';
 export type { UseAskableMultistepSourceOptions, UseAskableMultistepSourceResult, AskableMultistepStep, AskableMultistepSourceSnapshot } from './useAskableMultistepSource.js';
 
 // Re-export typed meta utility from core for convenience
-export { asMeta } from '@askable-ui/core';
+export { asMeta, a11yTextExtractor } from '@askable-ui/core';
 export type { AskableFocus, TypedAskableFocus } from '@askable-ui/core';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -45,7 +45,7 @@ export { useAskableCartSource } from './useAskableCartSource.js';
 export { useAskableStream } from './useAskableStream.js';
 export { useAskableChat } from './useAskableChat.js';
 // Re-export typed meta utility from core for convenience
-export { asMeta } from '@askable-ui/core';
+export { asMeta, a11yTextExtractor } from '@askable-ui/core';
 export type {
   TypedAskableFocus,
   AskableTabVisibility,

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -45,7 +45,7 @@ export { useAskableTextSelectionCapture } from './useAskableTextSelectionCapture
 export { useAskableStream } from './useAskableStream.js';
 export { useAskableChat } from './useAskableChat.js';
 // Re-export typed meta utility from core for convenience
-export { asMeta } from '@askable-ui/core';
+export { asMeta, a11yTextExtractor } from '@askable-ui/core';
 export type { TypedAskableFocus } from '@askable-ui/core';
 export type { AskableProps } from './Askable.js';
 export type { AskableInspectorProps } from './AskableInspector.js';

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -23,7 +23,7 @@ export type {
 } from './askable.js';
 
 // Re-export typed meta utility from core for convenience
-export { asMeta } from '@askable-ui/core';
+export { asMeta, a11yTextExtractor } from '@askable-ui/core';
 export type { TypedAskableFocus } from '@askable-ui/core';
 
 // Svelte 5 runes-based API:

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -45,7 +45,7 @@ export { useAskableCartSource } from './useAskableCartSource.js';
 export { useAskableStream } from './useAskableStream.js';
 export { useAskableChat } from './useAskableChat.js';
 // Re-export typed meta utility from core for convenience
-export { asMeta } from '@askable-ui/core';
+export { asMeta, a11yTextExtractor } from '@askable-ui/core';
 export type {
   TypedAskableFocus,
   AskableTabVisibility,

--- a/site/docs/guide/annotating.md
+++ b/site/docs/guide/annotating.md
@@ -219,6 +219,15 @@ const ctx = createAskableContext({ textExtractor: a11yTextExtractor });
 
 This is useful for icon buttons, data cells with screen-reader-only labels, or any element whose visible text is less informative than its accessible name.
 
+`a11yTextExtractor` is re-exported from every web framework package, so you can pass it straight to the hook without importing from `@askable-ui/core`:
+
+```tsx
+// React (also Vue, Svelte, Solid, Qwik)
+import { useAskable, a11yTextExtractor } from '@askable-ui/react';
+
+const { promptContext } = useAskable({ textExtractor: a11yTextExtractor });
+```
+
 ### Custom extractor
 
 For full control, write your own extractor. The function receives the DOM element and returns a string. It applies to all focus events and explicit `select()` calls:


### PR DESCRIPTION
## Summary

`a11yTextExtractor` — the accessibility-aware text extractor (prefers `aria-label` → `aria-labelledby` → `title` → `alt` → `placeholder` → `textContent`) — was only exported from `@askable-ui/core`. To use it, framework consumers had to add a second import from core just to pass it as the `textExtractor` option. For a content-extraction-for-AI library, accessible-name quality is a correctness/a11y concern, so this should be easy to reach.

## What's included

- Re-export `a11yTextExtractor` from **react, vue, solid, svelte, qwik** (alongside the existing `asMeta` re-export), so it sits next to `useAskable`:

  ```tsx
  import { useAskable, a11yTextExtractor } from '@askable-ui/react';
  const { promptContext } = useAskable({ textExtractor: a11yTextExtractor });
  ```

- Documented the framework-hook usage in the **Annotating Elements** guide's existing "Accessibility-aware text extraction" section.

No new dependencies; the `textExtractor` option already existed on every framework's `useAskable` options (they extend `AskableContextOptions`). React Native is intentionally excluded — it's press-driven and has no `HTMLElement` to extract from.

## Test plan

- [x] full workspace `tsc` build clean (all 5 packages)
- [x] docs build clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_