### PR TITLE
fix(qwik): defer context access until visible lifecycle

### DIFF
--- a/packages/qwik/README.md
+++ b/packages/qwik/README.md
@@ -54,6 +54,44 @@ await agent.send('Explain this metric', (request) =>
 
 Default hooks share a context by `name + events + viewport`. An unnamed hook that supplies `maxHistory`, `sanitizeMeta`, `sanitizeText`, `sanitizeSource`, or `textExtractor` receives a private context so capture and privacy configuration cannot affect unrelated consumers. Supplying `name` explicitly opts into sharing for the same `events` + `viewport` configuration, and that configuration's first mounted consumer supplies its creation options.
 
+### Context lifecycle
+
+Qwik initializes the DOM-backed context in a visible task. `ctxRef` is the stable
+signal for lifecycle-aware integrations; its value is `undefined` during SSR and
+is populated after the component mounts. Read `ctx` only from browser actions or
+visible tasks—do not destructure it during component render:
+
+```tsx
+const askable = useAskable();
+
+// Safe in an event handler after the component is visible.
+const readPrompt = () => askable.ctx.toPromptContext();
+
+// For reactive lifecycle code:
+const ctx = askable.ctxRef.value;
+```
+
+`useAskableStream`, `useAskableChat`, `useAskableHistory`,
+`useAskableSource`, and `useAskableAgent` resolve this signal at call/task time,
+so they do not capture the pre-mount context value.
+
+For SSR-to-browser resume, use a QRL factory to create a hook-owned context or
+reconstruct a custom source in the browser:
+
+```tsx
+import { $ } from '@builder.io/qwik';
+import { createAskableContext } from '@askable-ui/core';
+
+const askable = useAskable({ ctx$: $(() => createAskableContext()) });
+const source = useAskableSource('stats', $(() => ({
+  resolve: () => ({ count: 2 }),
+})));
+```
+
+The hook observes and destroys contexts created by `ctx$`. Passing `ctx` or a
+source object directly remains supported for client-only mounts; runtime objects
+wrapped with `noSerialize` are intentionally unavailable after SSR resume.
+
 ## Links
 
 - [Documentation](https://askable-ui.com/docs/)

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "vitest run"
+    "test": "vitest run && vitest run --config vitest.lifecycle.config.ts"
   },
   "keywords": [
     "ai",

--- a/packages/qwik/src/__tests__/lifecycle.test.tsx
+++ b/packages/qwik/src/__tests__/lifecycle.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { $, component$, noSerialize } from '@builder.io/qwik';
+import { createDOM } from '@builder.io/qwik/testing';
+import { createAskableContext } from '@askable-ui/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAskableAgent, type UseAskableAgentResult } from '../useAskableAgent.js';
+import { useAskableChat, type UseAskableChatResult } from '../useAskableChat.js';
+import { useAskableHistory, type UseAskableHistoryResult } from '../useAskableHistory.js';
+import { useAskableSource, type UseAskableSourceResult } from '../useAskableSource.js';
+import { useAskableStream, type UseAskableStreamResult } from '../useAskableStream.js';
+
+async function waitForMountedContext(result: { ctx: unknown }, expected: unknown): Promise<void> {
+  await vi.waitFor(() => expect(result.ctx).toBe(expected));
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('Qwik hook lifecycle', () => {
+  it('initializes a private configured context before stream actions run', async () => {
+    const holder: { stream?: UseAskableStreamResult } = {};
+    const Consumer = component$(() => {
+      holder.stream = useAskableStream({ maxHistory: 1 });
+      return <div>ready</div>;
+    });
+
+    const { render, screen } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+
+    expect(holder.stream).toBeDefined();
+    await vi.waitFor(() => expect(holder.stream!.ctx).toBeDefined());
+    await expect(holder.stream!.stream('question', async (_request, emit) => {
+      emit('answer');
+    })).resolves.toBe('answer');
+  });
+
+  it('resolves the mounted context when stream and chat actions run', async () => {
+    const provided = noSerialize(createAskableContext());
+    const holder: {
+      stream?: UseAskableStreamResult;
+      chat?: UseAskableChatResult;
+    } = {};
+    const Consumer = component$(() => {
+      holder.stream = useAskableStream({ ctx: provided });
+      holder.chat = useAskableChat({ ctx: provided });
+      return <div>ready</div>;
+    });
+
+    const { render } = await createDOM();
+    await render(<Consumer />);
+
+    expect(holder.stream).toBeDefined();
+    expect(holder.chat).toBeDefined();
+    await waitForMountedContext(holder.stream!, provided);
+    await waitForMountedContext(holder.chat!, provided);
+
+    await expect(holder.stream!.stream('stream question', async (_request, emit) => {
+      emit('answer');
+    })).resolves.toBe('answer');
+
+    await holder.chat!.append('chat question', async (_request, _messages, emit) => {
+      emit('reply');
+    });
+    expect(holder.chat!.messages.value.at(-1)?.content).toBe('reply');
+  });
+
+  it('registers source and history hooks against the mounted context', async () => {
+    const provided = noSerialize(createAskableContext());
+    const holder: {
+      history?: UseAskableHistoryResult;
+      source?: UseAskableSourceResult;
+    } = {};
+    const Consumer = component$(() => {
+      holder.history = useAskableHistory({ ctx: provided });
+      holder.source = useAskableSource(
+        'orders',
+        $(() => ({ resolve: () => ({ count: 2 }) })),
+        { ctx: provided },
+      );
+      return <div>ready</div>;
+    });
+
+    const { render } = await createDOM();
+    await render(<Consumer />);
+
+    expect(holder.history).toBeDefined();
+    expect(holder.source).toBeDefined();
+    await waitForMountedContext(holder.history!, provided);
+    await waitForMountedContext(holder.source!, provided);
+    await vi.waitFor(() => expect(provided.hasSource('orders')).toBe(true));
+
+    provided.push({ panel: 'orders' }, 'Orders');
+    await vi.waitFor(() => expect(holder.history!.current.value?.meta.panel).toBe('orders'));
+    await expect(holder.source!.resolve()).resolves.toMatchObject({ data: { count: 2 } });
+  });
+
+  it('creates an externally owned context from a resume-safe QRL factory', async () => {
+    const holder: { stream?: UseAskableStreamResult } = {};
+    const contextFactory = $(() => createAskableContext());
+    const Consumer = component$(() => {
+      holder.stream = useAskableStream({ ctx$: contextFactory });
+      return <div>ready</div>;
+    });
+
+    const { render, screen } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+
+    expect(holder.stream).toBeDefined();
+    await vi.waitFor(() => expect(holder.stream!.ctx).toBeDefined());
+    await expect(
+      holder.stream!.stream('question', async (_request, emit) => emit('answer')),
+    ).resolves.toBe('answer');
+  });
+
+  it('uses the mounted shared lifecycle for agent requests', async () => {
+    const provided = noSerialize(createAskableContext());
+    const holder: { agent?: UseAskableAgentResult<string> } = {};
+    const Consumer = component$(() => {
+      holder.agent = useAskableAgent<string>({ ctx: provided });
+      return <div>ready</div>;
+    });
+
+    const { render } = await createDOM();
+    await render(<Consumer />);
+
+    expect(holder.agent).toBeDefined();
+    await waitForMountedContext(holder.agent!, provided);
+    await expect(holder.agent!.send('question', async () => 'answer')).resolves.toBe('answer');
+    expect(holder.agent!.data.value).toBe('answer');
+  });
+
+});

--- a/packages/qwik/src/__tests__/useAskable.test.ts
+++ b/packages/qwik/src/__tests__/useAskable.test.ts
@@ -2,23 +2,65 @@ import { afterEach, describe, it, expect, vi } from 'vitest';
 import { createAskableContext } from '@askable-ui/core';
 import { useAskable } from '../useAskable.js';
 
-const { cleanups } = vi.hoisted(() => ({ cleanups: [] as Array<() => void> }));
+const { cleanups, visibleTasks } = vi.hoisted(() => ({
+  cleanups: [] as Array<() => void>,
+  visibleTasks: {
+    runImmediately: true,
+    pending: [] as Array<(args: { cleanup(callback: () => void): void }) => void>,
+  },
+}));
 
 vi.mock('@builder.io/qwik', () => ({
-  useSignal: <T>(value: T) => ({ value }),
+  noSerialize: <T>(value: T) => value,
+  useSignal: <T>(value?: T) => ({ value }),
   useVisibleTask$: (task: (args: { cleanup(callback: () => void): void }) => void) => {
+    if (!visibleTasks.runImmediately) {
+      visibleTasks.pending.push(task);
+      return;
+    }
     task({ cleanup: (callback) => cleanups.push(callback) });
   },
 }));
 
 afterEach(() => {
   while (cleanups.length > 0) cleanups.pop()!();
+  visibleTasks.runImmediately = true;
+  visibleTasks.pending = [];
+  vi.unstubAllGlobals();
 });
 
 // The Qwik primitives are mocked so adapter lifecycle and context-sharing
 // behavior can be exercised without a rendered Qwik component.
 
 describe('useAskable (Qwik) — contract tests', () => {
+  it('does not access document before the visible task runs', () => {
+    visibleTasks.runImmediately = false;
+    vi.stubGlobal('document', undefined);
+
+    const result = useAskable();
+
+    expect(result.ctxRef.value).toBeUndefined();
+    expect(result.ctx).toBeUndefined();
+    expect(visibleTasks.pending).toHaveLength(1);
+  });
+
+  it('destroys a factory context that resolves after cleanup', async () => {
+    let resolveContext!: (ctx: ReturnType<typeof createAskableContext>) => void;
+    const pendingContext = new Promise<ReturnType<typeof createAskableContext>>((resolve) => {
+      resolveContext = resolve;
+    });
+    const ctx = createAskableContext();
+    const destroy = vi.spyOn(ctx, 'destroy');
+
+    const result = useAskable({ ctx$: (() => pendingContext) as any });
+    expect(cleanups).toHaveLength(1);
+    cleanups.pop()!();
+
+    resolveContext(ctx);
+    await vi.waitFor(() => expect(destroy).toHaveBeenCalledOnce());
+    expect(result.ctxRef.value).toBeUndefined();
+  });
+
   it('createAskableContext() returns a valid context', () => {
     const ctx = createAskableContext();
     expect(ctx).toBeDefined();

--- a/packages/qwik/src/__tests__/useAskableSource.test.ts
+++ b/packages/qwik/src/__tests__/useAskableSource.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAskableContext } from '@askable-ui/core';
+import type { AskableContext, AskableContextSource } from '@askable-ui/core';
+import { useAskableSource } from '../useAskableSource.js';
+
+const state = vi.hoisted(() => ({
+  cleanups: [] as Array<() => void>,
+  ctxRef: { value: undefined as AskableContext | undefined },
+}));
+
+vi.mock('@builder.io/qwik', () => ({
+  noSerialize: <T>(value: T) => value,
+  useSignal: <T>(value?: T) => ({ value }),
+  useVisibleTask$: (
+    task: (args: {
+      cleanup(callback: () => void): void;
+      track<T>(read: () => T): T;
+    }) => void,
+  ) => task({
+    cleanup: (callback) => state.cleanups.push(callback),
+    track: (read) => read(),
+  }),
+}));
+
+vi.mock('../useAskable.js', () => ({
+  useAskable: () => ({ ctxRef: state.ctxRef }),
+}));
+
+beforeEach(() => {
+  state.ctxRef.value = createAskableContext();
+});
+
+afterEach(() => {
+  while (state.cleanups.length > 0) state.cleanups.pop()!();
+  state.ctxRef.value?.destroy();
+  state.ctxRef.value = undefined;
+});
+
+describe('useAskableSource lifecycle', () => {
+  it('unregisters a source handle exactly once after manual unregister and cleanup', () => {
+    const unregister = vi.fn();
+    vi.spyOn(state.ctxRef.value!, 'registerSource').mockReturnValue({
+      id: 'manual',
+      unregister,
+      notifyChanged: vi.fn(),
+    });
+
+    const result = useAskableSource('manual', { resolve: () => ({ ready: true }) });
+    result.unregister();
+    state.cleanups.pop()!();
+
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+
+  it('does not register a source factory that resolves after cleanup', async () => {
+    let resolveSource!: (source: AskableContextSource) => void;
+    const pendingSource = new Promise<AskableContextSource>((resolve) => {
+      resolveSource = resolve;
+    });
+    const registerSource = vi.spyOn(state.ctxRef.value!, 'registerSource');
+
+    useAskableSource('deferred', (() => pendingSource) as any);
+    expect(state.cleanups).toHaveLength(1);
+    state.cleanups.pop()!();
+
+    resolveSource({ resolve: () => ({ ready: true }) });
+    await pendingSource;
+    await Promise.resolve();
+    expect(registerSource).not.toHaveBeenCalled();
+    expect(state.ctxRef.value!.hasSource('deferred')).toBe(false);
+  });
+});

--- a/packages/qwik/src/contextRef.ts
+++ b/packages/qwik/src/contextRef.ts
@@ -1,0 +1,10 @@
+import type { NoSerialize, Signal } from '@builder.io/qwik';
+import type { AskableContext } from '@askable-ui/core';
+
+export type AskableContextRef = Signal<NoSerialize<AskableContext> | undefined>;
+
+export function getAskableContext(ctxRef: AskableContextRef): AskableContext {
+  const ctx = ctxRef.value;
+  if (!ctx) throw new Error('Askable context is not available before the Qwik visible task runs');
+  return ctx;
+}

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -3,9 +3,10 @@ export type { AskableProps } from './Askable.js';
 
 export { useAskable } from './useAskable.js';
 export type { UseAskableOptions, UseAskableResult } from './useAskable.js';
+export type { AskableContextRef } from './contextRef.js';
 
 export { useAskableSource } from './useAskableSource.js';
-export type { UseAskableSourceOptions, UseAskableSourceResult } from './useAskableSource.js';
+export type { AskableContextSourceFactory, UseAskableSourceOptions, UseAskableSourceResult } from './useAskableSource.js';
 
 export { useAskableAgent } from './useAskableAgent.js';
 export type { AskableAgentStatus, UseAskableAgentOptions, UseAskableAgentResult } from './useAskableAgent.js';

--- a/packages/qwik/src/useAskable.ts
+++ b/packages/qwik/src/useAskable.ts
@@ -1,15 +1,21 @@
-import { useSignal, useVisibleTask$ } from '@builder.io/qwik';
+import { noSerialize, useSignal, useVisibleTask$ } from '@builder.io/qwik';
+import type { NoSerialize, QRL } from '@builder.io/qwik';
 import { createAskableContext } from '@askable-ui/core';
 import type { AskableContext, AskableContextOptions, AskableEvent, AskableFocus } from '@askable-ui/core';
+import type { AskableContextRef } from './contextRef.js';
 
 export interface UseAskableOptions extends AskableContextOptions {
   events?: AskableEvent[];
   ctx?: AskableContext;
+  /** Resume-safe factory for a hook-owned browser context. */
+  ctx$?: QRL<() => AskableContext | Promise<AskableContext>>;
 }
 
 export interface UseAskableResult {
   focus: ReturnType<typeof useSignal<AskableFocus | null>>;
   promptContext: ReturnType<typeof useSignal<string>>;
+  /** Stable signal populated when the component becomes visible in the browser. */
+  ctxRef: AskableContextRef;
   ctx: AskableContext;
 }
 
@@ -85,25 +91,24 @@ function releaseCtx(key: string): void {
 export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const focus = useSignal<AskableFocus | null>(null);
   const promptContext = useSignal<string>('');
+  const ctxRef = useSignal<NoSerialize<AskableContext>>();
   const usesProvidedCtx = Boolean(options?.ctx);
-  const usePrivateCtx = !usesProvidedCtx && requiresPrivateContext(options);
+  const usesContextFactory = Boolean(options?.ctx$);
+  const usePrivateCtx = !usesProvidedCtx && !usesContextFactory && requiresPrivateContext(options);
+  const providedCtx = options?.ctx ? noSerialize(options.ctx) : undefined;
+  const providedCtxFactory = options?.ctx$;
+  const { ctx: _providedCtx, ctx$: _providedCtxFactory, ...contextOptions } = options ?? {};
 
-  let ctx: AskableContext | null = null;
   const key = sharedKey(options);
 
   // eslint-disable-next-line qwik/no-use-visible-task
-  useVisibleTask$(({ cleanup }) => {
-    ctx = usesProvidedCtx
-      ? options!.ctx!
-      : usePrivateCtx
-        ? createAdapterContext(options)
-        : retainCtx(key, options);
-    if (usePrivateCtx) {
-      ctx.observe(document, { events: options?.events ?? DEFAULT_EVENTS });
-    }
+  useVisibleTask$(async ({ cleanup }) => {
+    let disposed = false;
+    let ctx: AskableContext | undefined;
+    let subscribed = false;
 
-    const handleFocus = (f: AskableFocus) => {
-      focus.value = f;
+    const handleFocus = (focusValue: AskableFocus) => {
+      focus.value = focusValue;
       promptContext.value = ctx!.toPromptContext();
     };
     const handleClear = (_: null) => {
@@ -111,23 +116,55 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
       promptContext.value = '';
     };
 
-    ctx.on('focus', handleFocus);
-    ctx.on('clear', handleClear);
-
     cleanup(() => {
-      ctx!.off('focus', handleFocus);
-      ctx!.off('clear', handleClear);
+      disposed = true;
+      if (!ctx) return;
+      if (subscribed) {
+        ctx.off('focus', handleFocus);
+        ctx.off('clear', handleClear);
+      }
       if (!usesProvidedCtx) {
-        if (usePrivateCtx) ctx!.destroy();
+        if (usePrivateCtx || usesContextFactory) ctx.destroy();
         else releaseCtx(key);
       }
-      ctx = null;
+      if (ctxRef.value === ctx) ctxRef.value = undefined;
     });
+
+    try {
+      ctx = usesProvidedCtx
+        ? providedCtx
+        : usesContextFactory
+          ? await providedCtxFactory!()
+          : usePrivateCtx
+            ? createAdapterContext(contextOptions)
+            : retainCtx(key, contextOptions);
+    } catch (error) {
+      if (disposed) return;
+      throw error;
+    }
+    if (!ctx) {
+      throw new Error(
+        'Provided Askable context was not available after Qwik resume; pass ctx$ for SSR-resumable ownership',
+      );
+    }
+    if (disposed) {
+      if (usesContextFactory) ctx.destroy();
+      return;
+    }
+    ctxRef.value = noSerialize(ctx);
+    if (usePrivateCtx || usesContextFactory) {
+      ctx.observe(document, { events: contextOptions.events ?? DEFAULT_EVENTS });
+    }
+
+    ctx.on('focus', handleFocus);
+    ctx.on('clear', handleClear);
+    subscribed = true;
   });
 
   return {
     focus,
     promptContext,
-    get ctx() { return ctx!; },
+    ctxRef,
+    get ctx() { return ctxRef.value!; },
   };
 }

--- a/packages/qwik/src/useAskableAgent.ts
+++ b/packages/qwik/src/useAskableAgent.ts
@@ -1,18 +1,14 @@
-import { useSignal, useVisibleTask$, $ } from '@builder.io/qwik';
-import { createAskableContext } from '@askable-ui/core';
+import { useSignal, $ } from '@builder.io/qwik';
 import type {
   AskableAgentRequest,
   AskableAgentRequestOptions,
   AskableContext,
-  AskableContextOptions,
-  AskableEvent,
 } from '@askable-ui/core';
+import { useAskable, type UseAskableOptions } from './useAskable.js';
 
 export type AskableAgentStatus = 'idle' | 'pending' | 'success' | 'error';
 
-export interface UseAskableAgentOptions extends AskableContextOptions {
-  events?: AskableEvent[];
-  ctx?: AskableContext;
+export interface UseAskableAgentOptions extends UseAskableOptions {
   requestOptions?: AskableAgentRequestOptions;
 }
 
@@ -60,25 +56,14 @@ export function useAskableAgent<T = unknown>(
   const isLoading = useSignal<boolean>(false);
   const lastRequest = useSignal<AskableAgentRequest | null>(null);
 
-  let ctx: AskableContext | null = null;
-  const requestOptions = options?.requestOptions;
-
-  // eslint-disable-next-line qwik/no-use-visible-task
-  useVisibleTask$(({ cleanup }) => {
-    ctx = options?.ctx ?? createAskableContext(options);
-    if (!options?.ctx) {
-      ctx.observe(document, { events: options?.events });
-    }
-    cleanup(() => {
-      if (!options?.ctx) ctx?.destroy();
-      ctx = null;
-    });
-  });
+  const { requestOptions, ...askableOptions } = options ?? {};
+  const { ctxRef } = useAskable(askableOptions);
 
   const send = $(async (
     question: string,
     handler: (request: AskableAgentRequest) => T | Promise<T>,
   ): Promise<T | undefined> => {
+    const ctx = ctxRef.value;
     if (!ctx) return undefined;
 
     status.value = 'pending';
@@ -118,6 +103,6 @@ export function useAskableAgent<T = unknown>(
     lastRequest,
     send,
     reset,
-    get ctx() { return ctx!; },
+    get ctx() { return ctxRef.value!; },
   };
 }

--- a/packages/qwik/src/useAskableCartSource.ts
+++ b/packages/qwik/src/useAskableCartSource.ts
@@ -41,14 +41,14 @@ export interface UseAskableCartSourceResult extends UseAskableSourceResult {
  * ```
  */
 export function useAskableCartSource(options: UseAskableCartSourceOptions = {}): UseAskableCartSourceResult {
-  const { id = 'cart', items: initialItems = [], totals: initialTotals = {}, describe, kind, enabled, ctx, name, events } = options;
+  const { id = 'cart', items: initialItems = [], totals: initialTotals = {}, describe, kind, enabled, ctx, ctx$, name, events } = options;
 
   const snapshot = useSignal<AskableCartSourceSnapshot | null>(
     buildCartSnapshot(initialItems, initialTotals, new Date().toISOString()),
   );
 
   const source = createAskableCartSource({ describe, kind, getSnapshot: () => snapshot.value });
-  const result = useAskableSource(id, source, { enabled, ctx, name, events });
+  const result = useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 
   function getTotals(): AskableCartTotals {
     const s = snapshot.value;

--- a/packages/qwik/src/useAskableChat.ts
+++ b/packages/qwik/src/useAskableChat.ts
@@ -1,5 +1,6 @@
 import { useSignal } from '@builder.io/qwik';
 import type { AskableAgentRequest, AskableAgentRequestOptions, AskableContext } from '@askable-ui/core';
+import { getAskableContext } from './contextRef.js';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
 
 export type AskableChatRole = 'user' | 'assistant' | 'system';
@@ -75,7 +76,7 @@ function nextId() { return `msg-${Date.now()}-${++idCounter}`; }
  */
 export function useAskableChat(options: UseAskableChatOptions = {}): UseAskableChatResult {
   const { initialMessages = [], systemPrompt, onChunk, onFinish, onError, requestOptions, ...askableOptions } = options;
-  const { ctx } = useAskable(askableOptions);
+  const { ctxRef } = useAskable(askableOptions);
 
   const messages = useSignal<AskableChatMessage[]>([...initialMessages]);
   const status = useSignal<AskableChatStatus>('idle');
@@ -103,6 +104,7 @@ export function useAskableChat(options: UseAskableChatOptions = {}): UseAskableC
     abort();
     currentAc = new AbortController();
 
+    const ctx = getAskableContext(ctxRef);
     const userMsg: AskableChatMessage = { id: nextId(), role: 'user', content, createdAt: Date.now() };
     messages.value = [...messages.value, userMsg];
 
@@ -146,5 +148,5 @@ export function useAskableChat(options: UseAskableChatOptions = {}): UseAskableC
     }
   }
 
-  return { messages, status, error, isStreaming, append, clearMessages, abort, get ctx() { return ctx; } };
+  return { messages, status, error, isStreaming, append, clearMessages, abort, get ctx() { return ctxRef.value!; } };
 }

--- a/packages/qwik/src/useAskableErrorSource.ts
+++ b/packages/qwik/src/useAskableErrorSource.ts
@@ -32,7 +32,7 @@ export interface UseAskableErrorSourceResult extends UseAskableSourceResult {
  * ```
  */
 export function useAskableErrorSource(options: UseAskableErrorSourceOptions = {}): UseAskableErrorSourceResult {
-  const { id = 'errors', enabled, ctx, name, events, describe, kind, initialErrors = [], getErrors: customGetErrors } = options;
+  const { id = 'errors', enabled, ctx, ctx$, name, events, describe, kind, initialErrors = [], getErrors: customGetErrors } = options;
 
   const errors = useSignal<AskableErrorEntry[]>(initialErrors);
 
@@ -42,7 +42,7 @@ export function useAskableErrorSource(options: UseAskableErrorSourceOptions = {}
     getErrors: customGetErrors ?? (() => errors.value),
   });
 
-  const result = useAskableSource(id, source, { enabled, ctx, name, events });
+  const result = useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 
   function addError(entry: AskableErrorEntry): void {
     errors.value = [entry, ...errors.value.filter((e) => e.key !== entry.key)];

--- a/packages/qwik/src/useAskableFormSource.ts
+++ b/packages/qwik/src/useAskableFormSource.ts
@@ -22,7 +22,7 @@ export type UseAskableFormSourceResult = UseAskableSourceResult;
  * ```
  */
 export function useAskableFormSource(options: UseAskableFormSourceOptions = {}): UseAskableFormSourceResult {
-  const { id = 'form', enabled, ctx, name, events, ...sourceOptions } = options;
+  const { id = 'form', enabled, ctx, ctx$, name, events, ...sourceOptions } = options;
   const source = createAskableFormSource(sourceOptions);
-  return useAskableSource(id, source, { enabled, ctx, name, events });
+  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 }

--- a/packages/qwik/src/useAskableHistory.ts
+++ b/packages/qwik/src/useAskableHistory.ts
@@ -1,4 +1,4 @@
-import { useSignal, useVisibleTask$, useComputed$ } from '@builder.io/qwik';
+import { useSignal, useVisibleTask$ } from '@builder.io/qwik';
 import type { AskableContext, AskableFocus } from '@askable-ui/core';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
 
@@ -34,12 +34,14 @@ export function useAskableHistory(options?: UseAskableHistoryOptions): UseAskabl
   const maxEntries = options?.maxEntries ?? 10;
   const dedupe = options?.dedupe ?? true;
 
-  const { ctx } = useAskable(options);
+  const { ctxRef } = useAskable(options);
   const history = useSignal<AskableFocus[]>([]);
   const current = useSignal<AskableFocus | null>(null);
 
   // eslint-disable-next-line qwik/no-use-visible-task
-  useVisibleTask$(({ cleanup }) => {
+  useVisibleTask$(({ cleanup, track }) => {
+    const ctx = track(() => ctxRef.value);
+    if (!ctx) return;
     const handleFocus = (f: AskableFocus) => {
       current.value = f;
       const prev = history.value;
@@ -58,5 +60,9 @@ export function useAskableHistory(options?: UseAskableHistoryOptions): UseAskabl
     });
   });
 
-  return { history, current, ctx };
+  return {
+    history,
+    current,
+    get ctx() { return ctxRef.value!; },
+  };
 }

--- a/packages/qwik/src/useAskableMultistepSource.ts
+++ b/packages/qwik/src/useAskableMultistepSource.ts
@@ -47,7 +47,7 @@ export interface UseAskableMultistepSourceResult extends UseAskableSourceResult 
  * ```
  */
 export function useAskableMultistepSource(options: UseAskableMultistepSourceOptions = {}): UseAskableMultistepSourceResult {
-  const { id = 'multistep', steps: initialSteps = [], initialStep = 0, describe, kind, enabled, ctx, name, events } = options;
+  const { id = 'multistep', steps: initialSteps = [], initialStep = 0, describe, kind, enabled, ctx, ctx$, name, events } = options;
 
   function makeSteps(defs: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[], activeIdx: number): AskableMultistepStep[] {
     return defs.map((s, i) => ({
@@ -65,7 +65,7 @@ export function useAskableMultistepSource(options: UseAskableMultistepSourceOpti
   );
 
   const source = createAskableMultistepSource({ describe, kind, getSnapshot: () => snapshot.value });
-  const result = useAskableSource(id, source, { enabled, ctx, name, events });
+  const result = useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 
   function currentDefs(): Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[] {
     return snapshot.value?.steps.map((s) => ({ id: s.id, label: s.label, description: s.description, optional: s.optional })) ?? initialSteps;

--- a/packages/qwik/src/useAskableNavigationSource.ts
+++ b/packages/qwik/src/useAskableNavigationSource.ts
@@ -20,7 +20,7 @@ export type UseAskableNavigationSourceResult = UseAskableSourceResult;
  * ```
  */
 export function useAskableNavigationSource(options: UseAskableNavigationSourceOptions = {}): UseAskableNavigationSourceResult {
-  const { id = 'navigation', enabled, ctx, name, events, ...sourceOptions } = options;
+  const { id = 'navigation', enabled, ctx, ctx$, name, events, ...sourceOptions } = options;
   const source = createAskableNavigationSource(sourceOptions);
-  return useAskableSource(id, source, { enabled, ctx, name, events });
+  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 }

--- a/packages/qwik/src/useAskableNotificationSource.ts
+++ b/packages/qwik/src/useAskableNotificationSource.ts
@@ -35,7 +35,7 @@ export interface UseAskableNotificationSourceResult extends UseAskableSourceResu
 export function useAskableNotificationSource(
   options: UseAskableNotificationSourceOptions = {},
 ): UseAskableNotificationSourceResult {
-  const { id = 'notifications', enabled, ctx, name, events, maxEntries = 20, describe, kind } = options;
+  const { id = 'notifications', enabled, ctx, ctx$, name, events, maxEntries = 20, describe, kind } = options;
 
   const notifications = useSignal<AskableNotification[]>([]);
   let nextId = 1;
@@ -45,7 +45,7 @@ export function useAskableNotificationSource(
     kind,
     getNotifications: () => notifications.value,
   });
-  const result = useAskableSource(id, source, { enabled, ctx, name, events });
+  const result = useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 
   function push(notification: Omit<AskableNotification, 'id' | 'timestamp'>): void {
     const entry: AskableNotification = {

--- a/packages/qwik/src/useAskablePageSource.ts
+++ b/packages/qwik/src/useAskablePageSource.ts
@@ -22,7 +22,7 @@ export type UseAskablePageSourceResult = UseAskableSourceResult;
  * ```
  */
 export function useAskablePageSource(options: UseAskablePageSourceOptions = {}): UseAskablePageSourceResult {
-  const { id = 'page', enabled, ctx, name, events, describe, kind, root, includeLinks, maxLinks, maxHeadings, maxTextLength, textExtractor, sanitizeText } = options;
+  const { id = 'page', enabled, ctx, ctx$, name, events, describe, kind, root, includeLinks, maxLinks, maxHeadings, maxTextLength, textExtractor, sanitizeText } = options;
   const source = createAskablePageSource({ describe, kind, root, includeLinks, maxLinks, maxHeadings, maxTextLength, textExtractor, sanitizeText });
-  return useAskableSource(id, source, { enabled, ctx, name, events });
+  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 }

--- a/packages/qwik/src/useAskableSource.ts
+++ b/packages/qwik/src/useAskableSource.ts
@@ -1,4 +1,5 @@
-import { useVisibleTask$ } from '@builder.io/qwik';
+import { noSerialize, useSignal, useVisibleTask$ } from '@builder.io/qwik';
+import type { NoSerialize, QRL } from '@builder.io/qwik';
 import type {
   AskableAsyncPromptContextOptions,
   AskableContext,
@@ -7,6 +8,7 @@ import type {
   AskableContextSourceRequest,
   AskableResolvedContextSource,
 } from '@askable-ui/core';
+import { getAskableContext } from './contextRef.js';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
 
 export interface UseAskableSourceOptions extends Omit<UseAskableOptions, never> {
@@ -25,6 +27,10 @@ export interface UseAskableSourceResult {
   unregister(): void;
 }
 
+export type AskableContextSourceFactory = QRL<
+  () => AskableContextSource | Promise<AskableContextSource>
+>;
+
 /**
  * Qwik hook that registers an arbitrary context source on the shared
  * AskableContext. The source is registered once the component mounts in the
@@ -32,39 +38,59 @@ export interface UseAskableSourceResult {
  */
 export function useAskableSource(
   id: string,
-  source: AskableContextSource,
+  source: AskableContextSource | AskableContextSourceFactory,
   options: UseAskableSourceOptions = {},
 ): UseAskableSourceResult {
   const { enabled = true, ...askableOptions } = options;
-  const { ctx: _ctxRef } = useAskable(askableOptions);
+  const { ctxRef } = useAskable(askableOptions);
+  const sourceFactory = typeof source === 'function' ? source : undefined;
+  const clientSource = typeof source === 'function' ? undefined : noSerialize(source);
 
-  let handle: AskableContextSourceHandle | null = null;
+  const handleRef = useSignal<NoSerialize<AskableContextSourceHandle>>();
 
   // eslint-disable-next-line qwik/no-use-visible-task
-  useVisibleTask$(({ cleanup }) => {
-    const ctx = _ctxRef;
+  useVisibleTask$(async ({ cleanup, track }) => {
+    let disposed = false;
+    cleanup(() => {
+      disposed = true;
+      handleRef.value?.unregister();
+      handleRef.value = undefined;
+    });
+
+    const ctx = track(() => ctxRef.value);
     if (!ctx || !enabled || !id.trim()) return;
 
-    handle = ctx.registerSource(id.trim(), source);
-
-    cleanup(() => {
-      handle?.unregister();
-      handle = null;
-    });
+    let resolvedSource: AskableContextSource | undefined;
+    try {
+      resolvedSource = sourceFactory ? await sourceFactory() : clientSource;
+    } catch (error) {
+      if (disposed) return;
+      throw error;
+    }
+    if (!resolvedSource) {
+      throw new Error(
+        'Askable source was not available after Qwik resume; pass a QRL source factory instead',
+      );
+    }
+    if (disposed) return;
+    handleRef.value = noSerialize(ctx.registerSource(id.trim(), resolvedSource));
   });
 
   return {
-    get ctx() { return _ctxRef; },
+    get ctx() { return ctxRef.value!; },
     sourceId: id,
-    resolve: (request?) => _ctxRef.resolveSource(id, request),
+    resolve: (request?) => getAskableContext(ctxRef).resolveSource(id, request),
     toPromptContext: (opts?) => {
       const { source: sourceRequest, ...rest } = opts ?? {};
-      return _ctxRef.toPromptContextAsync({
+      return getAskableContext(ctxRef).toPromptContextAsync({
         ...rest,
         sources: [{ id, ...sourceRequest }],
       });
     },
-    notifyChanged: () => handle?.notifyChanged(),
-    unregister: () => { handle?.unregister(); handle = null; },
+    notifyChanged: () => handleRef.value?.notifyChanged(),
+    unregister: () => {
+      handleRef.value?.unregister();
+      handleRef.value = undefined;
+    },
   };
 }

--- a/packages/qwik/src/useAskableStream.ts
+++ b/packages/qwik/src/useAskableStream.ts
@@ -1,5 +1,6 @@
 import { useSignal } from '@builder.io/qwik';
 import type { AskableAgentRequest, AskableAgentRequestOptions, AskableContext } from '@askable-ui/core';
+import { getAskableContext } from './contextRef.js';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
 
 export type AskableStreamStatus = 'idle' | 'streaming' | 'success' | 'error';
@@ -60,7 +61,7 @@ export interface UseAskableStreamResult {
  */
 export function useAskableStream(options: UseAskableStreamOptions = {}): UseAskableStreamResult {
   const { onRequest, onChunk, onSuccess, onError, requestOptions, ...askableOptions } = options;
-  const { ctx } = useAskable(askableOptions);
+  const { ctxRef } = useAskable(askableOptions);
 
   const status = useSignal<AskableStreamStatus>('idle');
   const content = useSignal('');
@@ -88,6 +89,7 @@ export function useAskableStream(options: UseAskableStreamOptions = {}): UseAska
   async function stream(question: string, handler: AskableStreamHandler): Promise<string | undefined> {
     abort();
     abortController = new AbortController();
+    const ctx = getAskableContext(ctxRef);
     let req = await ctx.toAgentRequest(question, requestOptions);
     if (onRequest) { const override = onRequest(req); if (override) req = override; }
 
@@ -137,5 +139,5 @@ export function useAskableStream(options: UseAskableStreamOptions = {}): UseAska
     });
   }
 
-  return { stream, streamFrom, status, content, error, lastRequest, isStreaming, reset, abort, get ctx() { return ctx; } };
+  return { stream, streamFrom, status, content, error, lastRequest, isStreaming, reset, abort, get ctx() { return ctxRef.value!; } };
 }

--- a/packages/qwik/src/useAskableTableSource.ts
+++ b/packages/qwik/src/useAskableTableSource.ts
@@ -66,6 +66,7 @@ export function useAskableTableSource<TRow = unknown, TState = unknown>(
     advertisedModes,
     enabled,
     ctx,
+    ctx$,
     name,
     events,
   } = options;
@@ -90,5 +91,5 @@ export function useAskableTableSource<TRow = unknown, TState = unknown>(
     sanitizeItem: sanitizeRow ? (row) => sanitizeRow(row) : undefined,
   });
 
-  return useAskableSource(id, source, { enabled, ctx, name, events });
+  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 }

--- a/packages/qwik/src/useAskableUserSource.ts
+++ b/packages/qwik/src/useAskableUserSource.ts
@@ -22,7 +22,7 @@ export type UseAskableUserSourceResult = UseAskableSourceResult;
  * ```
  */
 export function useAskableUserSource(options: UseAskableUserSourceOptions): UseAskableUserSourceResult {
-  const { id = 'user', enabled, ctx, name, events, ...sourceOptions } = options;
+  const { id = 'user', enabled, ctx, ctx$, name, events, ...sourceOptions } = options;
   const source = createAskableUserSource(sourceOptions);
-  return useAskableSource(id, source, { enabled, ctx, name, events });
+  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
 }

--- a/packages/qwik/vitest.lifecycle.config.ts
+++ b/packages/qwik/vitest.lifecycle.config.ts
@@ -1,0 +1,12 @@
+import { qwikVite } from '@builder.io/qwik/optimizer';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  oxc: false,
+  plugins: [qwikVite()],
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/__tests__/lifecycle.test.tsx'],
+  },
+});

--- a/site/docs/guide/qwik.md
+++ b/site/docs/guide/qwik.md
@@ -49,14 +49,50 @@ Renders a `div` (or any element via `as`) annotated with `data-askable`.
 Creates (or shares) a context and returns reactive Qwik signals.
 
 ```tsx
-const { focus, promptContext, ctx } = useAskable();
+const askable = useAskable();
+const { focus, promptContext, ctxRef } = askable;
 
 // focus.value — current AskableFocus | null (signal)
 // promptContext.value — serialized string (signal)
-// ctx — raw AskableContext for advanced usage
+// ctxRef.value — AskableContext after the visible task mounts
 ```
 
 All hooks in the same Qwik app share a single context instance by default (matched by name + events key), so source hooks automatically connect to the same focus stream.
+
+The DOM-backed context is intentionally initialized in a visible task so SSR
+never accesses `document`. Do not destructure `ctx` during component render,
+because that reads before the visible task runs. Read `askable.ctx` from browser
+actions, or use the stable `ctxRef` signal in lifecycle-aware code:
+
+```tsx
+const askable = useAskable();
+
+// Browser action after mount
+const readPrompt = () => askable.ctx.toPromptContext();
+
+// Visible task or other reactive lifecycle code
+const ctx = askable.ctxRef.value;
+```
+
+The stream, chat, history, source, and agent hooks resolve `ctxRef` when their
+action/task runs rather than capturing a render-time value.
+
+For SSR-to-browser resume, use QRL factories to create hook-owned runtime
+contexts and reconstruct custom sources in the browser:
+
+```tsx
+import { $ } from '@builder.io/qwik';
+import { createAskableContext } from '@askable-ui/core';
+
+const askable = useAskable({ ctx$: $(() => createAskableContext()) });
+const source = useAskableSource('stats', $(() => ({
+  resolve: () => ({ count: 2 }),
+})));
+```
+
+The hook observes and destroys contexts created by `ctx$`. Direct `ctx` and
+source-object arguments remain supported for client-only mounts. Values wrapped
+with `noSerialize` are intentionally not restored after an SSR resume.
 
 ## Sources
 


### PR DESCRIPTION
## Summary

- replace render-time Qwik context dereferences with a stable `NoSerialize` context signal populated by the visible lifecycle
- resolve context readiness at action/task time across stream, chat, history, source, and agent hooks
- add QRL factories for SSR-resumable hook-owned contexts and custom sources while preserving client-only direct-object support
- add optimizer-backed rendered lifecycle regressions and document the lifecycle contract

Closes #372.

## Why

Qwik component setup runs before `useVisibleTask$`. The adapter previously destructured a getter backed by a local context variable during setup, permanently capturing the unavailable value. Optimizer-backed rendering also demonstrated that mutating that captured local is incompatible with Qwik's transformed lifecycle.

The new `ctxRef` signal keeps the render-time reference stable while the browser-only context remains `NoSerialize`. Dependent hooks read it only when a visible task or action actually needs the context.

## Validation

- `npm run build -w @askable-ui/qwik`
- `npm test -w @askable-ui/qwik` — 29 tests, including 5 optimizer-backed rendered lifecycle tests
- `npm audit --omit=dev --audit-level=high`
- `npm run build`
- `npm test` — 1,162 tests
- `npm ci && npm run build` in `site/docs`
- `git diff --check`

## Follow-up

Optimizer-backed investigation also found the broader pre-existing Qwik action-QRL limitation tracked separately in #388. This PR stays focused on context readiness and does not introduce a breaking action/callback API migration.
