### PR TITLE
fix(adapters): isolate context creation options

### DIFF
--- a/packages/qwik/README.md
+++ b/packages/qwik/README.md
@@ -50,6 +50,10 @@ await agent.send('Explain this metric', (request) =>
 | `<Askable meta={...}>` | Annotate rendered UI with `data-askable` |
 | `asMeta<T>(focus)` | Read typed focus metadata |
 
+### Context sharing and isolation
+
+Default hooks share a context by `name + events + viewport`. An unnamed hook that supplies `maxHistory`, `sanitizeMeta`, `sanitizeText`, `sanitizeSource`, or `textExtractor` receives a private context so capture and privacy configuration cannot affect unrelated consumers. Supplying `name` explicitly opts into sharing for the same `events` + `viewport` configuration, and that configuration's first mounted consumer supplies its creation options.
+
 ## Links
 
 - [Documentation](https://askable-ui.com/docs/)

--- a/packages/qwik/src/__tests__/useAskable.test.ts
+++ b/packages/qwik/src/__tests__/useAskable.test.ts
@@ -1,9 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { createAskableContext } from '@askable-ui/core';
+import { useAskable } from '../useAskable.js';
 
-// Qwik hooks require a component context and jsdom environment.
-// These tests exercise the underlying AskableContext API directly
-// (the same API useAskable() wraps) to verify the integration contract.
+const { cleanups } = vi.hoisted(() => ({ cleanups: [] as Array<() => void> }));
+
+vi.mock('@builder.io/qwik', () => ({
+  useSignal: <T>(value: T) => ({ value }),
+  useVisibleTask$: (task: (args: { cleanup(callback: () => void): void }) => void) => {
+    task({ cleanup: (callback) => cleanups.push(callback) });
+  },
+}));
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()!();
+});
+
+// The Qwik primitives are mocked so adapter lifecycle and context-sharing
+// behavior can be exercised without a rendered Qwik component.
 
 describe('useAskable (Qwik) — contract tests', () => {
   it('createAskableContext() returns a valid context', () => {
@@ -47,5 +60,59 @@ describe('useAskable (Qwik) — contract tests', () => {
     const ctx = createAskableContext();
     expect(ctx.getFocus()).toBeNull();
     ctx.destroy();
+  });
+
+  it.each([false, true])(
+    'isolates an unnamed sanitizeSource context when sanitized hook starts first=%s',
+    (sanitizedFirst) => {
+      const first = sanitizedFirst
+        ? useAskable({ sanitizeSource: (source) => source })
+        : useAskable();
+      const second = sanitizedFirst
+        ? useAskable()
+        : useAskable({ sanitizeSource: (source) => source });
+
+      expect(first.ctx).not.toBe(second.ctx);
+    }
+  );
+
+  it.each([
+    ['maxHistory', { maxHistory: 0 }],
+    ['sanitizeMeta', { sanitizeMeta: (meta: Record<string, unknown>) => meta }],
+    ['sanitizeText', { sanitizeText: (text: string) => text }],
+    ['sanitizeSource', { sanitizeSource: (source: any) => source }],
+    ['textExtractor', { textExtractor: (element: Element) => element.textContent ?? '' }],
+  ] as const)('isolates unnamed %s configuration', (_label, privateOptions) => {
+    expect(useAskable().ctx).not.toBe(useAskable(privateOptions).ctx);
+  });
+
+  it.each([false, true])(
+    'retains explicit named sharing when sanitized hook starts first=%s',
+    (sanitizedFirst) => {
+      const first = sanitizedFirst
+        ? useAskable({ name: 'shared', sanitizeSource: (source) => source })
+        : useAskable({ name: 'shared' });
+      const second = sanitizedFirst
+        ? useAskable({ name: 'shared' })
+        : useAskable({ name: 'shared', sanitizeSource: (source) => source });
+
+      expect(first.ctx).toBe(second.ctx);
+    }
+  );
+
+  it('owns named contexts independently for different event configurations', () => {
+    const click = useAskable({ name: 'region', events: ['click'] });
+    const focus = useAskable({ name: 'region', events: ['focus'] });
+    expect(click.ctx).not.toBe(focus.ctx);
+
+    const focusDestroy = vi.spyOn(focus.ctx, 'destroy');
+    cleanups.shift()!();
+    expect(focusDestroy).not.toHaveBeenCalled();
+    cleanups.shift()!();
+    expect(focusDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates viewport-aware shared contexts', () => {
+    expect(useAskable().ctx).not.toBe(useAskable({ viewport: true }).ctx);
   });
 });

--- a/packages/qwik/src/useAskable.ts
+++ b/packages/qwik/src/useAskable.ts
@@ -22,7 +22,25 @@ const globalRefCount = new Map<string, number>();
 function sharedKey(options?: UseAskableOptions): string {
   const name = options?.name?.trim() ? `name:${options.name.trim()}` : 'global';
   const evts = (options?.events ?? DEFAULT_EVENTS).slice().sort().join('|');
-  return `${name}::${evts}`;
+  const viewport = options?.viewport ? 'viewport:on' : 'viewport:off';
+  return `${name}::${evts}::${viewport}`;
+}
+
+function requiresPrivateContext(options?: UseAskableOptions): boolean {
+  if (options?.name?.trim()) return false;
+  return Boolean(
+    options?.maxHistory !== undefined ||
+    options?.sanitizeMeta ||
+    options?.sanitizeText ||
+    options?.sanitizeSource ||
+    options?.textExtractor
+  );
+}
+
+function createAdapterContext(options?: UseAskableOptions): AskableContext {
+  if (!options?.name) return createAskableContext(options);
+  const { name: _name, ...contextOptions } = options;
+  return createAskableContext(contextOptions);
 }
 
 function retainCtx(key: string, options?: UseAskableOptions): AskableContext {
@@ -31,7 +49,7 @@ function retainCtx(key: string, options?: UseAskableOptions): AskableContext {
     globalRefCount.set(key, (globalRefCount.get(key) ?? 0) + 1);
     return existing;
   }
-  const ctx = createAskableContext(options);
+  const ctx = createAdapterContext(options);
   globalCtxByKey.set(key, ctx);
   globalRefCount.set(key, 1);
   ctx.observe(document, { events: options?.events ?? DEFAULT_EVENTS });
@@ -68,13 +86,21 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const focus = useSignal<AskableFocus | null>(null);
   const promptContext = useSignal<string>('');
   const usesProvidedCtx = Boolean(options?.ctx);
+  const usePrivateCtx = !usesProvidedCtx && requiresPrivateContext(options);
 
   let ctx: AskableContext | null = null;
   const key = sharedKey(options);
 
   // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(({ cleanup }) => {
-    ctx = usesProvidedCtx ? options!.ctx! : retainCtx(key, options);
+    ctx = usesProvidedCtx
+      ? options!.ctx!
+      : usePrivateCtx
+        ? createAdapterContext(options)
+        : retainCtx(key, options);
+    if (usePrivateCtx) {
+      ctx.observe(document, { events: options?.events ?? DEFAULT_EVENTS });
+    }
 
     const handleFocus = (f: AskableFocus) => {
       focus.value = f;
@@ -91,7 +117,10 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
     cleanup(() => {
       ctx!.off('focus', handleFocus);
       ctx!.off('clear', handleClear);
-      if (!usesProvidedCtx) releaseCtx(key);
+      if (!usesProvidedCtx) {
+        if (usePrivateCtx) ctx!.destroy();
+        else releaseCtx(key);
+      }
       ctx = null;
     });
   });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -175,6 +175,8 @@ const { focus: focusOnly } = useAskable({ events: ['focus'] });
 
 The hook manages a shared singleton context per `name + events + viewport` configuration. Multiple `useAskable()` consumers with the same shared configuration reuse one observer lifecycle, while differing configurations get isolated shared contexts of their own. Each shared context is automatically destroyed when its last consumer unmounts.
 
+Unnamed hooks that pass `maxHistory`, `sanitizeMeta`, `sanitizeText`, `sanitizeSource`, or `textExtractor` receive a private auto-created context so privacy and capture configuration cannot leak through the default shared context. Supplying `name` explicitly opts into sharing for the same `events` + `viewport` configuration, and that configuration's first mounted consumer supplies its creation options.
+
 If you need isolation, create your own context and pass it through `ctx`:
 
 ```tsx

--- a/packages/react/src/__tests__/useAskable.test.tsx
+++ b/packages/react/src/__tests__/useAskable.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { useEffect } from 'react';
+import { StrictMode, useEffect } from 'react';
 import { createAskableContext } from '@askable-ui/core';
-import type { AskableContext } from '@askable-ui/core';
+import type { AskableContext, AskableEvent } from '@askable-ui/core';
 import { Askable } from '../Askable';
 import { useAskable } from '../useAskable';
 
@@ -207,6 +207,176 @@ describe('useAskable', () => {
     first.unmount();
   });
 
+  it.each([false, true])(
+    'isolates an unnamed sanitizeSource context when sanitized consumer is mounted first=%s',
+    async (sanitizedFirst) => {
+      let defaultCtx: AskableContext | null = null;
+      let sanitizedCtx: AskableContext | null = null;
+
+      function DefaultConsumer() {
+        defaultCtx = useAskable().ctx;
+        return null;
+      }
+
+      function SanitizedConsumer() {
+        sanitizedCtx = useAskable({
+          sanitizeSource: (source) => ({ ...source, state: { redacted: true } }),
+        }).ctx;
+        return null;
+      }
+
+      const view = render(
+        sanitizedFirst ? (
+          <><SanitizedConsumer /><DefaultConsumer /></>
+        ) : (
+          <><DefaultConsumer /><SanitizedConsumer /></>
+        )
+      );
+
+      expect(defaultCtx).not.toBeNull();
+      expect(sanitizedCtx).not.toBeNull();
+      expect(sanitizedCtx).not.toBe(defaultCtx);
+
+      sanitizedCtx!.registerSource('account', {
+        getState: () => ({ token: 'secret' }),
+      });
+      defaultCtx!.registerSource('account', {
+        getState: () => ({ token: 'secret' }),
+      });
+
+      expect((await sanitizedCtx!.resolveSource('account')).state).toEqual({ redacted: true });
+      expect((await defaultCtx!.resolveSource('account')).state).toEqual({ token: 'secret' });
+
+      view.unmount();
+    }
+  );
+
+  it.each([
+    ['maxHistory', { maxHistory: 0 }],
+    ['sanitizeMeta', { sanitizeMeta: (meta: Record<string, unknown>) => meta }],
+    ['sanitizeText', { sanitizeText: (text: string) => text }],
+    ['sanitizeSource', { sanitizeSource: (source: any) => source }],
+    ['textExtractor', { textExtractor: (element: Element) => element.textContent ?? '' }],
+  ] as const)('isolates unnamed %s configuration', (_label, privateOptions) => {
+    let defaultCtx: AskableContext | null = null;
+    let configuredCtx: AskableContext | null = null;
+
+    function DefaultConsumer() {
+      defaultCtx = useAskable().ctx;
+      return null;
+    }
+    function ConfiguredConsumer() {
+      configuredCtx = useAskable(privateOptions).ctx;
+      return null;
+    }
+
+    const view = render(<><DefaultConsumer /><ConfiguredConsumer /></>);
+    expect(configuredCtx).not.toBe(defaultCtx);
+    view.unmount();
+  });
+
+  it('keeps a private context alive through Strict Mode replay and event changes', async () => {
+    let capturedCtx: AskableContext | null = null;
+
+    function PrivateConsumer({ events }: { events: AskableEvent[] }) {
+      const { ctx } = useAskable({ events, sanitizeSource: (source) => source });
+      if (!ctx.hasSource('strict-source')) {
+        ctx.registerSource('strict-source', { getState: () => ({ alive: true }) });
+      }
+      capturedCtx = ctx;
+      return null;
+    }
+
+    const view = render(<StrictMode><PrivateConsumer events={['click']} /></StrictMode>);
+    await flushMicrotasks();
+    expect((await capturedCtx!.resolveSource('strict-source')).state).toEqual({ alive: true });
+
+    const destroySpy = vi.spyOn(capturedCtx!, 'destroy');
+    view.rerender(<StrictMode><PrivateConsumer events={['focus']} /></StrictMode>);
+    await flushMicrotasks();
+
+    expect(destroySpy).not.toHaveBeenCalled();
+    expect((await capturedCtx!.resolveSource('strict-source')).state).toEqual({ alive: true });
+
+    view.unmount();
+    await flushMicrotasks();
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a shared context alive and cached through Strict Mode replay', async () => {
+    const contexts: Record<string, AskableContext> = {};
+
+    function SharedConsumer({ slot }: { slot: string }) {
+      const { ctx } = useAskable({ name: 'strict-shared' });
+      if (!ctx.hasSource('strict-shared-source')) {
+        ctx.registerSource('strict-shared-source', { getState: () => ({ alive: true }) });
+      }
+      contexts[slot] = ctx;
+      return null;
+    }
+
+    const strictView = render(
+      <StrictMode><SharedConsumer slot="strict" /></StrictMode>
+    );
+    await flushMicrotasks();
+    expect((await contexts.strict.resolveSource('strict-shared-source')).state).toEqual({ alive: true });
+
+    const secondView = render(<SharedConsumer slot="second" />);
+    await flushMicrotasks();
+    expect(contexts.second).toBe(contexts.strict);
+
+    const destroySpy = vi.spyOn(contexts.strict, 'destroy');
+    strictView.unmount();
+    await flushMicrotasks();
+    expect(destroySpy).not.toHaveBeenCalled();
+
+    secondView.unmount();
+    await flushMicrotasks();
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys every retired private context during same-turn mode changes', async () => {
+    let capturedCtx: AskableContext | null = null;
+
+    function DynamicConsumer({ privateMode }: { privateMode: boolean }) {
+      capturedCtx = useAskable(privateMode
+        ? { sanitizeSource: (source) => source }
+        : undefined).ctx;
+      return null;
+    }
+
+    const view = render(<DynamicConsumer privateMode />);
+    const retiredCtx = capturedCtx!;
+    const retiredDestroy = vi.spyOn(retiredCtx, 'destroy');
+
+    view.rerender(<DynamicConsumer privateMode={false} />);
+    view.rerender(<DynamicConsumer privateMode />);
+    expect(capturedCtx).not.toBe(retiredCtx);
+
+    await flushMicrotasks();
+    expect(retiredDestroy).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    await flushMicrotasks();
+  });
+
+  it('retains explicit named sharing when sanitizeSource is configured', () => {
+    const seen: AskableContext[] = [];
+
+    function NamedConsumer({ sanitized }: { sanitized?: boolean }) {
+      seen.push(useAskable({
+        name: 'shared-sanitizer',
+        ...(sanitized ? { sanitizeSource: (source) => source } : {}),
+      }).ctx);
+      return null;
+    }
+
+    const view = render(<><NamedConsumer sanitized /><NamedConsumer /></>);
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBe(seen[1]);
+    view.unmount();
+  });
+
   it('keeps different named shared contexts isolated', async () => {
     const seen: AskableContext[] = [];
 
@@ -230,6 +400,29 @@ describe('useAskable', () => {
     expect(seen[0]).not.toBe(seen[1]);
 
     view.unmount();
+  });
+
+  it('owns named contexts independently for different event configurations', async () => {
+    let clickCtx: AskableContext | null = null;
+    let focusCtx: AskableContext | null = null;
+
+    function NamedConsumer({ events }: { events: AskableEvent[] }) {
+      const { ctx } = useAskable({ name: 'region', events });
+      if (events[0] === 'click') clickCtx = ctx;
+      else focusCtx = ctx;
+      return null;
+    }
+
+    const clickView = render(<NamedConsumer events={['click']} />);
+    const focusView = render(<NamedConsumer events={['focus']} />);
+    expect(clickCtx).not.toBe(focusCtx);
+
+    const focusDestroy = vi.spyOn(focusCtx!, 'destroy');
+    clickView.unmount();
+    expect(focusDestroy).not.toHaveBeenCalled();
+    focusView.unmount();
+    await flushMicrotasks();
+    expect(focusDestroy).toHaveBeenCalledTimes(1);
   });
 
   it('observes the shared global context only once for multiple consumers with the same events', async () => {

--- a/packages/react/src/useAskable.ts
+++ b/packages/react/src/useAskable.ts
@@ -5,6 +5,7 @@ import type { AskableContextOptions, AskableEvent, AskableFocus, AskableContext,
 const DEFAULT_EVENTS: AskableEvent[] = ['click', 'hover', 'focus'];
 const globalCtxByEvents = new Map<string, AskableContext>();
 const globalRefCountByEvents = new Map<string, number>();
+const pendingGlobalReleaseByEvents = new Map<string, symbol>();
 
 function normalizeEvents(events?: AskableEvent[]): AskableEvent[] {
   const configured = events ?? DEFAULT_EVENTS;
@@ -21,22 +22,42 @@ function getSharedKey(name?: string, events?: AskableEvent[], viewport?: boolean
   return `${scope}::${getEventsKey(events)}::${viewportKey}`;
 }
 
+function requiresPrivateContext(options?: UseAskableOptions): boolean {
+  if (options?.name?.trim()) return false;
+  return Boolean(
+    options?.maxHistory !== undefined ||
+    options?.sanitizeMeta ||
+    options?.sanitizeText ||
+    options?.sanitizeSource ||
+    options?.textExtractor
+  );
+}
+
+// Adapter caches own named-context lifetime. Strip the core-level name so one
+// adapter/key cannot destroy a context retained under another adapter/key.
+function createAdapterContext(options?: UseAskableOptions): AskableContext {
+  if (!options?.name) return createAskableContext(options);
+  const { name: _name, ...contextOptions } = options;
+  return createAskableContext(contextOptions);
+}
+
 function getGlobalCtx(options?: UseAskableOptions): AskableContext {
   // During SSR (no window), never persist to the module-level singleton —
   // each render gets a fresh throwaway context so requests don't share state.
   if (typeof window === 'undefined') {
-    return createAskableContext(options);
+    return createAdapterContext(options);
   }
   const key = getSharedKey(options?.name, options?.events, options?.viewport);
   const existing = globalCtxByEvents.get(key);
   if (existing) return existing;
-  const ctx = createAskableContext(options);
+  const ctx = createAdapterContext(options);
   globalCtxByEvents.set(key, ctx);
   return ctx;
 }
 
 function retainGlobalCtx(ctx: AskableContext, name?: string, events?: AskableEvent[], viewport?: boolean): void {
   const key = getSharedKey(name, events, viewport);
+  pendingGlobalReleaseByEvents.delete(key);
   const nextCount = (globalRefCountByEvents.get(key) ?? 0) + 1;
   globalRefCountByEvents.set(key, nextCount);
   if (nextCount === 1 && typeof document !== 'undefined') {
@@ -53,9 +74,21 @@ function releaseGlobalCtx(name?: string, events?: AskableEvent[], viewport?: boo
     globalRefCountByEvents.set(key, nextCount);
     return;
   }
-  globalRefCountByEvents.delete(key);
-  globalCtxByEvents.delete(key);
-  ctx.destroy();
+  globalRefCountByEvents.set(key, 0);
+  ctx.unobserve();
+
+  const releaseToken = Symbol('askable-shared-context-release');
+  pendingGlobalReleaseByEvents.set(key, releaseToken);
+  queueMicrotask(() => {
+    if (pendingGlobalReleaseByEvents.get(key) !== releaseToken) return;
+    if ((globalRefCountByEvents.get(key) ?? 0) > 0) return;
+    if (globalCtxByEvents.get(key) !== ctx) return;
+
+    pendingGlobalReleaseByEvents.delete(key);
+    globalRefCountByEvents.delete(key);
+    globalCtxByEvents.delete(key);
+    ctx.destroy();
+  });
 }
 
 export interface UseAskableOptions extends AskableContextOptions {
@@ -76,20 +109,10 @@ export interface UseAskableResult {
   ctx: AskableContext;
 }
 
-function hasContextCreationOptions(options?: UseAskableOptions): boolean {
-  return Boolean(
-    options?.maxHistory !== undefined ||
-    options?.sanitizeMeta ||
-    options?.sanitizeText ||
-    options?.textExtractor
-  );
-}
-
 export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const usesProvidedCtx = Boolean(options?.ctx);
-  const usesNamedSharedCtx = !usesProvidedCtx && Boolean(options?.name?.trim());
   // Use a private context when context-creation options are specified without a shared name
-  const usePrivateCtx = !usesProvidedCtx && !usesNamedSharedCtx && hasContextCreationOptions(options);
+  const usePrivateCtx = !usesProvidedCtx && requiresPrivateContext(options);
 
   const sharedKey = getSharedKey(options?.name, options?.events, options?.viewport);
   const privateCtxRef = useRef<AskableContext | null>(null);
@@ -100,13 +123,14 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
   }, [options?.ctx, usePrivateCtx, sharedKey]);
 
   if (!options?.ctx && usePrivateCtx && !privateCtxRef.current) {
-    privateCtxRef.current = createAskableContext(options);
+    privateCtxRef.current = createAdapterContext(options);
   }
   if (!usePrivateCtx && !options?.ctx) {
     privateCtxRef.current = null;
   }
 
   const ctx = options?.ctx ?? privateCtxRef.current ?? sharedCtx!;
+  const privateLifecycleTokensRef = useRef(new WeakMap<AskableContext, symbol>());
   const [focus, setFocus] = useState<AskableFocus | null>(() => ctx.getFocus());
 
   const inspectorKey = JSON.stringify(options?.inspector ?? false);
@@ -145,16 +169,31 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
       current.off('clear', clearHandler);
       if (!usesProvidedCtx) {
         if (usePrivateCtx) {
-          current.destroy();
-          if (privateCtxRef.current === current) {
-            privateCtxRef.current = null;
-          }
+          current.unobserve();
         } else {
           releaseGlobalCtx(options?.name, options?.events, options?.viewport);
         }
       }
     };
   }, [ctx, sharedKey, usesProvidedCtx, usePrivateCtx, inspectorKey]);
+
+  // Strict Mode replays effects in development. A deferred, token-guarded
+  // teardown lets the replay claim the context before the microtask runs.
+  useEffect(() => {
+    if (!usePrivateCtx) return;
+    const current = ctx;
+    const token = Symbol('askable-private-context');
+    privateLifecycleTokensRef.current.set(current, token);
+
+    return () => {
+      queueMicrotask(() => {
+        if (privateLifecycleTokensRef.current.get(current) !== token) return;
+        current.destroy();
+        privateLifecycleTokensRef.current.delete(current);
+        if (privateCtxRef.current === current) privateCtxRef.current = null;
+      });
+    };
+  }, [ctx, usePrivateCtx]);
 
   return {
     focus,

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -82,6 +82,10 @@ fetch('/api/chat', {
 | `<Askable meta={...}>` | Wrapper component that sets `data-askable` |
 | `asMeta<T>(focus)` | Cast `focus.meta` to your typed schema |
 
+### Context sharing and isolation
+
+Default hooks share a context by `name + events + viewport`. An unnamed hook that supplies `maxHistory`, `sanitizeMeta`, `sanitizeText`, `sanitizeSource`, or `textExtractor` receives a private context so capture and privacy configuration cannot affect unrelated consumers. Supplying `name` explicitly opts into sharing for the same `events` + `viewport` configuration, and that configuration's first mounted consumer supplies its creation options.
+
 ## Links
 
 - [askable-ui.com](https://askable-ui.com) — docs and demos

--- a/packages/solid/src/__tests__/useAskable.test.tsx
+++ b/packages/solid/src/__tests__/useAskable.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@solidjs/testing-library';
 import { createAskableContext } from '@askable-ui/core';
 import { createSignal, type Component } from 'solid-js';
@@ -53,5 +53,75 @@ describe('useAskable (SolidJS)', () => {
     expect(getByTestId('focus-meta').textContent).toBe('null');
     unmount();
     ctx.destroy();
+  });
+
+  it.each([false, true])(
+    'isolates an unnamed sanitizeSource context when sanitized consumer is mounted first=%s',
+    (sanitizedFirst) => {
+      const contexts: Record<string, ReturnType<typeof createAskableContext>> = {};
+
+      const DefaultConsumer: Component = () => {
+        contexts.default = useAskable().ctx;
+        return null;
+      };
+      const SanitizedConsumer: Component = () => {
+        contexts.sanitized = useAskable({ sanitizeSource: (source) => source }).ctx;
+        return null;
+      };
+
+      const view = render(() => sanitizedFirst
+        ? <><SanitizedConsumer /><DefaultConsumer /></>
+        : <><DefaultConsumer /><SanitizedConsumer /></>);
+
+      expect(contexts.sanitized).toBeDefined();
+      expect(contexts.default).toBeDefined();
+      expect(contexts.sanitized).not.toBe(contexts.default);
+      view.unmount();
+    }
+  );
+
+  it.each([
+    ['maxHistory', { maxHistory: 0 }],
+    ['sanitizeMeta', { sanitizeMeta: (meta: Record<string, unknown>) => meta }],
+    ['sanitizeText', { sanitizeText: (text: string) => text }],
+    ['sanitizeSource', { sanitizeSource: (source: any) => source }],
+    ['textExtractor', { textExtractor: (element: Element) => element.textContent ?? '' }],
+  ] as const)('isolates unnamed %s configuration', (_label, privateOptions) => {
+    const contexts: Record<string, ReturnType<typeof createAskableContext>> = {};
+    const DefaultConsumer: Component = () => {
+      contexts.default = useAskable().ctx;
+      return null;
+    };
+    const ConfiguredConsumer: Component = () => {
+      contexts.configured = useAskable(privateOptions).ctx;
+      return null;
+    };
+
+    const view = render(() => <><DefaultConsumer /><ConfiguredConsumer /></>);
+    expect(contexts.configured).not.toBe(contexts.default);
+    view.unmount();
+  });
+
+  it('owns named contexts independently for different event configurations', () => {
+    let clickCtx: ReturnType<typeof createAskableContext>;
+    let focusCtx: ReturnType<typeof createAskableContext>;
+    const ClickConsumer: Component = () => {
+      clickCtx = useAskable({ name: 'region', events: ['click'] }).ctx;
+      return null;
+    };
+    const FocusConsumer: Component = () => {
+      focusCtx = useAskable({ name: 'region', events: ['focus'] }).ctx;
+      return null;
+    };
+
+    const clickView = render(() => <ClickConsumer />);
+    const focusView = render(() => <FocusConsumer />);
+    expect(clickCtx!).not.toBe(focusCtx!);
+
+    const focusDestroy = vi.spyOn(focusCtx!, 'destroy');
+    clickView.unmount();
+    expect(focusDestroy).not.toHaveBeenCalled();
+    focusView.unmount();
+    expect(focusDestroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/solid/src/useAskable.ts
+++ b/packages/solid/src/useAskable.ts
@@ -17,14 +17,31 @@ function getSharedKey(name?: string, events?: AskableEvent[], viewport?: boolean
   return `${scope}::${normalizeEvents(events).join('|')}::${viewportKey}`;
 }
 
+function requiresPrivateContext(options?: UseAskableOptions): boolean {
+  if (options?.name?.trim()) return false;
+  return Boolean(
+    options?.maxHistory !== undefined ||
+    options?.sanitizeMeta ||
+    options?.sanitizeText ||
+    options?.sanitizeSource ||
+    options?.textExtractor
+  );
+}
+
+function createAdapterContext(options?: UseAskableOptions): AskableContext {
+  if (!options?.name) return createAskableContext(options);
+  const { name: _name, ...contextOptions } = options;
+  return createAskableContext(contextOptions);
+}
+
 function retainGlobalCtx(key: string, options?: UseAskableOptions): AskableContext {
-  if (typeof window === 'undefined') return createAskableContext(options);
+  if (typeof window === 'undefined') return createAdapterContext(options);
   const existing = globalCtxByKey.get(key);
   if (existing) {
     globalRefCountByKey.set(key, (globalRefCountByKey.get(key) ?? 0) + 1);
     return existing;
   }
-  const ctx = createAskableContext(options);
+  const ctx = createAdapterContext(options);
   globalCtxByKey.set(key, ctx);
   globalRefCountByKey.set(key, 1);
   if (typeof document !== 'undefined') {
@@ -56,9 +73,15 @@ export interface UseAskableResult {
 
 export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const usesProvidedCtx = Boolean(options?.ctx);
+  const usePrivateCtx = !usesProvidedCtx && requiresPrivateContext(options);
   const sharedKey = getSharedKey(options?.name, options?.events, options?.viewport);
 
-  const ctx = options?.ctx ?? retainGlobalCtx(sharedKey, options);
+  const ctx = options?.ctx ?? (usePrivateCtx
+    ? createAdapterContext(options)
+    : retainGlobalCtx(sharedKey, options));
+  if (usePrivateCtx && typeof document !== 'undefined') {
+    ctx.observe(document, { events: normalizeEvents(options?.events) });
+  }
   const [focus, setFocus] = createSignal<AskableFocus | null>(ctx.getFocus());
 
   createEffect(() => {
@@ -72,7 +95,8 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
       ctx.off('focus', handleFocus);
       ctx.off('clear', handleClear);
       if (!usesProvidedCtx) {
-        releaseGlobalCtx(sharedKey);
+        if (usePrivateCtx) ctx.destroy();
+        else releaseGlobalCtx(sharedKey);
       }
     });
   });

--- a/packages/vue/src/__tests__/useAskable.test.ts
+++ b/packages/vue/src/__tests__/useAskable.test.ts
@@ -165,6 +165,69 @@ describe('useAskable (Vue)', () => {
     wrapperA.unmount();
   });
 
+  it.each([false, true])(
+    'isolates an unnamed sanitizeSource context when sanitized consumer is mounted first=%s',
+    async (sanitizedFirst) => {
+      const contexts: Record<string, unknown> = {};
+
+      const DefaultConsumer = defineComponent({
+        setup() {
+          contexts.default = useAskable().ctx;
+          return {};
+        },
+        template: `<span />`,
+      });
+      const SanitizedConsumer = defineComponent({
+        setup() {
+          contexts.sanitized = useAskable({ sanitizeSource: (source) => source }).ctx;
+          return {};
+        },
+        template: `<span />`,
+      });
+
+      const components = sanitizedFirst
+        ? { First: SanitizedConsumer, Second: DefaultConsumer }
+        : { First: DefaultConsumer, Second: SanitizedConsumer };
+      const wrapper = track(mount(defineComponent({
+        components,
+        template: `<div><First /><Second /></div>`,
+      }), { attachTo: document.body }));
+      await flushAll();
+
+      expect(contexts.sanitized).toBeDefined();
+      expect(contexts.default).toBeDefined();
+      expect(contexts.sanitized).not.toBe(contexts.default);
+      wrapper.unmount();
+    }
+  );
+
+  it.each([
+    ['maxHistory', { maxHistory: 0 }],
+    ['sanitizeMeta', { sanitizeMeta: (meta: Record<string, unknown>) => meta }],
+    ['sanitizeText', { sanitizeText: (text: string) => text }],
+    ['sanitizeSource', { sanitizeSource: (source: any) => source }],
+    ['textExtractor', { textExtractor: (element: Element) => element.textContent ?? '' }],
+  ] as const)('isolates unnamed %s configuration', async (_label, privateOptions) => {
+    const contexts: Record<string, unknown> = {};
+    const DefaultConsumer = defineComponent({
+      setup() { contexts.default = useAskable().ctx; return {}; },
+      template: `<span />`,
+    });
+    const ConfiguredConsumer = defineComponent({
+      setup() { contexts.configured = useAskable(privateOptions).ctx; return {}; },
+      template: `<span />`,
+    });
+
+    const wrapper = track(mount(defineComponent({
+      components: { DefaultConsumer, ConfiguredConsumer },
+      template: `<div><DefaultConsumer /><ConfiguredConsumer /></div>`,
+    }), { attachTo: document.body }));
+    await flushAll();
+
+    expect(contexts.configured).not.toBe(contexts.default);
+    wrapper.unmount();
+  });
+
   it('observes the shared global context only once for multiple consumers with the same events', async () => {
     let capturedCtx: ReturnType<typeof import('@askable-ui/core').createAskableContext> | null = null;
 
@@ -192,7 +255,7 @@ describe('useAskable (Vue)', () => {
     wrapperA.unmount();
   });
 
-  it('isolates differing shared event configurations and preserves the remaining config on unmount', async () => {
+  it('isolates named contexts with different events and preserves the remaining context on unmount', async () => {
     const EventConsumer = defineComponent({
       name: 'EventConsumer',
       props: {
@@ -200,7 +263,7 @@ describe('useAskable (Vue)', () => {
         events: { type: Array as () => ('click' | 'focus')[], required: true },
       },
       setup(props) {
-        const { focus } = useAskable({ events: props.events });
+        const { focus } = useAskable({ name: 'region', events: props.events });
         return { focus };
       },
       template: `<span :data-testid="'event-' + label">{{ focus ? JSON.stringify(focus.meta) : 'null' }}</span>`,

--- a/packages/vue/src/useAskable.ts
+++ b/packages/vue/src/useAskable.ts
@@ -21,16 +21,33 @@ function getSharedKey(name?: string, events?: AskableEvent[], viewport?: boolean
   return `${scope}::${getEventsKey(events)}::${viewportKey}`;
 }
 
+function requiresPrivateContext(options?: UseAskableOptions): boolean {
+  if (options?.name?.trim()) return false;
+  return Boolean(
+    options?.maxHistory !== undefined ||
+    options?.sanitizeMeta ||
+    options?.sanitizeText ||
+    options?.sanitizeSource ||
+    options?.textExtractor
+  );
+}
+
+function createAdapterContext(options?: UseAskableOptions): AskableContext {
+  if (!options?.name) return createAskableContext(options);
+  const { name: _name, ...contextOptions } = options;
+  return createAskableContext(contextOptions);
+}
+
 function getGlobalCtx(options?: UseAskableOptions): AskableContext {
   // During SSR (no window), never persist to the module-level singleton —
   // each render gets a fresh throwaway context so requests don't share state.
   if (typeof window === 'undefined') {
-    return createAskableContext(options);
+    return createAdapterContext(options);
   }
   const key = getSharedKey(options?.name, options?.events, options?.viewport);
   const existing = globalCtxByEvents.get(key);
   if (existing) return existing;
-  const ctx = createAskableContext(options);
+  const ctx = createAdapterContext(options);
   globalCtxByEvents.set(key, ctx);
   return ctx;
 }
@@ -76,22 +93,12 @@ export interface UseAskableResult {
   ctx: AskableContext;
 }
 
-function hasContextCreationOptions(options?: UseAskableOptions): boolean {
-  return Boolean(
-    options?.maxHistory !== undefined ||
-    options?.sanitizeMeta ||
-    options?.sanitizeText ||
-    options?.textExtractor
-  );
-}
-
 export function useAskable(options?: UseAskableOptions) {
   const usesProvidedCtx = Boolean(options?.ctx);
-  const usesNamedSharedCtx = !usesProvidedCtx && Boolean(options?.name?.trim());
   // Use a private context when context-creation options are specified without a shared name
-  const usePrivateCtx = !usesProvidedCtx && !usesNamedSharedCtx && hasContextCreationOptions(options);
+  const usePrivateCtx = !usesProvidedCtx && requiresPrivateContext(options);
 
-  const ctx = options?.ctx ?? (usePrivateCtx ? createAskableContext(options) : getGlobalCtx(options));
+  const ctx = options?.ctx ?? (usePrivateCtx ? createAdapterContext(options) : getGlobalCtx(options));
   const focus = ref<AskableFocus | null>(ctx.getFocus());
   // Reference focus.value so Vue tracks it as a reactive dependency;
   // ctx.toPromptContext() is a plain method and not itself reactive.

--- a/site/docs/api/react.md
+++ b/site/docs/api/react.md
@@ -343,13 +343,16 @@ On touch-like devices, Askable maps `hover` to tap/click by default. That means 
 
 ### Shared vs custom contexts
 
-`useAskable()` has three common modes in React:
+`useAskable()` has four common modes in React:
 
 - **Default shared context** — `useAskable()` with no `ctx` or `name` reuses one shared document observer for the same `events` + `viewport` configuration.
 - **Named shared context** — `useAskable({ name: 'chart' })` reuses a separate shared context for one UI region or surface.
+- **Private auto-created context** — passing `maxHistory`, `sanitizeMeta`, `sanitizeText`, `sanitizeSource`, or `textExtractor` without `name` or `ctx` creates an isolated context for that hook instance.
 - **Custom context** — `useAskable({ ctx })` attaches to an explicitly created `AskableContext` that you observe/configure yourself.
 
 Use a shared context when multiple components on the same page should agree on the same focus/history. Provide a custom `ctx` when you need isolation, a custom root element, or different lifecycle control.
+
+Supplying `name` explicitly opts into sharing for the same `events` + `viewport` configuration. Context-creation options are taken from that configuration's first mounted consumer, so matching consumers should use the same sanitizers and history configuration.
 
 ```tsx
 function SharedChatInput() {

--- a/site/docs/api/vue.md
+++ b/site/docs/api/vue.md
@@ -113,10 +113,12 @@ Vue mirrors the React adapter's context model:
 
 - **Default shared context** — `useAskable()` reuses one shared document observer for the same `events` + `viewport` configuration.
 - **Named shared context** — `useAskable({ name: 'chart' })` reuses a separate shared context for one region or AI surface.
-- **Private auto-created context** — passing context-creation options like `maxHistory`, `sanitizeMeta`, `sanitizeText`, or `textExtractor` without `name` or `ctx` creates a private context for that composable instance.
+- **Private auto-created context** — passing context-creation options like `maxHistory`, `sanitizeMeta`, `sanitizeText`, `sanitizeSource`, or `textExtractor` without `name` or `ctx` creates a private context for that composable instance.
 - **Custom provided context** — `useAskable({ ctx })` attaches to an explicitly created `AskableContext` that you observe/configure yourself.
 
 Use the shared mode when multiple Vue components should agree on the same focus/history. Use a private or provided context when one panel needs isolation or a custom root.
+
+Supplying `name` explicitly opts into sharing for the same `events` + `viewport` configuration. Context-creation options are taken from that configuration's first mounted consumer, so matching consumers should use the same sanitizers and history configuration.
 
 ```ts
 // Shared chart/chat pair


### PR DESCRIPTION
## Summary

- isolate unnamed adapter contexts whenever `maxHistory`, `sanitizeMeta`, `sanitizeText`, `sanitizeSource`, or `textExtractor` is configured
- preserve explicit named sharing while making each framework adapter authoritative for its `name + events + viewport` cache and teardown lifecycle
- include viewport mode in Qwik shared-context identity
- make React private-context teardown safe under Strict Mode effect replay and event/inspector reconfiguration
- document private auto-created contexts and first-mounted creation options for explicitly named contexts
- add sanitizer mount-order, all-option parity, named teardown, Strict Mode, and Qwik viewport regression coverage

Closes #374.

## Validation

- `npm audit --omit=dev --audit-level=high`
- `npm run build`
- `npm test` — 1,153 tests passed
- `npm --prefix site/docs run build`
