### PR TITLE
docs(readme): reposition around the vision — one attribute, one protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">askable-ui</h1>
 
 <p align="center">
-  <strong>Your LLM doesn't know what the user is looking at. Fix that in two lines.</strong><br />
-  One attribute. Real-time UI context. Works with every LLM SDK and MCP client.
+  <strong>Give your LLM eyes. One attribute for humans, one protocol for agents.</strong><br />
+  <code>data-askable</code> turns what the user is looking at into structured, real-time context — for every LLM SDK and every MCP client.
 </p>
 
 <p align="center">
@@ -35,6 +35,7 @@
   <a href="#mcp-claude-desktop--cursor">MCP</a> &nbsp;·&nbsp;
   <a href="#how-it-works">How it works</a> &nbsp;·&nbsp;
   <a href="#capture-modes">Capture modes</a> &nbsp;·&nbsp;
+  <a href="#an-open-protocol-not-just-a-library">Protocol</a> &nbsp;·&nbsp;
   <a href="#packages">Packages</a> &nbsp;·&nbsp;
   <a href="https://askable-ui.com/docs/">Docs</a> &nbsp;·&nbsp;
   <a href="https://askable-mu.vercel.app/">Live Demo</a>
@@ -129,38 +130,37 @@ React + Vite + CopilotKit, wired up and ready to go.
 
 ## MCP — Claude Desktop, Cursor, and any MCP client
 
-Expose your app's live UI context as an MCP server. Any agent that connects can ask what the user currently sees.
-
-```bash
-npm install @askable-ui/mcp
-```
-
-```ts
-import { createAskableMcpServer, createAskableMcpContextProvider } from '@askable-ui/mcp';
-
-const server = createAskableMcpServer({
-  provider: createAskableMcpContextProvider(ctx),
-});
-
-server.connect(transport);
-```
-
-Add to `claude_desktop_config.json`:
+**Give Claude eyes into your running app in one command.** If your app exposes its current context at an endpoint (one `GET` route returning `ctx.toContextPacket()`), the bundled `askable-mcp` binary serves it to any MCP client over stdio — no server framework, no extra dependencies:
 
 ```json
+// claude_desktop_config.json
 {
   "mcpServers": {
     "my-app": {
-      "command": "node",
-      "args": ["path/to/your/mcp-server.js"]
+      "command": "npx",
+      "args": ["-y", "@askable-ui/mcp", "--url", "http://localhost:3001/context"]
     }
   }
 }
 ```
 
-Claude Desktop can now call `get_current_context` and `format_context_for_prompt` — it sees exactly what your user sees, without screenshots or manual description.
+Claude Desktop and Cursor can now call `get_current_context`, `format_context_for_prompt`, and `list_context_sources`, or read the live `askable://current` resource — they see exactly what your user sees, without screenshots or manual description. Add `--require-redacted` to refuse serving unredacted packets.
 
-→ **[MCP integration guide](https://askable-ui.com/docs/api/mcp)**
+Prefer embedding? The same server runs in-process:
+
+```ts
+import { createAskableMcpServer, createAskableMcpContextProvider } from '@askable-ui/mcp';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = createAskableMcpServer({
+  provider: createAskableMcpContextProvider(ctx),
+});
+await server.connect(new StdioServerTransport());
+```
+
+There's also a fetch-compatible HTTP handler (`createAskableMcpWebHandler`) for remote WebMCP endpoints, and a browser-local page bridge for extensions.
+
+→ **[MCP integration guide](https://askable-ui.com/docs/guide/mcp)**
 
 ---
 
@@ -247,7 +247,7 @@ const { visibleItems, promptContext } = useAskableViewport({ threshold: 0.5 });
 // promptContext → "Visible UI elements:\n- {"metric":"revenue","value":"$2.3M"} ..."
 ```
 
-Available in React, Vue, and Svelte (both Svelte 4 and 5).
+Available in React, Vue, Svelte (both 4 and 5), SolidJS, and Angular.
 
 ### Navigation history
 
@@ -260,7 +260,7 @@ const { history, promptContext } = useAskableHistory({ maxEntries: 5 });
 // promptContext → "User navigation trail (most recent first):\n→ {"metric":"churn"}..."
 ```
 
-Deduplicates consecutive identical entries by default. Available in React, Vue, and Svelte.
+Deduplicates consecutive identical entries by default. Available in React, Vue, Svelte, SolidJS, Angular, and Qwik.
 
 ### Composing context streams
 
@@ -461,6 +461,27 @@ All sources are also available from the main entry point — the split is about 
 
 ---
 
+## An open protocol, not just a library
+
+Everything above serializes to one versioned wire format: the **Context Packet** (`askable.context/0.1`). It's a small JSON envelope that carries what was captured, how, and — first-class — whether it was redacted and under what consent:
+
+```json
+{
+  "protocol": "askable.context",
+  "version": "0.1",
+  "capture": { "mode": "lasso", "intent": "explain the highlighted region" },
+  "target": { "text": "NRR 118%", "metadata": { "metric": "net revenue retention" } },
+  "privacy": { "redacted": true, "consent": "explicit" },
+  "provenance": { "producer": "askable-ui", "method": "app" }
+}
+```
+
+The format lives in [`@askable-ui/context`](https://www.npmjs.com/package/@askable-ui/context) — a dependency-free package with the types, the JSON Schema, and a runtime guard. askable-ui is the reference implementation; any producer (app, extension, native client) and any consumer (prompt builder, MCP client, agent runtime) can speak it.
+
+→ **[Read the spec](https://askable-ui.com/docs/guide/protocol)**
+
+---
+
 ## Works with
 
 **LLM SDKs**
@@ -483,7 +504,7 @@ All sources are also available from the main entry point — the split is about 
 | Svelte 4 & 5 | `@askable-ui/svelte` | `createAskableStore()`, `useAskableAgent()`, `useAskableStream()`, `useAskableChat()`, `useAskableKeyboardShortcut()`, `useAskablePageSource()`, `useAskableFormSource()`, `useAskableTableSource()`, `useAskableErrorSource()`, `useAskableUserSource()`, `useAskableNavigationSource()`, `useAskableDOMSource()`, `useAskableStorageSource()`, `useAskableCartSource()`, `useAskableMultistepSource()`, `useAskableScrollSource()`, `useAskableThemeSource()`, `useAskableWindowSource()`, `useAskableLocaleSource()`, `useAskableNetworkSource()`, `useAskableTimeSource()`, `useAskableFocusSource()`, `useAskableTabSource()`, `useAskablePerformanceSource()`, `useAskableBatterySource()`, `useAskableGeolocationSource()`, `useAskableViewport()`, `useAskableHistory()`, `<Askable>` |
 | SolidJS | `@askable-ui/solid` | `useAskable()`, `useAskableAgent()`, `useAskableStream()`, `useAskableChat()`, `useAskableKeyboardShortcut()`, `useAskablePageSource()`, `useAskableFormSource()`, `useAskableTableSource()`, `useAskableErrorSource()`, `useAskableUserSource()`, `useAskableNavigationSource()`, `useAskableDOMSource()`, `useAskableStorageSource()`, `useAskableCartSource()`, `useAskableMultistepSource()`, `useAskableScrollSource()`, `useAskableThemeSource()`, `useAskableWindowSource()`, `useAskableLocaleSource()`, `useAskableNetworkSource()`, `useAskableTimeSource()`, `useAskableFocusSource()`, `useAskableTabSource()`, `useAskablePerformanceSource()`, `useAskableBatterySource()`, `useAskableGeolocationSource()`, `useAskableViewport()`, `useAskableHistory()`, `<Askable>` |
 | Angular 16+ | `@askable-ui/angular` | `AskableService`, `AskablePageSourceService`, `AskableFormSourceService`, `AskableErrorSourceService`, `AskableUserSourceService`, `AskableNavigationSourceService`, `AskableCartSourceService`, `AskableMultistepSourceService`, `AskableScrollSourceService`, `AskableThemeSourceService`, `AskableWindowSourceService`, `AskableLocaleSourceService`, `AskableNetworkSourceService`, `AskableTimeSourceService`, `AskableFocusSourceService`, `AskableTabSourceService`, `AskablePerformanceSourceService`, `AskableBatterySourceService`, `AskableGeolocationSourceService`, `AskableAgentService`, `AskableDirective`, `AskableViewportService`, `AskableHistoryService` |
-| Qwik | `@askable-ui/qwik` | `useAskable()`, `<Askable>` for Qwik City apps |
+| Qwik | `@askable-ui/qwik` | `useAskable()`, `useAskableStream()`, `useAskableChat()`, `useAskableHistory()`, `useAskablePageSource()`, `useAskableFormSource()`, `useAskableTableSource()`, `useAskableErrorSource()`, `useAskableUserSource()`, `useAskableNavigationSource()`, `useAskableNotificationSource()`, `useAskableCartSource()`, `useAskableMultistepSource()`, `<Askable>` for Qwik City apps |
 | Web Component | `@askable-ui/web-component` | `<askable-context>` custom element, works in HTMX, Ember, vanilla HTML |
 | React Native | `@askable-ui/react-native` | `useAskable()`, `<Askable>`, scroll view adapter |
 | Vanilla JS | `@askable-ui/core` | `createAskableContext()`, zero dependencies |
@@ -613,7 +634,7 @@ export class AppComponent {
     { label: 'Focused element', value: this.askable.promptContext() },
   ]);
 
-  { promptContext } = useAskableCompose(this.sections);
+  promptContext = useAskableCompose(this.sections).promptContext;
 }
 ```
 

--- a/packages/angular/src/use-askable-compose.ts
+++ b/packages/angular/src/use-askable-compose.ts
@@ -29,7 +29,7 @@ export interface UseAskableComposeResult {
  *     { label: 'Focused element', value: this.askable.promptContext() },
  *   ]);
  *
- *   { promptContext } = useAskableCompose(this.sections);
+ *   promptContext = useAskableCompose(this.sections).promptContext;
  * }
  * ```
  */


### PR DESCRIPTION
## Summary

Part 2 of the vision work: the README now tells one retellable story — **"Give your LLM eyes. One attribute for humans, one protocol for agents."** — and leads with the two most shareable capabilities (the one-command Claude Desktop setup and the open wire format) instead of burying them.

## Changes

- **Tagline** → the vision statement.
- **MCP section rewritten to lead with the wow moment**: the `npx -y @askable-ui/mcp --url …` stdio setup for Claude Desktop/Cursor (shipped in #349) is now the first thing shown, with the in-process server and web handler as secondary paths. Documents `list_context_sources` and the live `askable://current` resource (shipped in #353), plus `--require-redacted`.
- **New section "An open protocol, not just a library"** — introduces the Context Packet (`askable.context/0.1`) with a mini example and links to the spec page (#359). Added to the header nav links.
- **Fixed an invalid Angular sample** (README + the identical snippet in `use-askable-compose.ts` JSDoc): `{ promptContext } = useAskableCompose(…)` is not valid in a class body — replaced with the field-initializer form `promptContext = useAskableCompose(this.sections).promptContext;`.
- **Refreshed stale claims**: viewport is available in React/Vue/Svelte/Solid/Angular, history additionally in Qwik; the Qwik package row now reflects its 15-hook surface (post-#342), and the broken MCP guide link (`/docs/api/mcp` → `/docs/guide/mcp`) is corrected.

## Test plan

- [x] Angular package builds clean (JSDoc-only source change)
- [x] All claims verified against package exports
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_