### PR TITLE
fix(mcp): enforce request body limit on actual bytes

### DIFF
--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -578,6 +578,139 @@ describe('createAskableMcpWebHandler', () => {
     }));
   });
 
+  it('rejects oversized MCP request bodies using actual bytes when content length is absent or false', async () => {
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn(),
+    };
+    const handler = createAskableMcpWebHandler({
+      provider,
+      maxRequestBodyBytes: 3,
+    });
+
+    const withoutContentLength = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: '😀',
+    }));
+    const falseContentLength = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'Content-Length': '1',
+      },
+      body: '😀',
+    }));
+
+    expect(withoutContentLength.status).toBe(413);
+    expect(falseContentLength.status).toBe(413);
+    expect(provider.getContext).not.toHaveBeenCalled();
+  });
+
+  it('cancels both branches of an oversized streamed MCP request', async () => {
+    let pulls = 0;
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array([pulls]));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const handler = createAskableMcpWebHandler({
+      provider: { getContext: vi.fn() },
+      maxRequestBodyBytes: 3,
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body,
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' }));
+    const pullsAtResponse = pulls;
+    await Promise.resolve();
+
+    expect(response.status).toBe(413);
+    expect(cancelled).toBe(true);
+    expect(pulls).toBe(pullsAtResponse);
+  });
+
+  it('supports authorization that consumes the body and returns parsedBody', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'semantic' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'get_current_context', arguments: {} },
+    });
+    const handler = createAskableMcpWebHandler({
+      provider,
+      maxRequestBodyBytes: new TextEncoder().encode(body).byteLength,
+      authorize: async (request) => ({
+        parsedBody: await request.json() as Record<string, unknown>,
+      }),
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+      },
+      body,
+    }));
+
+    expect(response.status).toBe(200);
+    expect(provider.getContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts an MCP request whose actual byte length equals the configured limit', async () => {
+    const packet = createWebContextPacket({
+      capture: { mode: 'semantic' },
+    });
+    const provider: AskableMcpContextProvider = {
+      getContext: vi.fn().mockResolvedValue(packet),
+    };
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'get_current_context', arguments: {} },
+    });
+    const handler = createAskableMcpWebHandler({
+      provider,
+      maxRequestBodyBytes: new TextEncoder().encode(body).byteLength,
+    });
+
+    const response = await handler(new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+      },
+      body,
+    }));
+
+    expect(response.status).toBe(200);
+    expect(provider.getContext).toHaveBeenCalledTimes(1);
+  });
+
   it('supports custom and disabled MCP request body limits', async () => {
     const packet = createWebContextPacket({
       capture: { mode: 'semantic' },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -500,6 +500,7 @@ export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions)
   return async (request) => {
     const startedAt = Date.now();
     let corsHeaders: Headers | undefined;
+    let requestBodySizeCheck: AskableMcpRequestBodySizeCheck | undefined;
     const finalize = (
       response: Response,
       outcome: AskableMcpWebOutcome,
@@ -529,21 +530,33 @@ export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions)
         );
       }
 
-      if (isRequestBodyTooLarge(request, resolveMaxRequestBodyBytes(options.maxRequestBodyBytes))) {
+      const maxRequestBodyBytes = resolveMaxRequestBodyBytes(options.maxRequestBodyBytes);
+      if (isDeclaredRequestBodyTooLarge(request, maxRequestBodyBytes)) {
         return finalize(
           createAskableMcpErrorResponse(413, -32004, 'MCP request body is too large.'),
           'payload_too_large',
         );
       }
 
+      requestBodySizeCheck = createRequestBodySizeCheck(request, maxRequestBodyBytes);
+
       const authorization = options.authorize ? await options.authorize(request) : undefined;
       if (authorization instanceof Response) {
+        await requestBodySizeCheck?.cancel();
         return finalize(authorization, authorization.status >= 400 ? 'unauthorized' : 'success');
       }
       if (authorization === false) {
+        await requestBodySizeCheck?.cancel();
         return finalize(
           createAskableMcpErrorResponse(401, -32001, 'Unauthorized MCP request.'),
           'unauthorized',
+        );
+      }
+
+      if (await requestBodySizeCheck?.exceedsLimit()) {
+        return finalize(
+          createAskableMcpErrorResponse(413, -32004, 'MCP request body is too large.'),
+          'payload_too_large',
         );
       }
 
@@ -567,6 +580,7 @@ export function createAskableMcpWebHandler(options: AskableMcpWebHandlerOptions)
         'success',
       );
     } catch (error) {
+      await requestBodySizeCheck?.cancel();
       options.onError?.(error, request);
       return finalize(
         createAskableMcpErrorResponse(500, -32000, 'Askable MCP handler failed.'),
@@ -920,7 +934,7 @@ function resolveMaxRequestBodyBytes(value: AskableMcpWebHandlerOptions['maxReque
   return defaultMaxRequestBodyBytes;
 }
 
-function isRequestBodyTooLarge(request: Request, maxRequestBodyBytes: number | false): boolean {
+function isDeclaredRequestBodyTooLarge(request: Request, maxRequestBodyBytes: number | false): boolean {
   if (maxRequestBodyBytes === false || !requestMayHaveBody(request)) return false;
 
   const contentLength = request.headers.get('Content-Length');
@@ -928,6 +942,73 @@ function isRequestBodyTooLarge(request: Request, maxRequestBodyBytes: number | f
 
   const bytes = Number(contentLength);
   return Number.isFinite(bytes) && bytes > maxRequestBodyBytes;
+}
+
+interface AskableMcpRequestBodySizeCheck {
+  exceedsLimit(): Promise<boolean>;
+  cancel(): Promise<void>;
+}
+
+function createRequestBodySizeCheck(
+  request: Request,
+  maxRequestBodyBytes: number | false,
+): AskableMcpRequestBodySizeCheck | undefined {
+  if (maxRequestBodyBytes === false || !requestMayHaveBody(request) || !request.body) return undefined;
+
+  const reader = request.clone().body?.getReader();
+  const requestBody = request.body;
+  if (!reader || !requestBody) return undefined;
+
+  let finished = false;
+  let cancellation: Promise<void> | undefined;
+  let bytes = 0;
+
+  const releaseReader = () => {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The reader may already be released by a runtime after cancellation.
+    }
+  };
+
+  const cancel = (): Promise<void> => {
+    if (cancellation) return cancellation;
+    if (finished) return Promise.resolve();
+    finished = true;
+
+    // A cloned Request tees the underlying stream. Start cancellation on both
+    // branches before awaiting either one so the source can actually stop.
+    const cloneCancellation = reader.cancel().catch(() => undefined);
+    const requestCancellation = requestBody.cancel().catch(() => undefined);
+    cancellation = Promise.all([cloneCancellation, requestCancellation]).then(() => {
+      releaseReader();
+    });
+    return cancellation;
+  };
+
+  const exceedsLimit = async (): Promise<boolean> => {
+    if (finished) return false;
+    try {
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          finished = true;
+          releaseReader();
+          return false;
+        }
+        bytes += chunk.value.byteLength;
+        if (bytes > maxRequestBodyBytes) {
+          await cancel();
+          return true;
+        }
+      }
+    } catch (error) {
+      await cancel();
+      throw error;
+    }
+  };
+
+  return { exceedsLimit, cancel };
 }
 
 function requestMayHaveBody(request: Request): boolean {

--- a/site/docs/api/mcp.md
+++ b/site/docs/api/mcp.md
@@ -133,10 +133,12 @@ When `cors` is configured, preflight requests are answered before auth or contex
 reads. Web responses also receive `Cache-Control: no-store` and
 `X-Content-Type-Options: nosniff` unless the response already set those headers.
 
-`maxRequestBodyBytes` rejects oversized MCP requests with a JSON-RPC `413`
-before authorization, server setup, or MCP body parsing runs. The default is
-1 MiB. Pass `false` to disable the built-in guard when another layer already
-enforces request limits.
+`maxRequestBodyBytes` rejects oversized MCP requests with a JSON-RPC `413`.
+An oversized declared `Content-Length` is rejected before authorization. The
+actual streamed bytes are also checked after authorization and before server
+setup or MCP body parsing, so missing or inaccurate length headers cannot bypass
+the limit. The default is 1 MiB. Pass `false` to disable the built-in guard when
+another layer already enforces request limits.
 
 `telemetry` receives sanitized request metadata such as method, path, status,
 outcome, duration, origin, user agent, and request ID. It does not include MCP


### PR DESCRIPTION
## Summary

- preserve the existing early `Content-Length` rejection for obviously oversized requests
- verify actual streamed request-body bytes before handing accepted requests to the MCP transport
- create the verification branch before authorization so `authorize()` can consume the original body and return `parsedBody`
- cancel both branches of the Fetch tee on overflow or authorization rejection so streaming uploads actually stop
- reject bodies with missing, invalid, or falsely small `Content-Length` values once they exceed the configured limit
- preserve `maxRequestBodyBytes: false`
- document declared-length versus streamed-byte validation ordering

Closes #371.

## Tests

- `npm run build`
- `npm test`
- `npm test -w @askable-ui/mcp -- --run src/__tests__/index.test.ts`

Full validation passed with 1,115 tests, including streamed cancellation, authorization body consumption, UTF-8 byte counting, missing/false content length, and exact-boundary acceptance.
