### PR TITLE
fix(react): keep navigation source options current

### DIFF
--- a/packages/core/src/__tests__/navigation-source.test.ts
+++ b/packages/core/src/__tests__/navigation-source.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createAskableNavigationSource } from '../navigation-source.js';
+import type { AskableCreateNavigationSourceOptions } from '../navigation-source.js';
 import { createAskableContext } from '../index.js';
 
 describe('createAskableNavigationSource', () => {
@@ -124,6 +125,36 @@ describe('createAskableNavigationSource', () => {
     const resolved = await ctx.resolveSource('nav');
     const data = resolved.data as { history: unknown[] };
     expect(data.history).toHaveLength(1);
+    ctx.destroy();
+  });
+
+  it('reads updated options without resetting navigation history', async () => {
+    const ctx = createAskableContext();
+    const options: AskableCreateNavigationSourceOptions = {
+      getPath,
+      getTitle,
+      maxHistory: 3,
+      kind: 'route',
+      describe: (snapshot) => `First: ${snapshot.currentPath}`,
+    };
+    const source = createAskableNavigationSource(options);
+    ctx.registerSource('nav', source);
+
+    await ctx.resolveSource('nav');
+    path = '/settings';
+    await ctx.resolveSource('nav');
+
+    options.getPath = () => '/profile';
+    options.getTitle = () => 'Profile';
+    options.maxHistory = 2;
+    options.kind = 'router';
+    options.describe = (snapshot) => `Latest: ${snapshot.currentTitle}`;
+
+    const resolved = await ctx.resolveSource('nav');
+    const data = resolved.data as { history: { path: string }[] };
+    expect(resolved.kind).toBe('router');
+    expect(resolved.description).toBe('Latest: Profile');
+    expect(data.history.map((entry) => entry.path)).toEqual(['/profile', '/settings']);
     ctx.destroy();
   });
 

--- a/packages/core/src/navigation-source.ts
+++ b/packages/core/src/navigation-source.ts
@@ -1,4 +1,3 @@
-import { createAskableSource } from './sources.js';
 import type { AskableContextSource } from './types.js';
 
 export interface AskableNavigationEntry {
@@ -126,22 +125,16 @@ function buildDefaultDescribe(snapshot: AskableNavigationSourceSnapshot): string
 export function createAskableNavigationSource(
   options: AskableCreateNavigationSourceOptions = {},
 ): AskableContextSource {
-  const {
-    getPath = defaultGetPath,
-    getTitle = defaultGetTitle,
-    getParams,
-    maxHistory = 10,
-    describe,
-    kind = 'navigation',
-  } = options;
-
   const history: AskableNavigationEntry[] = [];
 
   function buildSnapshot(): AskableNavigationSourceSnapshot {
+    const getPath = options.getPath ?? defaultGetPath;
+    const getTitle = options.getTitle ?? defaultGetTitle;
     const currentPath = getPath();
-    const currentTitle = getTitle?.() ?? null;
-    const params = getParams?.() ?? null;
+    const currentTitle = getTitle() ?? null;
+    const params = options.getParams?.() ?? null;
     const query = parseQuery(currentPath);
+    const maxHistory = options.maxHistory ?? 10;
 
     const latest = history[0];
     if (!latest || latest.path !== currentPath) {
@@ -150,18 +143,24 @@ export function createAskableNavigationSource(
         title: currentTitle ?? undefined,
         timestamp: new Date().toISOString(),
       });
-      if (history.length > maxHistory) history.length = maxHistory;
     }
+    if (history.length > maxHistory) history.length = maxHistory;
 
     return { currentPath, currentTitle, params, query, history: [...history] };
   }
 
-  return createAskableSource({
-    kind,
-    describe: describe
-      ? () => describe(buildSnapshot())
-      : () => buildDefaultDescribe(buildSnapshot()),
-    state: () => {
+  return {
+    get kind() {
+      return options.kind ?? 'navigation';
+    },
+    modes: ['state'],
+    describe: () => {
+      const snapshot = buildSnapshot();
+      return options.describe
+        ? options.describe(snapshot)
+        : buildDefaultDescribe(snapshot);
+    },
+    getState: () => {
       const snapshot = buildSnapshot();
       return {
         currentPath: snapshot.currentPath,
@@ -169,6 +168,6 @@ export function createAskableNavigationSource(
         historyLength: snapshot.history.length,
       };
     },
-    data: () => buildSnapshot(),
-  });
+    resolve: () => buildSnapshot(),
+  };
 }

--- a/packages/react/src/__tests__/useAskableNavigationSource.test.tsx
+++ b/packages/react/src/__tests__/useAskableNavigationSource.test.tsx
@@ -1,7 +1,11 @@
+import { Suspense, startTransition } from 'react';
 import { render, act } from '@testing-library/react';
 import { createAskableContext } from '@askable-ui/core';
 import { useAskableNavigationSource } from '../useAskableNavigationSource.js';
-import type { UseAskableNavigationSourceResult } from '../useAskableNavigationSource.js';
+import type {
+  AskableNavigationEntry,
+  UseAskableNavigationSourceResult,
+} from '../useAskableNavigationSource.js';
 
 let hookRef: UseAskableNavigationSourceResult | undefined;
 
@@ -96,6 +100,164 @@ describe('useAskableNavigationSource', () => {
 
     const after = await hookRef!.resolve();
     expect((after.data as { currentPath: string }).currentPath).toBe('/about');
+    ctx.destroy();
+  });
+
+  it('uses the latest router closures without registering another source', async () => {
+    const ctx = createAskableContext();
+    const registerSpy = vi.spyOn(ctx, 'registerSource');
+
+    function RouterConsumer({
+      path,
+      title,
+      params,
+    }: {
+      path: string;
+      title: string;
+      params: Record<string, string>;
+    }) {
+      hookRef = useAskableNavigationSource({
+        ctx,
+        pathname: path,
+        getPath: () => path,
+        getTitle: () => title,
+        getParams: () => params,
+      });
+      return null;
+    }
+
+    const { rerender } = render(
+      <RouterConsumer path="/first" title="First" params={{ slug: 'first' }} />,
+    );
+
+    await hookRef!.resolve();
+    rerender(<RouterConsumer path="/second" title="Second" params={{ slug: 'second' }} />);
+
+    const resolved = await hookRef!.resolve();
+    const data = resolved.data as {
+      currentPath: string;
+      currentTitle: string;
+      params: Record<string, string>;
+      history: AskableNavigationEntry[];
+    };
+    expect(data.currentPath).toBe('/second');
+    expect(data.currentTitle).toBe('Second');
+    expect(data.params).toEqual({ slug: 'second' });
+    expect(data.history.map((entry) => entry.path)).toEqual(['/second', '/first']);
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+    ctx.destroy();
+  });
+
+  it('does not expose router callbacks from an uncommitted suspended render', async () => {
+    const ctx = createAskableContext();
+    const never = new Promise<void>(() => {});
+
+    function ConcurrentConsumer({ path, suspend }: { path: string; suspend: boolean }) {
+      useAskableNavigationSource({
+        ctx,
+        pathname: path,
+        getPath: () => path,
+      });
+      if (suspend) throw never;
+      return null;
+    }
+
+    const view = render(
+      <Suspense fallback={null}>
+        <ConcurrentConsumer path="/committed" suspend={false} />
+      </Suspense>,
+    );
+    expect(
+      ((await ctx.resolveSource('navigation')).data as { currentPath: string }).currentPath,
+    ).toBe('/committed');
+
+    act(() => {
+      startTransition(() => {
+        view.rerender(
+          <Suspense fallback={null}>
+            <ConcurrentConsumer path="/aborted" suspend />
+          </Suspense>,
+        );
+      });
+    });
+
+    expect(
+      ((await ctx.resolveSource('navigation')).data as { currentPath: string }).currentPath,
+    ).toBe('/committed');
+    view.unmount();
+    ctx.destroy();
+  });
+
+  it('uses the latest Next.js pathname and search params closures', async () => {
+    const ctx = createAskableContext();
+
+    function NextConsumer({ pathname, search }: { pathname: string; search: string }) {
+      hookRef = useAskableNavigationSource({
+        ctx,
+        pathname,
+        getPath: () => pathname + (search ? `?${search}` : ''),
+      });
+      return null;
+    }
+
+    const { rerender } = render(<NextConsumer pathname="/products" search="page=1" />);
+    expect(
+      ((await hookRef!.resolve()).data as { currentPath: string }).currentPath,
+    ).toBe('/products?page=1');
+
+    rerender(<NextConsumer pathname="/products/42" search="ref=home" />);
+    expect(
+      ((await hookRef!.resolve()).data as { currentPath: string }).currentPath,
+    ).toBe('/products/42?ref=home');
+    ctx.destroy();
+  });
+
+  it('uses updated description, kind, and history limit options', async () => {
+    const ctx = createAskableContext();
+    const registerSpy = vi.spyOn(ctx, 'registerSource');
+
+    function RouterConsumer({
+      path,
+      description,
+      kind,
+      maxHistory,
+    }: {
+      path: string;
+      description: string;
+      kind: string;
+      maxHistory: number;
+    }) {
+      hookRef = useAskableNavigationSource({
+        ctx,
+        pathname: path,
+        getPath: () => path,
+        describe: () => description,
+        kind,
+        maxHistory,
+      });
+      return null;
+    }
+
+    const { rerender } = render(
+      <RouterConsumer path="/first" description="First description" kind="route" maxHistory={3} />,
+    );
+    expect((await hookRef!.resolve()).description).toBe('First description');
+
+    rerender(
+      <RouterConsumer path="/second" description="Second description" kind="route" maxHistory={3} />,
+    );
+    await hookRef!.resolve();
+
+    rerender(
+      <RouterConsumer path="/third" description="Third description" kind="router" maxHistory={2} />,
+    );
+    const resolved = await hookRef!.resolve();
+    expect(resolved.kind).toBe('router');
+    expect(resolved.description).toBe('Third description');
+    expect(
+      (resolved.data as { history: AskableNavigationEntry[] }).history.map((entry) => entry.path),
+    ).toEqual(['/third', '/second']);
+    expect(registerSpy).toHaveBeenCalledTimes(1);
     ctx.destroy();
   });
 

--- a/packages/react/src/useAskableNavigationSource.ts
+++ b/packages/react/src/useAskableNavigationSource.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { createAskableNavigationSource } from '@askable-ui/core';
 import type {
   AskableCreateNavigationSourceOptions,
@@ -7,6 +7,8 @@ import type {
 import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
 
 export type { AskableNavigationEntry };
+
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 export interface UseAskableNavigationSourceOptions
   extends UseAskableSourceOptions,
@@ -74,17 +76,37 @@ export function useAskableNavigationSource(
     events,
   } = options;
 
+  const sourceOptionsRef = useRef<AskableCreateNavigationSourceOptions>({
+    getPath,
+    getTitle,
+    getParams,
+    maxHistory,
+    describe,
+    kind,
+  });
+
+  useIsomorphicLayoutEffect(() => {
+    Object.assign(sourceOptionsRef.current, {
+      getPath,
+      getTitle,
+      getParams,
+      maxHistory,
+      describe,
+      kind,
+    });
+  }, [getPath, getTitle, getParams, maxHistory, describe, kind]);
+
   const source = useMemo(
-    () => createAskableNavigationSource({ getPath, getTitle, getParams, maxHistory, describe, kind }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    () => createAskableNavigationSource(sourceOptionsRef.current),
     [],
   );
 
   const result = useAskableSource(id, source, { enabled, ctx, name, events });
+  const { notifyChanged } = result;
 
   useEffect(() => {
-    result.notifyChanged();
-  }, [pathname, result]);
+    notifyChanged();
+  }, [pathname, notifyChanged]);
 
   return result;
 }


### PR DESCRIPTION
## Summary

- keep React navigation source callbacks and scalar options synchronized with committed router renders
- preserve navigation history and one source registration when callbacks, `kind`, or `maxHistory` change
- make core navigation sources read mutable options dynamically while retaining state-mode behavior
- add React Router, Next.js, history-preservation, and suspended-render regressions

## Testing

- Core navigation source tests (11 passed)
- React navigation source tests (10 passed)
- Full workspace build
- Full workspace test suite (1,167 passed)
- TypeScript package builds and diff validation

Closes #373
