### PR TITLE
feat(mcp): add MCP Registry manifest (server.json + mcpName)

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,6 +2,7 @@
   "name": "@askable-ui/mcp",
   "version": "0.15.0",
   "description": "MCP server and page bridge to expose UI context to Claude Desktop, Cursor, and any MCP client",
+  "mcpName": "io.github.askable-ui/askable",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
+  "name": "io.github.askable-ui/askable",
+  "description": "Expose your web app's live UI context — what the user is looking at, as structured Context Packets — to Claude Desktop, Cursor, and any MCP client.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/askable-ui/askable",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "0.15.0"
+  },
+  "packages": [
+    {
+      "registry_name": "npm",
+      "name": "@askable-ui/mcp",
+      "version": "0.15.0",
+      "runtime_hint": "npx",
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "--url",
+          "description": "HTTP(S) endpoint that returns the current Context packet as JSON on GET",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "type": "named",
+          "name": "--file",
+          "description": "Path to a static Context packet JSON file (alternative to --url)",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "type": "named",
+          "name": "--require-redacted",
+          "description": "Refuse to serve packets with privacy.redacted === false",
+          "is_required": false,
+          "format": "boolean"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Part 3 of the vision work: prepare `@askable-ui/mcp` for publication to the **official MCP Registry** — the directory Claude Desktop/Cursor users browse for servers. Registry listing is the highest-intent free distribution channel for the `askable-mcp` stdio server shipped in #349.

## What's included

- **`packages/mcp/server.json`** — registry manifest: server name (`io.github.askable-ui/askable`), description, repo, npm package with `npx` runtime hint, and the CLI flags (`--url`, `--file`, `--require-redacted`).
- **`mcpName` field** in `packages/mcp/package.json` — the registry's npm-ownership validation reads this from the published tarball.

Both are **inert until published**: after the next npm release of `@askable-ui/mcp`, a maintainer runs `mcp-publisher login github && mcp-publisher publish` from `packages/mcp/` to list it. The registry CLI validates `server.json` at publish time, so if the schema has iterated since this manifest was authored, it will flag exactly what to adjust — nothing here can break the package or CI.

## Test plan

- [x] Both JSON files parse
- [x] mcp 50/50 tests pass (package.json touched)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SH45FVjjq9U9LXhXKdmZK)_