### PR TITLE
fix(qwik): make hook actions resumable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10173,7 +10173,7 @@
         "vitest": "^4.1.8"
       },
       "peerDependencies": {
-        "@builder.io/qwik": ">=1.0.0"
+        "@builder.io/qwik": ">=1.6.0"
       }
     },
     "packages/qwik/node_modules/@builder.io/qwik": {

--- a/packages/qwik/README.md
+++ b/packages/qwik/README.md
@@ -31,15 +31,30 @@ Use `useAskableAgent()` when a question should be sent with the current UI
 context:
 
 ```tsx
-const agent = useAskableAgent();
+import { $ } from '@builder.io/qwik';
 
-await agent.send('Explain this metric', (request) =>
+const agent = useAskableAgent();
+const handler = $((request) =>
   fetch('/api/ai', {
     method: 'POST',
     body: JSON.stringify(request),
   }).then((response) => response.json()),
 );
+
+await agent.send('Explain this metric', handler);
 ```
+
+Imperative hook actions are QRLs and can be captured directly by `onClick$`.
+Handlers and callback options passed to those actions must also be created with
+`$()`. Synchronous source and context callbacks such as `textExtractor`,
+`sanitizeText`, and router getters use Qwik's `sync$()`; asynchronous callbacks
+such as `sanitizeSource` use `$()`. `sync$()` requires Qwik 1.6 or newer and
+cannot capture lexical state. QRL invocation is asynchronous;
+`await` mutation actions before immediately reading their updated signals.
+
+`streamFrom()` is a runtime-only QRL action: create its `ReadableStream` or
+`AsyncIterable` in the browser event that invokes it. Streams themselves are
+not serialized into the SSR snapshot.
 
 ## API
 
@@ -65,7 +80,7 @@ visible tasks—do not destructure it during component render:
 const askable = useAskable();
 
 // Safe in an event handler after the component is visible.
-const readPrompt = () => askable.ctx.toPromptContext();
+const readPrompt = $(() => askable.ctx.toPromptContext());
 
 // For reactive lifecycle code:
 const ctx = askable.ctxRef.value;

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "peerDependencies": {
-    "@builder.io/qwik": ">=1.0.0"
+    "@builder.io/qwik": ">=1.6.0"
   },
   "dependencies": {
     "@askable-ui/core": "^0.15.0"

--- a/packages/qwik/src/__tests__/lifecycle.test.tsx
+++ b/packages/qwik/src/__tests__/lifecycle.test.tsx
@@ -1,13 +1,31 @@
 // @vitest-environment node
-import { $, component$, noSerialize } from '@builder.io/qwik';
+import { $, component$, noSerialize, sync$, useSignal } from '@builder.io/qwik';
 import { createDOM } from '@builder.io/qwik/testing';
 import { createAskableContext } from '@askable-ui/core';
+import type { AskableAgentRequest, AskableContextSource } from '@askable-ui/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useAskableAgent, type UseAskableAgentResult } from '../useAskableAgent.js';
-import { useAskableChat, type UseAskableChatResult } from '../useAskableChat.js';
+import {
+  useAskableChat,
+  type AskableChatMessage,
+  type AskableChatStreamHandler,
+  type UseAskableChatResult,
+} from '../useAskableChat.js';
 import { useAskableHistory, type UseAskableHistoryResult } from '../useAskableHistory.js';
+import { useAskableNotificationSource } from '../useAskableNotificationSource.js';
+import { useAskableCartSource } from '../useAskableCartSource.js';
+import { useAskableErrorSource } from '../useAskableErrorSource.js';
+import { useAskableMultistepSource } from '../useAskableMultistepSource.js';
+import { useAskableNavigationSource } from '../useAskableNavigationSource.js';
+import { useAskablePageSource } from '../useAskablePageSource.js';
+import { useAskableFormSource } from '../useAskableFormSource.js';
+import { useAskableTableSource } from '../useAskableTableSource.js';
 import { useAskableSource, type UseAskableSourceResult } from '../useAskableSource.js';
-import { useAskableStream, type UseAskableStreamResult } from '../useAskableStream.js';
+import {
+  useAskableStream,
+  type AskableStreamHandler,
+  type UseAskableStreamResult,
+} from '../useAskableStream.js';
 
 async function waitForMountedContext(result: { ctx: unknown }, expected: unknown): Promise<void> {
   await vi.waitFor(() => expect(result.ctx).toBe(expected));
@@ -34,8 +52,26 @@ describe('Qwik hook lifecycle', () => {
     })).resolves.toBe('answer');
   });
 
+  it('reconstructs QRL context callbacks forwarded through specialized hooks', async () => {
+    const holder: { stream?: UseAskableStreamResult } = {};
+    const Consumer = component$(() => {
+      holder.stream = useAskableStream({
+        sanitizeText: sync$((text) => `safe:${text}`),
+      });
+      return <div>ready</div>;
+    });
+
+    const { render, screen } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await vi.waitFor(() => expect(holder.stream!.ctx).toBeDefined());
+
+    holder.stream!.ctx.push({ field: 'note' }, 'private');
+    expect(holder.stream!.ctx.getFocus()?.text).toBe('safe:private');
+  });
+
   it('resolves the mounted context when stream and chat actions run', async () => {
-    const provided = noSerialize(createAskableContext());
+    const provided = noSerialize(createAskableContext())!;
     const holder: {
       stream?: UseAskableStreamResult;
       chat?: UseAskableChatResult;
@@ -65,7 +101,7 @@ describe('Qwik hook lifecycle', () => {
   });
 
   it('registers source and history hooks against the mounted context', async () => {
-    const provided = noSerialize(createAskableContext());
+    const provided = noSerialize(createAskableContext())!;
     const holder: {
       history?: UseAskableHistoryResult;
       source?: UseAskableSourceResult;
@@ -114,7 +150,7 @@ describe('Qwik hook lifecycle', () => {
   });
 
   it('uses the mounted shared lifecycle for agent requests', async () => {
-    const provided = noSerialize(createAskableContext());
+    const provided = noSerialize(createAskableContext())!;
     const holder: { agent?: UseAskableAgentResult<string> } = {};
     const Consumer = component$(() => {
       holder.agent = useAskableAgent<string>({ ctx: provided });
@@ -128,6 +164,635 @@ describe('Qwik hook lifecycle', () => {
     await waitForMountedContext(holder.agent!, provided);
     await expect(holder.agent!.send('question', async () => 'answer')).resolves.toBe('answer');
     expect(holder.agent!.data.value).toBe('answer');
+  });
+
+  it('executes stream actions from an optimizer-generated event QRL', async () => {
+    const Consumer = component$(() => {
+      const stream = useAskableStream();
+      const handler = $(async (
+        _request: AskableAgentRequest,
+        emit: (chunk: string) => void,
+      ) => emit('answer'));
+      return (
+        <>
+          <button onClick$={() => stream.stream('question', handler)}>Run stream</button>
+          <output>{stream.content.value}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await userEvent('button', 'click');
+
+    await vi.waitFor(() => expect(screen.querySelector('output')?.textContent).toBe('answer'));
+  });
+
+  it('invokes resumable stream callbacks from an event action', async () => {
+    const Consumer = component$(() => {
+      const events = useSignal('');
+      const stream = useAskableStream({
+        onRequest: $((request) => ({
+          ...request,
+          question: `${request.question}!`,
+        })),
+        onChunk: $((chunk, content) => {
+          events.value += `chunk:${chunk}:${content};`;
+        }),
+        onSuccess: $((content) => {
+          events.value += `success:${content}`;
+        }),
+      });
+      const handler = $(async (
+        request: AskableAgentRequest,
+        emit: (chunk: string) => void,
+      ) => emit(request.question));
+      return (
+        <>
+          <button onClick$={() => stream.stream('question', handler)}>Run</button>
+          <output id="callback-content">{stream.content.value}</output>
+          <output id="callback-events">{events.value}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await userEvent('button', 'click');
+
+    await vi.waitFor(() => {
+      expect(screen.querySelector('#callback-content')?.textContent).toBe('question!');
+      expect(screen.querySelector('#callback-events')?.textContent)
+        .toBe('chunk:question!:question!;success:question!');
+    });
+  });
+
+  it('executes chat actions from an optimizer-generated event QRL', async () => {
+    const Consumer = component$(() => {
+      const chat = useAskableChat();
+      const handler = $(async (
+        _request: AskableAgentRequest,
+        _messages: AskableChatMessage[],
+        emit: (chunk: string) => void,
+      ) => emit('reply'));
+      return (
+        <>
+          <button onClick$={() => chat.append('question', handler)}>Run chat</button>
+          <output>{chat.messages.value.at(-1)?.content}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await userEvent('button', 'click');
+
+    await vi.waitFor(() => expect(screen.querySelector('output')?.textContent).toBe('reply'));
+  });
+
+  it('keeps stream ownership with the newest overlapping preflight', async () => {
+    const provided = noSerialize(createAskableContext())!;
+    const toAgentRequest = provided.toAgentRequest.bind(provided);
+    provided.toAgentRequest = async (question, requestOptions) => {
+      await new Promise((resolve) => setTimeout(resolve, question === 'first' ? 30 : 1));
+      return toAgentRequest(question, requestOptions);
+    };
+    const holder: { stream?: UseAskableStreamResult } = {};
+    const Consumer = component$(() => {
+      holder.stream = useAskableStream({ ctx: provided });
+      return <div>ready</div>;
+    });
+
+    const { render, screen } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await waitForMountedContext(holder.stream!, provided);
+
+    const handler = (async (
+      request: AskableAgentRequest,
+      emit: (chunk: string) => void,
+    ) => emit(request.question)) as unknown as AskableStreamHandler;
+    const first = holder.stream!.stream('first', handler);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = holder.stream!.stream('second', handler);
+    await Promise.all([first, second]);
+
+    expect(holder.stream!.content.value).toBe('second');
+    expect(holder.stream!.lastRequest.value?.question).toBe('second');
+    expect(holder.stream!.status.value).toBe('success');
+    expect(holder.stream!.isStreaming.value).toBe(false);
+  });
+
+  it('suppresses a stale stream result when onSuccess starts a replacement', async () => {
+    const provided = noSerialize(createAskableContext())!;
+    const holder: {
+      stream?: UseAskableStreamResult;
+      successStarted?: ReturnType<typeof useSignal<boolean>>;
+    } = {};
+    const Consumer = component$(() => {
+      const successStarted = useSignal(false);
+      holder.successStarted = successStarted;
+      holder.stream = useAskableStream({
+        ctx: provided,
+        onSuccess: $(async (result) => {
+          if (result !== 'first') return;
+          successStarted.value = true;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }),
+      });
+      return <div>ready</div>;
+    });
+
+    const { render, screen } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await waitForMountedContext(holder.stream!, provided);
+
+    const handler = (async (
+      request: AskableAgentRequest,
+      emit: (chunk: string) => void,
+    ) => emit(request.question)) as unknown as AskableStreamHandler;
+    const first = holder.stream!.stream('first', handler);
+    await vi.waitFor(() => expect(holder.successStarted?.value).toBe(true));
+    const second = holder.stream!.stream('second', handler);
+
+    await expect(second).resolves.toBe('second');
+    await expect(first).resolves.toBeUndefined();
+    expect(holder.stream!.content.value).toBe('second');
+  });
+
+  it('preserves stream abort and reset behavior with QRL actions', async () => {
+    const holder: { stream?: UseAskableStreamResult } = {};
+    const Consumer = component$(() => {
+      holder.stream = useAskableStream();
+      return <div>ready</div>;
+    });
+
+    const { render, screen } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await vi.waitFor(() => expect(holder.stream!.ctx).toBeDefined());
+    const stream = holder.stream!;
+
+    const delayedHandler = (async (
+      _request: AskableAgentRequest,
+      emit: (chunk: string) => void,
+      signal: AbortSignal,
+    ) => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      if (!signal.aborted) emit('late');
+    }) as unknown as AskableStreamHandler;
+    const pending = stream.stream('question', delayedHandler);
+    await vi.waitFor(() => expect(stream.isStreaming.value).toBe(true));
+    await stream.abort();
+    await pending;
+
+    expect(stream.content.value).toBe('');
+    expect(stream.status.value).toBe('idle');
+    expect(stream.isStreaming.value).toBe(false);
+
+    const immediateHandler = (
+      (_request: AskableAgentRequest, emit: (chunk: string) => void) => emit('answer')
+    ) as unknown as AskableStreamHandler;
+    await stream.stream('again', immediateHandler);
+    expect(stream.content.value).toBe('answer');
+    await stream.reset();
+    expect(stream.content.value).toBe('');
+    expect(stream.status.value).toBe('idle');
+    expect(stream.lastRequest.value).toBeNull();
+  });
+
+  it('propagates chat abort and suppresses stale chunks', async () => {
+    const Consumer = component$(() => {
+      const chat = useAskableChat();
+      const handler = $(async (
+        _request: AskableAgentRequest,
+        _messages: AskableChatMessage[],
+        emit: (chunk: string) => void,
+        signal: AbortSignal,
+      ) => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        if (!signal.aborted) emit('late');
+      });
+      return (
+        <>
+          <button id="append" onClick$={() => { void chat.append('question', handler); }}>Append</button>
+          <button id="abort" onClick$={() => { void chat.abort(); }}>Abort</button>
+          <output id="message">{chat.messages.value.at(-1)?.content}</output>
+          <output id="chat-status">{chat.status.value}:{String(chat.isStreaming.value)}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await userEvent('#append', 'click');
+    await userEvent('#abort', 'click');
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(screen.querySelector('#message')?.textContent).toBe('');
+    expect(screen.querySelector('#chat-status')?.textContent).toBe('idle:false');
+  });
+
+  it('keeps chat messages owned by the newest overlapping preflight', async () => {
+    const provided = noSerialize(createAskableContext())!;
+    const toAgentRequest = provided.toAgentRequest.bind(provided);
+    provided.toAgentRequest = async (question, requestOptions) => {
+      await new Promise((resolve) => setTimeout(resolve, question === 'first' ? 30 : 1));
+      return toAgentRequest(question, requestOptions);
+    };
+    const holder: { chat?: UseAskableChatResult } = {};
+    const Consumer = component$(() => {
+      holder.chat = useAskableChat({ ctx: provided });
+      return <div>ready</div>;
+    });
+
+    const { render } = await createDOM();
+    await render(<Consumer />);
+    await waitForMountedContext(holder.chat!, provided);
+
+    const handler = (async function chatHandler(
+      request: AskableAgentRequest,
+      _messages: AskableChatMessage[],
+      emit: (chunk: string) => void,
+    ) {
+      emit(request.question);
+    }) as unknown as AskableChatStreamHandler;
+    const first = holder.chat!.append('first', handler);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = holder.chat!.append('second', handler);
+    await Promise.all([first, second]);
+
+    expect(holder.chat!.messages.value.map(({ role, content }) => ({ role, content })))
+      .toEqual([
+        { role: 'user', content: 'second' },
+        { role: 'assistant', content: 'second' },
+      ]);
+    expect(holder.chat!.status.value).toBe('idle');
+    expect(holder.chat!.isStreaming.value).toBe(false);
+  });
+
+  it('handles stream and chat preflight failures without invoking transports', async () => {
+    const provided = noSerialize(createAskableContext())!;
+    provided.toAgentRequest = async () => {
+      throw new Error('preflight failed');
+    };
+    const holder: {
+      stream?: UseAskableStreamResult;
+      chat?: UseAskableChatResult;
+    } = {};
+    const Consumer = component$(() => {
+      holder.stream = useAskableStream({ ctx: provided });
+      holder.chat = useAskableChat({ ctx: provided });
+      return <div>ready</div>;
+    });
+
+    const { render } = await createDOM();
+    await render(<Consumer />);
+    await waitForMountedContext(holder.stream!, provided);
+    await waitForMountedContext(holder.chat!, provided);
+
+    const streamHandler = (() => {
+      throw new Error('stream handler must not run');
+    }) as unknown as AskableStreamHandler;
+    const chatHandler = (() => {
+      throw new Error('chat handler must not run');
+    }) as unknown as AskableChatStreamHandler;
+
+    await expect(holder.stream!.stream('question', streamHandler)).resolves.toBeUndefined();
+    await expect(holder.chat!.append('question', chatHandler)).resolves.toBeUndefined();
+
+    expect(holder.stream!.status.value).toBe('error');
+    expect(holder.stream!.error.value).toEqual(new Error('preflight failed'));
+    expect(holder.stream!.isStreaming.value).toBe(false);
+    expect(holder.chat!.messages.value).toEqual([]);
+    expect(holder.chat!.status.value).toBe('error');
+    expect(holder.chat!.error.value).toEqual(new Error('preflight failed'));
+    expect(holder.chat!.isStreaming.value).toBe(false);
+  });
+
+  it('aborts active stream and chat handlers when their component unmounts', async () => {
+    const holder: {
+      stream?: UseAskableStreamResult;
+      chat?: UseAskableChatResult;
+    } = {};
+    const signals: AbortSignal[] = [];
+    const Consumer = component$(() => {
+      holder.stream = useAskableStream();
+      holder.chat = useAskableChat();
+      return <div>ready</div>;
+    });
+
+    const { render, screen } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    const rendered = await render(<Consumer />);
+    await vi.waitFor(() => {
+      expect(holder.stream!.ctx).toBeDefined();
+      expect(holder.chat!.ctx).toBeDefined();
+    });
+
+    const streamHandler = (async function streamCleanupHandler(
+      _request: AskableAgentRequest,
+      _emit: (chunk: string) => void,
+      signal: AbortSignal,
+    ) {
+      signals.push(signal);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }) as unknown as AskableStreamHandler;
+    const chatHandler = (async function chatCleanupHandler(
+      _request: AskableAgentRequest,
+      _messages: AskableChatMessage[],
+      _emit: (chunk: string) => void,
+      signal: AbortSignal,
+    ) {
+      signals.push(signal);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }) as unknown as AskableChatStreamHandler;
+
+    const streamPending = holder.stream!.stream('stream', streamHandler);
+    const chatPending = holder.chat!.append('chat', chatHandler);
+    await vi.waitFor(() => expect(signals).toHaveLength(2));
+    rendered.cleanup();
+
+    await vi.waitFor(() => {
+      expect(signals.every((signal) => signal.aborted)).toBe(true);
+    });
+    await Promise.all([streamPending, chatPending]);
+  });
+
+  it('prevents late async source factories from registering after unregister', async () => {
+    const provided = noSerialize(createAskableContext())!;
+    const holder: {
+      source?: UseAskableSourceResult;
+      started?: ReturnType<typeof useSignal<boolean>>;
+    } = {};
+    const Consumer = component$(() => {
+      const started = useSignal(false);
+      holder.started = started;
+      holder.source = useAskableSource(
+        'delayed',
+        $(async () => {
+          started.value = true;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          return { resolve: () => ({ ready: true }) };
+        }),
+        { ctx: provided },
+      );
+      return <div>ready</div>;
+    });
+
+    const { render } = await createDOM();
+    await render(<Consumer />);
+    await vi.waitFor(() => expect(holder.started?.value).toBe(true));
+    await holder.source!.unregister();
+    await new Promise((resolve) => setTimeout(resolve, 75));
+
+    expect(provided.hasSource('delayed')).toBe(false);
+  });
+
+  it('executes generic source actions from an optimizer-generated event QRL', async () => {
+    const Consumer = component$(() => {
+      const resolved = useSignal('');
+      const source = useAskableSource(
+        'orders',
+        $(() => ({ resolve: () => ({ count: 2 }) })),
+      );
+      return (
+        <>
+          <button onClick$={async () => {
+            const value = await source.resolve();
+            resolved.value = String((value.data as { count: number }).count);
+          }}>Resolve source</button>
+          <output>{resolved.value}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await vi.waitFor(() => expect(screen.ownerDocument.body.textContent).toContain('Resolve source'));
+    await userEvent('button', 'click');
+
+    await vi.waitFor(() => expect(screen.querySelector('output')?.textContent).toBe('2'));
+  });
+
+  it('executes source-helper actions from an optimizer-generated event QRL', async () => {
+    const Consumer = component$(() => {
+      const notifications = useAskableNotificationSource();
+      return (
+        <>
+          <button onClick$={() => notifications.push({
+            message: 'Saved',
+            severity: 'success',
+          })}>Push notification</button>
+          <output>{notifications.notifications.value[0]?.message}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await userEvent('button', 'click');
+
+    await vi.waitFor(() => expect(screen.querySelector('output')?.textContent).toBe('Saved'));
+  });
+
+  it('executes agent actions from an optimizer-generated event QRL', async () => {
+    const Consumer = component$(() => {
+      const agent = useAskableAgent<string>();
+      const handler = $((_request: AskableAgentRequest) => 'answer');
+      return (
+        <>
+          <button onClick$={() => agent.send('question', handler)}>Run agent</button>
+          <output>{agent.data.value}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await userEvent('button', 'click');
+
+    await vi.waitFor(() => expect(screen.querySelector('output')?.textContent).toBe('answer'));
+  });
+
+  it('executes all mutable source-helper actions from event QRLs', async () => {
+    const Consumer = component$(() => {
+      const cart = useAskableCartSource();
+      const errors = useAskableErrorSource();
+      const steps = useAskableMultistepSource({
+        steps: [{ id: 'one', label: 'One' }, { id: 'two', label: 'Two' }],
+      });
+      return (
+        <>
+          <button id="cart" onClick$={() => cart.addItem({
+            id: 'sku',
+            name: 'Item',
+            price: 10,
+            quantity: 1,
+          })}>Add cart item</button>
+          <button id="error" onClick$={() => errors.addError({
+            key: 'email',
+            message: 'Required',
+          })}>Add error</button>
+          <button id="step" onClick$={() => steps.next()}>Next step</button>
+          <output id="cart-output">{cart.snapshot.value?.itemCount}</output>
+          <output id="error-output">{errors.errors.value[0]?.message}</output>
+          <output id="step-output">{steps.snapshot.value?.currentIndex}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await userEvent('#cart', 'click');
+    await userEvent('#error', 'click');
+    await userEvent('#step', 'click');
+
+    await vi.waitFor(() => {
+      expect(screen.querySelector('#cart-output')?.textContent).toBe('1');
+      expect(screen.querySelector('#error-output')?.textContent).toBe('Required');
+      expect(screen.querySelector('#step-output')?.textContent).toBe('1');
+    });
+  });
+
+  it('preserves direct page roots and form factories for client-only mounts', async () => {
+    const holder: {
+      page?: ReturnType<typeof useAskablePageSource>;
+      form?: ReturnType<typeof useAskableFormSource>;
+      factoryForm?: ReturnType<typeof useAskableFormSource>;
+    } = {};
+    const Consumer = component$(() => {
+      const pageValue = useSignal('');
+      const formValue = useSignal('');
+      const page = useAskablePageSource({
+        root: document.body,
+        textExtractor: sync$((root) => root.textContent ?? ''),
+      });
+      const directForm = document.createElement('form');
+      const form = useAskableFormSource({ form: directForm });
+      const factoryForm = useAskableFormSource({
+        id: 'factory-form',
+        form: () => undefined,
+      });
+      holder.page = page;
+      holder.form = form;
+      holder.factoryForm = factoryForm;
+      return (
+        <>
+          <article>Client root content</article>
+          <button id="resolve-client-sources" onClick$={async () => {
+            const pageResult = await page.resolve({ mode: 'all' });
+            pageValue.value = String((pageResult.data as { text?: string }).text?.includes('Client root content'));
+            formValue.value = String(form.ctx.hasSource('form'));
+          }}>Resolve client sources</button>
+          <output id="page-client-output">{pageValue.value}</output>
+          <output id="form-client-output">{formValue.value}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    await render(<Consumer />);
+    await vi.waitFor(() => {
+      expect(holder.page!.ctx.hasSource('page')).toBe(true);
+      expect(holder.form!.ctx.hasSource('form')).toBe(true);
+      expect(holder.factoryForm!.ctx.hasSource('factory-form')).toBe(true);
+    });
+    await userEvent('#resolve-client-sources', 'click');
+
+    await vi.waitFor(() => {
+      expect(screen.querySelector('#page-client-output')?.textContent).toBe('true');
+      expect(screen.querySelector('#form-client-output')?.textContent).toBe('true');
+    });
+  });
+
+  it('reconstructs stateless source helpers from QRL factories', async () => {
+    const Consumer = component$(() => {
+      const navigationValue = useSignal('');
+      const tableValue = useSignal('');
+      const navigation = useAskableNavigationSource({
+        getPath: sync$(() => '/resumed'),
+      });
+      const table = useAskableTableSource({
+        rows: $(() => Array.from({ length: 101 }, (_, index) => ({ id: `row-${index}` }))),
+      });
+      return (
+        <>
+          <button id="navigation" onClick$={async () => {
+            const value = await navigation.resolve();
+            navigationValue.value = String((value.data as { currentPath: string }).currentPath);
+          }}>Resolve navigation</button>
+          <button id="table" onClick$={async () => {
+            const value = await table.resolve({ mode: 'all' });
+            const data = value.data as { items?: Array<{ id: string }> };
+            tableValue.value = `${data.items?.[0]?.id ?? ''}:${data.items?.length ?? 0}`;
+          }}>Resolve table</button>
+          <output id="navigation-output">{navigationValue.value}</output>
+          <output id="table-output">{tableValue.value}</output>
+        </>
+      );
+    });
+
+    const { render, screen, userEvent } = await createDOM();
+    vi.stubGlobal('document', screen.ownerDocument);
+    vi.stubGlobal('window', screen.ownerDocument.defaultView);
+    await render(<Consumer />);
+    await vi.waitFor(() => expect(screen.ownerDocument.body.textContent).toContain('Resolve table'));
+    await userEvent('#navigation', 'click');
+    await userEvent('#table', 'click');
+
+    await vi.waitFor(() => {
+      expect(screen.querySelector('#navigation-output')?.textContent).toBe('/resumed');
+      expect(screen.querySelector('#table-output')?.textContent).toBe('row-0:100');
+    });
+  });
+
+  // Keep this teardown assertion last: Qwik's createDOM cleanup closes its
+  // render scheduler and intentionally cannot be followed by another render.
+  it('unregisters a source exactly once across manual release and cleanup', async () => {
+    const provided = noSerialize(createAskableContext())!;
+    const unregister = vi.fn();
+    const registerSource = provided.registerSource.bind(provided);
+    vi.spyOn(provided, 'registerSource').mockImplementation((
+      id: string,
+      source: AskableContextSource,
+    ) => {
+      const handle = registerSource(id, source);
+      return {
+        ...handle,
+        unregister: () => {
+          unregister();
+          handle.unregister();
+        },
+      };
+    });
+    const holder: { source?: UseAskableSourceResult } = {};
+    const Consumer = component$(() => {
+      holder.source = useAskableSource(
+        'once',
+        $(() => ({ resolve: () => ({ ready: true }) })),
+        { ctx: provided },
+      );
+      return <div>ready</div>;
+    });
+
+    const { render } = await createDOM();
+    const rendered = await render(<Consumer />);
+    await vi.waitFor(() => expect(provided.hasSource('once')).toBe(true));
+    await holder.source!.unregister();
+    rendered.cleanup();
+
+    expect(unregister).toHaveBeenCalledTimes(1);
   });
 
 });

--- a/packages/qwik/src/__tests__/useAskableSource.test.ts
+++ b/packages/qwik/src/__tests__/useAskableSource.test.ts
@@ -9,6 +9,7 @@ const state = vi.hoisted(() => ({
 }));
 
 vi.mock('@builder.io/qwik', () => ({
+  $: <T>(value: T) => value,
   noSerialize: <T>(value: T) => value,
   useSignal: <T>(value?: T) => ({ value }),
   useVisibleTask$: (

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -9,7 +9,7 @@ export { useAskableSource } from './useAskableSource.js';
 export type { AskableContextSourceFactory, UseAskableSourceOptions, UseAskableSourceResult } from './useAskableSource.js';
 
 export { useAskableAgent } from './useAskableAgent.js';
-export type { AskableAgentStatus, UseAskableAgentOptions, UseAskableAgentResult } from './useAskableAgent.js';
+export type { AskableAgentStatus, AskableAgentHandler, UseAskableAgentOptions, UseAskableAgentResult } from './useAskableAgent.js';
 
 export { useAskableStream } from './useAskableStream.js';
 export type { AskableStreamStatus, AskableStreamHandler, UseAskableStreamOptions, UseAskableStreamResult } from './useAskableStream.js';

--- a/packages/qwik/src/useAskable.ts
+++ b/packages/qwik/src/useAskable.ts
@@ -1,14 +1,21 @@
 import { noSerialize, useSignal, useVisibleTask$ } from '@builder.io/qwik';
-import type { NoSerialize, QRL } from '@builder.io/qwik';
+import type { NoSerialize, QRL, SyncQRL } from '@builder.io/qwik';
 import { createAskableContext } from '@askable-ui/core';
 import type { AskableContext, AskableContextOptions, AskableEvent, AskableFocus } from '@askable-ui/core';
 import type { AskableContextRef } from './contextRef.js';
 
-export interface UseAskableOptions extends AskableContextOptions {
+export interface UseAskableOptions extends Omit<
+  AskableContextOptions,
+  'textExtractor' | 'sanitizeMeta' | 'sanitizeText' | 'sanitizeSource'
+> {
   events?: AskableEvent[];
   ctx?: AskableContext;
   /** Resume-safe factory for a hook-owned browser context. */
   ctx$?: QRL<() => AskableContext | Promise<AskableContext>>;
+  textExtractor?: SyncQRL<NonNullable<AskableContextOptions['textExtractor']>>;
+  sanitizeMeta?: SyncQRL<NonNullable<AskableContextOptions['sanitizeMeta']>>;
+  sanitizeText?: SyncQRL<NonNullable<AskableContextOptions['sanitizeText']>>;
+  sanitizeSource?: QRL<NonNullable<AskableContextOptions['sanitizeSource']>>;
 }
 
 export interface UseAskableResult {
@@ -20,6 +27,15 @@ export interface UseAskableResult {
 }
 
 const DEFAULT_EVENTS: AskableEvent[] = ['click', 'hover', 'focus'];
+type ResolvedUseAskableOptions = AskableContextOptions & Pick<UseAskableOptions, 'events'>;
+
+function resolveQrlOrFunction<T extends (...args: any[]) => any>(
+  value: QRL<T> | T | undefined,
+): T | Promise<T> | undefined {
+  return value && 'resolve' in value && typeof value.resolve === 'function'
+    ? value.resolve()
+    : value as T | undefined;
+}
 
 // Module-level cache so all hooks in the same page share one default context
 const globalCtxByKey = new Map<string, AskableContext>();
@@ -43,13 +59,13 @@ function requiresPrivateContext(options?: UseAskableOptions): boolean {
   );
 }
 
-function createAdapterContext(options?: UseAskableOptions): AskableContext {
+function createAdapterContext(options?: ResolvedUseAskableOptions): AskableContext {
   if (!options?.name) return createAskableContext(options);
   const { name: _name, ...contextOptions } = options;
   return createAskableContext(contextOptions);
 }
 
-function retainCtx(key: string, options?: UseAskableOptions): AskableContext {
+function retainCtx(key: string, options?: ResolvedUseAskableOptions): AskableContext {
   const existing = globalCtxByKey.get(key);
   if (existing) {
     globalRefCount.set(key, (globalRefCount.get(key) ?? 0) + 1);
@@ -97,7 +113,15 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
   const usePrivateCtx = !usesProvidedCtx && !usesContextFactory && requiresPrivateContext(options);
   const providedCtx = options?.ctx ? noSerialize(options.ctx) : undefined;
   const providedCtxFactory = options?.ctx$;
-  const { ctx: _providedCtx, ctx$: _providedCtxFactory, ...contextOptions } = options ?? {};
+  const {
+    ctx: _providedCtx,
+    ctx$: _providedCtxFactory,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    ...contextOptions
+  } = options ?? {};
 
   const key = sharedKey(options);
 
@@ -131,13 +155,42 @@ export function useAskable(options?: UseAskableOptions): UseAskableResult {
     });
 
     try {
+      const callbackValues = [
+        resolveQrlOrFunction(textExtractor),
+        resolveQrlOrFunction(sanitizeMeta),
+        resolveQrlOrFunction(sanitizeText),
+        resolveQrlOrFunction(sanitizeSource),
+      ] as const;
+      const resolvedCallbacks = (callbackValues.some(
+        (value) => value && typeof (value as Promise<unknown>).then === 'function',
+      )
+        ? await Promise.all(callbackValues)
+        : callbackValues) as [
+          AskableContextOptions['textExtractor'],
+          AskableContextOptions['sanitizeMeta'],
+          AskableContextOptions['sanitizeText'],
+          AskableContextOptions['sanitizeSource'],
+        ];
+      const [
+        resolvedTextExtractor,
+        resolvedSanitizeMeta,
+        resolvedSanitizeText,
+        resolvedSanitizeSource,
+      ] = resolvedCallbacks;
+      const resolvedContextOptions = {
+        ...contextOptions,
+        textExtractor: resolvedTextExtractor,
+        sanitizeMeta: resolvedSanitizeMeta,
+        sanitizeText: resolvedSanitizeText,
+        sanitizeSource: resolvedSanitizeSource,
+      };
       ctx = usesProvidedCtx
         ? providedCtx
         : usesContextFactory
           ? await providedCtxFactory!()
           : usePrivateCtx
-            ? createAdapterContext(contextOptions)
-            : retainCtx(key, contextOptions);
+            ? createAdapterContext(resolvedContextOptions)
+            : retainCtx(key, resolvedContextOptions);
     } catch (error) {
       if (disposed) return;
       throw error;

--- a/packages/qwik/src/useAskableAgent.ts
+++ b/packages/qwik/src/useAskableAgent.ts
@@ -1,10 +1,12 @@
 import { useSignal, $ } from '@builder.io/qwik';
+import type { QRL } from '@builder.io/qwik';
 import type {
   AskableAgentRequest,
   AskableAgentRequestOptions,
   AskableContext,
 } from '@askable-ui/core';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
+import type { AskableContextRef } from './contextRef.js';
 
 export type AskableAgentStatus = 'idle' | 'pending' | 'success' | 'error';
 
@@ -12,14 +14,20 @@ export interface UseAskableAgentOptions extends UseAskableOptions {
   requestOptions?: AskableAgentRequestOptions;
 }
 
+export type AskableAgentHandler<T> = QRL<
+  (request: AskableAgentRequest) => T | Promise<T>
+>;
+
 export interface UseAskableAgentResult<T = unknown> {
   status: ReturnType<typeof useSignal<AskableAgentStatus>>;
   data: ReturnType<typeof useSignal<T | null>>;
   error: ReturnType<typeof useSignal<unknown>>;
   isLoading: ReturnType<typeof useSignal<boolean>>;
   lastRequest: ReturnType<typeof useSignal<AskableAgentRequest | null>>;
-  send: (question: string, handler: (request: AskableAgentRequest) => T | Promise<T>) => Promise<T | undefined>;
-  reset: () => void;
+  send: QRL<(question: string, handler: AskableAgentHandler<T>) => Promise<T | undefined>>;
+  reset: QRL<() => void>;
+  /** Stable resumable reference populated when the browser lifecycle mounts. */
+  ctxRef: AskableContextRef;
   ctx: AskableContext;
 }
 
@@ -29,18 +37,19 @@ export interface UseAskableAgentResult<T = unknown> {
  *
  * @example
  * ```tsx
- * import { component$ } from '@builder.io/qwik';
+ * import { $, component$ } from '@builder.io/qwik';
  * import { useAskableAgent } from '@askable-ui/qwik';
  *
  * export const AskButton = component$(() => {
  *   const { send, isLoading } = useAskableAgent();
+ *   const sendRequest = $(async (req) =>
+ *     fetch('/api/ai', { method: 'POST', body: JSON.stringify(req) }).then(r => r.json())
+ *   );
  *
  *   return (
- *     <button disabled={isLoading.value} onClick$={$(() =>
- *       send('What is this?', async (req) =>
- *         fetch('/api/ai', { method: 'POST', body: JSON.stringify(req) }).then(r => r.json())
- *       )
- *     )}>
+ *     <button disabled={isLoading.value} onClick$={() =>
+ *       send('What is this?', sendRequest)
+ *     }>
  *       {isLoading.value ? 'Thinking…' : 'Ask AI'}
  *     </button>
  *   );
@@ -61,7 +70,7 @@ export function useAskableAgent<T = unknown>(
 
   const send = $(async (
     question: string,
-    handler: (request: AskableAgentRequest) => T | Promise<T>,
+    handler: AskableAgentHandler<T>,
   ): Promise<T | undefined> => {
     const ctx = ctxRef.value;
     if (!ctx) return undefined;
@@ -103,6 +112,7 @@ export function useAskableAgent<T = unknown>(
     lastRequest,
     send,
     reset,
+    ctxRef,
     get ctx() { return ctxRef.value!; },
   };
 }

--- a/packages/qwik/src/useAskableCartSource.ts
+++ b/packages/qwik/src/useAskableCartSource.ts
@@ -1,4 +1,5 @@
-import { useSignal } from '@builder.io/qwik';
+import { $, useSignal } from '@builder.io/qwik';
+import type { QRL, SyncQRL } from '@builder.io/qwik';
 import { createAskableCartSource, buildCartSnapshot } from '@askable-ui/core';
 import type {
   AskableCreateCartSourceOptions,
@@ -6,95 +7,161 @@ import type {
   AskableCartSourceSnapshot,
   AskableCartTotals,
 } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+import {
+  useAskableSource,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
 
 export type { AskableCartItem, AskableCartSourceSnapshot, AskableCartTotals };
 
 export interface UseAskableCartSourceOptions
   extends UseAskableSourceOptions,
-    Omit<AskableCreateCartSourceOptions, 'getSnapshot'> {
+    Omit<AskableCreateCartSourceOptions, 'describe' | 'getSnapshot'> {
   id?: string;
   items?: AskableCartItem[];
   totals?: AskableCartTotals;
+  /** Resume-safe synchronous source description callback. */
+  describe?: SyncQRL<NonNullable<AskableCreateCartSourceOptions['describe']>>;
 }
 
 export interface UseAskableCartSourceResult extends UseAskableSourceResult {
   snapshot: ReturnType<typeof useSignal<AskableCartSourceSnapshot | null>>;
-  addItem(item: AskableCartItem): void;
-  removeItem(id: string): void;
-  updateQuantity(id: string, quantity: number): void;
-  setItems(items: AskableCartItem[]): void;
-  setTotals(totals: AskableCartTotals): void;
-  clearCart(): void;
+  addItem: QRL<(item: AskableCartItem) => Promise<void>>;
+  removeItem: QRL<(id: string) => Promise<void>>;
+  updateQuantity: QRL<(id: string, quantity: number) => Promise<void>>;
+  setItems: QRL<(items: AskableCartItem[]) => Promise<void>>;
+  setTotals: QRL<(totals: AskableCartTotals) => Promise<void>>;
+  clearCart: QRL<() => Promise<void>>;
 }
 
-/**
- * Qwik hook that tracks shopping cart state and exposes it to AI assistants.
- *
- * ```tsx
- * export const CartWidget = component$(() => {
- *   const { snapshot, addItem } = useAskableCartSource({
- *     items: [], totals: { currency: 'USD' },
- *   });
- *   return <p>{snapshot.value?.itemCount} items</p>;
- * });
- * ```
- */
-export function useAskableCartSource(options: UseAskableCartSourceOptions = {}): UseAskableCartSourceResult {
-  const { id = 'cart', items: initialItems = [], totals: initialTotals = {}, describe, kind, enabled, ctx, ctx$, name, events } = options;
+function totalsFromSnapshot(snapshot: AskableCartSourceSnapshot | null): AskableCartTotals {
+  return snapshot
+    ? {
+        discount: snapshot.discount,
+        tax: snapshot.tax,
+        shipping: snapshot.shipping,
+        currency: snapshot.currency,
+        couponCode: snapshot.couponCode,
+      }
+    : {};
+}
+
+/** Qwik hook that tracks shopping cart state and exposes resumable actions. */
+export function useAskableCartSource(
+  options: UseAskableCartSourceOptions = {},
+): UseAskableCartSourceResult {
+  const {
+    id = 'cart',
+    items: initialItems = [],
+    totals: initialTotals = {},
+    describe,
+    kind,
+    enabled,
+    ctx,
+    ctx$,
+    name,
+    events,
+    viewport,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    maxHistory,
+  } = options;
 
   const snapshot = useSignal<AskableCartSourceSnapshot | null>(
     buildCartSnapshot(initialItems, initialTotals, new Date().toISOString()),
   );
+  const sourceFactory = $(async () => createAskableCartSource({
+    describe: await describe?.resolve(),
+    kind,
+    getSnapshot: () => snapshot.value,
+  }));
+  const result = useAskableSource(id, sourceFactory, {
+    enabled, ctx, ctx$, name, events, viewport, textExtractor,
+    sanitizeMeta, sanitizeText, sanitizeSource, maxHistory,
+  });
+  const notifyChanged = result.notifyChanged;
 
-  const source = createAskableCartSource({ describe, kind, getSnapshot: () => snapshot.value });
-  const result = useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+  const addItem = $(async (item: AskableCartItem): Promise<void> => {
+    const previous = snapshot.value;
+    if (!previous) return;
+    const index = previous.items.findIndex((current) => current.id === item.id);
+    const items = index >= 0
+      ? previous.items.map((current, currentIndex) => currentIndex === index ? item : current)
+      : [...previous.items, item];
+    snapshot.value = buildCartSnapshot(
+      items,
+      totalsFromSnapshot(previous),
+      new Date().toISOString(),
+    );
+    await notifyChanged();
+  });
 
-  function getTotals(): AskableCartTotals {
-    const s = snapshot.value;
-    return s ? { discount: s.discount, tax: s.tax, shipping: s.shipping, currency: s.currency, couponCode: s.couponCode } : {};
-  }
+  const removeItem = $(async (itemId: string): Promise<void> => {
+    const previous = snapshot.value;
+    if (!previous) return;
+    snapshot.value = buildCartSnapshot(
+      previous.items.filter((item) => item.id !== itemId),
+      totalsFromSnapshot(previous),
+      new Date().toISOString(),
+    );
+    await notifyChanged();
+  });
 
-  function addItem(item: AskableCartItem): void {
-    const prev = snapshot.value;
-    if (!prev) return;
-    const idx = prev.items.findIndex((i) => i.id === item.id);
-    const items = idx >= 0 ? prev.items.map((i, k) => (k === idx ? item : i)) : [...prev.items, item];
-    snapshot.value = buildCartSnapshot(items, getTotals(), new Date().toISOString());
-    result.notifyChanged();
-  }
-
-  function removeItem(id: string): void {
-    if (!snapshot.value) return;
-    snapshot.value = buildCartSnapshot(snapshot.value.items.filter((i) => i.id !== id), getTotals(), new Date().toISOString());
-    result.notifyChanged();
-  }
-
-  function updateQuantity(id: string, quantity: number): void {
-    if (!snapshot.value) return;
+  const updateQuantity = $(async (itemId: string, quantity: number): Promise<void> => {
+    const previous = snapshot.value;
+    if (!previous) return;
     const items = quantity <= 0
-      ? snapshot.value.items.filter((i) => i.id !== id)
-      : snapshot.value.items.map((i) => (i.id === id ? { ...i, quantity } : i));
-    snapshot.value = buildCartSnapshot(items, getTotals(), new Date().toISOString());
-    result.notifyChanged();
-  }
+      ? previous.items.filter((item) => item.id !== itemId)
+      : previous.items.map((item) => item.id === itemId ? { ...item, quantity } : item);
+    snapshot.value = buildCartSnapshot(
+      items,
+      totalsFromSnapshot(previous),
+      new Date().toISOString(),
+    );
+    await notifyChanged();
+  });
 
-  function setItems(items: AskableCartItem[]): void {
-    snapshot.value = buildCartSnapshot(items, getTotals(), new Date().toISOString());
-    result.notifyChanged();
-  }
+  const setItems = $(async (items: AskableCartItem[]): Promise<void> => {
+    const previous = snapshot.value;
+    snapshot.value = buildCartSnapshot(
+      items,
+      totalsFromSnapshot(previous),
+      new Date().toISOString(),
+    );
+    await notifyChanged();
+  });
 
-  function setTotals(totals: AskableCartTotals): void {
-    if (!snapshot.value) return;
-    snapshot.value = buildCartSnapshot(snapshot.value.items, totals, new Date().toISOString());
-    result.notifyChanged();
-  }
+  const setTotals = $(async (totals: AskableCartTotals): Promise<void> => {
+    const previous = snapshot.value;
+    if (!previous) return;
+    snapshot.value = buildCartSnapshot(
+      previous.items,
+      totals,
+      new Date().toISOString(),
+    );
+    await notifyChanged();
+  });
 
-  function clearCart(): void {
+  const clearCart = $(async (): Promise<void> => {
     const currency = snapshot.value?.currency ?? 'USD';
-    snapshot.value = buildCartSnapshot([], { discount: 0, tax: 0, shipping: 0, currency, couponCode: null }, new Date().toISOString());
-    result.notifyChanged();
-  }
+    snapshot.value = buildCartSnapshot(
+      [],
+      { discount: 0, tax: 0, shipping: 0, currency, couponCode: null },
+      new Date().toISOString(),
+    );
+    await notifyChanged();
+  });
 
-  return { ...result, snapshot, addItem, removeItem, updateQuantity, setItems, setTotals, clearCart };
+  return Object.assign(result, {
+    snapshot,
+    addItem,
+    removeItem,
+    updateQuantity,
+    setItems,
+    setTotals,
+    clearCart,
+  });
 }

--- a/packages/qwik/src/useAskableChat.ts
+++ b/packages/qwik/src/useAskableChat.ts
@@ -1,6 +1,8 @@
-import { useSignal } from '@builder.io/qwik';
+import { $, noSerialize, useSignal, useTask$ } from '@builder.io/qwik';
+import type { NoSerialize, QRL } from '@builder.io/qwik';
 import type { AskableAgentRequest, AskableAgentRequestOptions, AskableContext } from '@askable-ui/core';
 import { getAskableContext } from './contextRef.js';
+import type { AskableContextRef } from './contextRef.js';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
 
 export type AskableChatRole = 'user' | 'assistant' | 'system';
@@ -15,20 +17,20 @@ export interface AskableChatMessage {
 
 export type AskableChatStatus = 'idle' | 'streaming' | 'error';
 
-export type AskableChatStreamHandler = (
+export type AskableChatStreamHandler = QRL<(
   request: AskableAgentRequest,
   messages: AskableChatMessage[],
   emit: (chunk: string) => void,
-) => Promise<void>;
+  signal: AbortSignal,
+) => void | Promise<void>>;
 
-export interface UseAskableChatOptions extends Omit<UseAskableOptions, 'inspector'> {
+export interface UseAskableChatOptions extends UseAskableOptions {
   initialMessages?: AskableChatMessage[];
-  systemPrompt?: string | ((context: string) => string);
-  onChunk?: (chunk: string) => void;
-  onFinish?: (message: AskableChatMessage) => void;
-  onError?: (error: unknown) => void;
+  systemPrompt?: string | QRL<(context: string) => string | Promise<string>>;
+  onChunk?: QRL<(chunk: string) => void | Promise<void>>;
+  onFinish?: QRL<(message: AskableChatMessage) => void | Promise<void>>;
+  onError?: QRL<(error: unknown) => void | Promise<void>>;
   requestOptions?: AskableAgentRequestOptions;
-  ctx?: AskableContext;
 }
 
 export interface UseAskableChatResult {
@@ -36,117 +38,171 @@ export interface UseAskableChatResult {
   status: ReturnType<typeof useSignal<AskableChatStatus>>;
   error: ReturnType<typeof useSignal<unknown>>;
   isStreaming: ReturnType<typeof useSignal<boolean>>;
-  append(content: string, handler: AskableChatStreamHandler): Promise<void>;
-  clearMessages(): void;
-  abort(): void;
+  append: QRL<(content: string, handler: AskableChatStreamHandler) => Promise<void>>;
+  clearMessages: QRL<() => void>;
+  abort: QRL<() => void>;
+  /** Stable resumable reference populated when the browser lifecycle mounts. */
+  ctxRef: AskableContextRef;
   ctx: AskableContext;
 }
 
-let idCounter = 0;
-function nextId() { return `msg-${Date.now()}-${++idCounter}`; }
-
 /**
  * Qwik hook for multi-turn AI chat. Injects the current UI context into every
- * turn automatically.
+ * turn automatically. Handlers and callbacks are QRLs so actions can be used
+ * from resumable Qwik event handlers.
  *
  * ```tsx
  * export const ChatPanel = component$(() => {
- *   const { messages, append, isStreaming } = useAskableChat({
- *     systemPrompt: (ctx) => `You are helpful.\n\n${ctx}`,
+ *   const chat = useAskableChat({
+ *     systemPrompt: 'You are helpful.',
+ *   });
+ *   const handler = $(async (req, messages, emit, signal) => {
+ *     const res = await fetch('/api/chat', {
+ *       method: 'POST',
+ *       body: JSON.stringify({ req, messages }),
+ *       signal,
+ *     });
+ *     const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+ *     while (true) {
+ *       const { done, value } = await reader.read();
+ *       if (done) break;
+ *       emit(value);
+ *     }
  *   });
  *
- *   return (
- *     <>
- *       {messages.value.map((m) => (
- *         <p key={m.id} class={m.role}>{m.content}</p>
- *       ))}
- *       <button onClick$={() => append('Explain this', async (req, msgs, emit) => {
- *         const res = await fetch('/api/chat', { method: 'POST', body: JSON.stringify(req) });
- *         const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
- *         while (true) {
- *           const { done, value } = await reader.read();
- *           if (done) break;
- *           emit(value);
- *         }
- *       })}>Send</button>
- *     </>
- *   );
+ *   return <button onClick$={() => chat.append('Explain this', handler)}>Send</button>;
  * });
  * ```
  */
 export function useAskableChat(options: UseAskableChatOptions = {}): UseAskableChatResult {
-  const { initialMessages = [], systemPrompt, onChunk, onFinish, onError, requestOptions, ...askableOptions } = options;
+  const {
+    initialMessages = [],
+    systemPrompt,
+    onChunk,
+    onFinish,
+    onError,
+    requestOptions,
+    ...askableOptions
+  } = options;
   const { ctxRef } = useAskable(askableOptions);
 
   const messages = useSignal<AskableChatMessage[]>([...initialMessages]);
   const status = useSignal<AskableChatStatus>('idle');
   const error = useSignal<unknown>(null);
   const isStreaming = useSignal(false);
+  const abortControllerRef = useSignal<NoSerialize<AbortController>>();
+  const idCounter = useSignal(0);
 
-  let currentAc: AbortController | null = null;
-  let contentAccum = '';
+  useTask$(({ cleanup }) => {
+    cleanup(() => abortControllerRef.value?.abort());
+  });
 
-  function abort(): void {
-    currentAc?.abort();
-    currentAc = null;
+  const abort = $(() => {
+    abortControllerRef.value?.abort();
+    abortControllerRef.value = undefined;
     isStreaming.value = false;
     status.value = 'idle';
-  }
+  });
 
-  function clearMessages(): void {
+  const clearMessages = $(() => {
+    abortControllerRef.value?.abort();
+    abortControllerRef.value = undefined;
     messages.value = [];
     status.value = 'idle';
     error.value = null;
     isStreaming.value = false;
-  }
+  });
 
-  async function append(content: string, handler: AskableChatStreamHandler): Promise<void> {
-    abort();
-    currentAc = new AbortController();
-
-    const ctx = getAskableContext(ctxRef);
-    const userMsg: AskableChatMessage = { id: nextId(), role: 'user', content, createdAt: Date.now() };
-    messages.value = [...messages.value, userMsg];
-
-    let req = await ctx.toAgentRequest(content, requestOptions);
-
-    if (systemPrompt) {
-      const sys = typeof systemPrompt === 'function' ? systemPrompt(ctx.toPromptContext()) : systemPrompt;
-      req = { ...req, metadata: { ...req.metadata, systemPrompt: sys } };
-    }
-
-    const assistantId = nextId();
-    contentAccum = '';
-    const assistantMsg: AskableChatMessage = { id: assistantId, role: 'assistant', content: '', request: req, createdAt: Date.now() };
-    messages.value = [...messages.value, assistantMsg];
-
+  const append = $(async (
+    content: string,
+    handler: AskableChatStreamHandler,
+  ): Promise<void> => {
+    abortControllerRef.value?.abort();
+    const controller = new AbortController();
+    abortControllerRef.value = noSerialize(controller);
     status.value = 'streaming';
     isStreaming.value = true;
     error.value = null;
 
+    const nextId = () => `msg-${Date.now()}-${++idCounter.value}`;
+    const userMsg: AskableChatMessage = {
+      id: nextId(),
+      role: 'user',
+      content,
+      createdAt: Date.now(),
+    };
+    let req: AskableAgentRequest | undefined;
+    let assistantId: string | undefined;
+    let accumulated = '';
+    const chunkCallbacks: Promise<void>[] = [];
+    const isCurrent = () => (
+      !controller.signal.aborted && abortControllerRef.value === controller
+    );
+
     try {
-      await handler(req, messages.value.slice(0, -1), (chunk) => {
-        contentAccum += chunk;
-        messages.value = messages.value.map((m) =>
-          m.id === assistantId ? { ...m, content: contentAccum } : m,
-        );
-        onChunk?.(chunk);
-      });
-
-      const finished = messages.value.find((m) => m.id === assistantId)!;
-      onFinish?.(finished);
-      status.value = 'idle';
-    } catch (e) {
-      if ((e as Error)?.name !== 'AbortError') {
-        error.value = e;
-        status.value = 'error';
-        onError?.(e);
+      const ctx = getAskableContext(ctxRef);
+      req = await ctx.toAgentRequest(content, requestOptions);
+      if (!isCurrent()) return;
+      if (systemPrompt) {
+        const prompt = typeof systemPrompt === 'string'
+          ? systemPrompt
+          : await systemPrompt(ctx.toPromptContext());
+        if (!isCurrent()) return;
+        req = { ...req, metadata: { ...req.metadata, systemPrompt: prompt } };
       }
-    } finally {
-      isStreaming.value = false;
-      currentAc = null;
-    }
-  }
 
-  return { messages, status, error, isStreaming, append, clearMessages, abort, get ctx() { return ctxRef.value!; } };
+      assistantId = nextId();
+      const assistantMsg: AskableChatMessage = {
+        id: assistantId,
+        role: 'assistant',
+        content: '',
+        request: req,
+        createdAt: Date.now(),
+      };
+      messages.value = [...messages.value, userMsg, assistantMsg];
+
+      await handler(req, messages.value.slice(0, -1), (chunk) => {
+        if (!isCurrent()) return;
+        accumulated += chunk;
+        messages.value = messages.value.map((message) =>
+          message.id === assistantId
+            ? { ...message, content: accumulated }
+            : message,
+        );
+        if (onChunk) chunkCallbacks.push(onChunk(chunk));
+      }, controller.signal);
+      await Promise.all(chunkCallbacks);
+
+      if (!isCurrent()) return;
+      const finished = messages.value.find((message) => message.id === assistantId);
+      if (finished) await onFinish?.(finished);
+      if (!isCurrent()) return;
+      status.value = 'idle';
+    } catch (caught) {
+      if (!isCurrent() || (caught as Error)?.name === 'AbortError') {
+        if (abortControllerRef.value === controller) status.value = 'idle';
+        return;
+      }
+      error.value = caught;
+      status.value = 'error';
+      await onError?.(caught);
+    } finally {
+      if (abortControllerRef.value === controller) {
+        abortControllerRef.value = undefined;
+        isStreaming.value = false;
+      }
+    }
+  });
+
+  return {
+    messages,
+    status,
+    error,
+    isStreaming,
+    append,
+    clearMessages,
+    abort,
+    ctxRef,
+    get ctx() { return ctxRef.value!; },
+  };
 }

--- a/packages/qwik/src/useAskableErrorSource.ts
+++ b/packages/qwik/src/useAskableErrorSource.ts
@@ -1,63 +1,86 @@
-import { useSignal } from '@builder.io/qwik';
+import { $, useSignal } from '@builder.io/qwik';
+import type { QRL } from '@builder.io/qwik';
 import { createAskableErrorSource } from '@askable-ui/core';
 import type { AskableCreateErrorSourceOptions, AskableErrorEntry } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+import {
+  useAskableSource,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
 
 export type { AskableErrorEntry };
 
 export interface UseAskableErrorSourceOptions
   extends UseAskableSourceOptions,
-    Omit<AskableCreateErrorSourceOptions, 'getErrors'> {
+    Omit<AskableCreateErrorSourceOptions, 'describe' | 'getErrors'> {
   id?: string;
-  /** Initial list of errors. Pass `getErrors` for dynamic sources. */
+  /** Initial list of errors. Pass a QRL `getErrors` for dynamic sources. */
   initialErrors?: AskableErrorEntry[];
-  /** Override the error getter with a custom async function. */
-  getErrors?: AskableCreateErrorSourceOptions['getErrors'];
+  /** Resume-safe description callback. */
+  describe?: string | QRL<() => string | Promise<string>>;
+  /** Resume-safe override for dynamic errors. */
+  getErrors?: QRL<() => AskableErrorEntry[] | Promise<AskableErrorEntry[]>>;
 }
 
 export interface UseAskableErrorSourceResult extends UseAskableSourceResult {
   errors: ReturnType<typeof useSignal<AskableErrorEntry[]>>;
-  addError(entry: AskableErrorEntry): void;
-  removeError(key: string): void;
-  clearErrors(): void;
+  addError: QRL<(entry: AskableErrorEntry) => Promise<void>>;
+  removeError: QRL<(key: string) => Promise<void>>;
+  clearErrors: QRL<() => Promise<void>>;
 }
 
 /**
  * Registers an error source that captures recent application errors so the AI
- * can reference them. Errors are managed reactively via `addError`/`removeError`.
- *
- * ```tsx
- * const { addError } = useAskableErrorSource();
- * // On catch: addError({ key: 'submit', message: 'Network timeout', severity: 'error' });
- * ```
+ * can reference them. Mutation actions are resumable QRLs.
  */
-export function useAskableErrorSource(options: UseAskableErrorSourceOptions = {}): UseAskableErrorSourceResult {
-  const { id = 'errors', enabled, ctx, ctx$, name, events, describe, kind, initialErrors = [], getErrors: customGetErrors } = options;
-
-  const errors = useSignal<AskableErrorEntry[]>(initialErrors);
-
-  const source = createAskableErrorSource({
+export function useAskableErrorSource(
+  options: UseAskableErrorSourceOptions = {},
+): UseAskableErrorSourceResult {
+  const {
+    id = 'errors',
+    enabled,
+    ctx,
+    ctx$,
+    name,
+    events,
+    viewport,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    maxHistory,
     describe,
     kind,
-    getErrors: customGetErrors ?? (() => errors.value),
+    initialErrors = [],
+    getErrors: customGetErrors,
+  } = options;
+
+  const errors = useSignal<AskableErrorEntry[]>(initialErrors);
+  const sourceFactory = $(async () => createAskableErrorSource({
+    describe: typeof describe === 'string' ? describe : await describe?.resolve(),
+    kind,
+    getErrors: await customGetErrors?.resolve() ?? (() => errors.value),
+  }));
+  const result = useAskableSource(id, sourceFactory, {
+    enabled, ctx, ctx$, name, events, viewport, textExtractor,
+    sanitizeMeta, sanitizeText, sanitizeSource, maxHistory,
+  });
+  const notifyChanged = result.notifyChanged;
+
+  const addError = $(async (entry: AskableErrorEntry): Promise<void> => {
+    errors.value = [entry, ...errors.value.filter((errorEntry) => errorEntry.key !== entry.key)];
+    await notifyChanged();
   });
 
-  const result = useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+  const removeError = $(async (key: string): Promise<void> => {
+    errors.value = errors.value.filter((entry) => entry.key !== key);
+    await notifyChanged();
+  });
 
-  function addError(entry: AskableErrorEntry): void {
-    errors.value = [entry, ...errors.value.filter((e) => e.key !== entry.key)];
-    result.notifyChanged();
-  }
-
-  function removeError(key: string): void {
-    errors.value = errors.value.filter((e) => e.key !== key);
-    result.notifyChanged();
-  }
-
-  function clearErrors(): void {
+  const clearErrors = $(async (): Promise<void> => {
     errors.value = [];
-    result.notifyChanged();
-  }
+    await notifyChanged();
+  });
 
-  return { ...result, errors, addError, removeError, clearErrors };
+  return Object.assign(result, { errors, addError, removeError, clearErrors });
 }

--- a/packages/qwik/src/useAskableFormSource.ts
+++ b/packages/qwik/src/useAskableFormSource.ts
@@ -1,28 +1,101 @@
+import { $, noSerialize, useSignal } from '@builder.io/qwik';
+import type { NoSerialize, QRL, SyncQRL } from '@builder.io/qwik';
 import { createAskableFormSource } from '@askable-ui/core';
 import type { AskableCreateFormSourceOptions } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+import {
+  useAskableSource,
+  type AskableContextSourceFactory,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
+
+type FormDescription = Extract<
+  NonNullable<AskableCreateFormSourceOptions['describe']>,
+  (...args: never[]) => unknown
+>;
 
 export interface UseAskableFormSourceOptions
   extends UseAskableSourceOptions,
-    AskableCreateFormSourceOptions {
+    Omit<
+      AskableCreateFormSourceOptions,
+      'form' | 'describe' | 'resolveLabel' | 'resolveValue' | 'sanitizeSnapshot'
+    > {
   id?: string;
+  /** Selectors and direct runtime forms remain supported; use `form$` for resume. */
+  form?: AskableCreateFormSourceOptions['form'];
+  form$?: QRL<() => HTMLFormElement | null | undefined>;
+  describe?: string | QRL<FormDescription>;
+  resolveLabel?: SyncQRL<NonNullable<AskableCreateFormSourceOptions['resolveLabel']>>;
+  resolveValue?: SyncQRL<NonNullable<AskableCreateFormSourceOptions['resolveValue']>>;
+  sanitizeSnapshot?: SyncQRL<NonNullable<AskableCreateFormSourceOptions['sanitizeSnapshot']>>;
+  /** Advanced resume-safe factory for custom form integration. */
+  source$?: AskableContextSourceFactory;
 }
 
-export type UseAskableFormSourceResult = UseAskableSourceResult;
+export interface UseAskableFormSourceResult extends UseAskableSourceResult {}
 
-/**
- * Registers a form source that serializes field values and validation state
- * for a given `<form>` element.
- *
- * ```tsx
- * export const ContactForm = component$(() => {
- *   useAskableFormSource({ selector: '#contact-form' });
- *   // ...
- * });
- * ```
- */
-export function useAskableFormSource(options: UseAskableFormSourceOptions = {}): UseAskableFormSourceResult {
-  const { id = 'form', enabled, ctx, ctx$, name, events, ...sourceOptions } = options;
-  const source = createAskableFormSource(sourceOptions);
-  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+/** Registers a form source that can be reconstructed after SSR resume. */
+export function useAskableFormSource(
+  options: UseAskableFormSourceOptions = {},
+): UseAskableFormSourceResult {
+  const {
+    id = 'form',
+    enabled,
+    ctx,
+    ctx$,
+    name,
+    events,
+    viewport,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    maxHistory,
+    form,
+    form$,
+    describe,
+    resolveLabel,
+    resolveValue,
+    sanitizeSnapshot,
+    source$,
+    ...sourceOptions
+  } = options;
+
+  const formSelector = typeof form === 'string' ? form : undefined;
+  const directForm = useSignal<NoSerialize<{
+    value: HTMLFormElement | (() => HTMLFormElement | null | undefined);
+  }>>(form && typeof form !== 'string' ? noSerialize({ value: form }) : undefined);
+  const hasDirectForm = form !== undefined && typeof form !== 'string';
+
+  const defaultSourceFactory = $(async () => {
+    const resolvedForm = await form$?.() ?? directForm.value?.value ?? formSelector;
+    if (hasDirectForm && !resolvedForm) {
+      throw new Error(
+        'Askable form was not available after Qwik resume; pass a selector or QRL form$ instead',
+      );
+    }
+    const [resolvedDescribe, resolvedLabel, resolvedValue, resolvedSanitizeSnapshot] =
+      await Promise.all([
+        typeof describe === 'string' ? describe : describe?.resolve(),
+        resolveLabel?.resolve(),
+        resolveValue?.resolve(),
+        sanitizeSnapshot?.resolve(),
+      ]);
+    return createAskableFormSource({
+      ...sourceOptions,
+      form: resolvedForm,
+      describe: resolvedDescribe,
+      resolveLabel: resolvedLabel,
+      resolveValue: resolvedValue,
+      sanitizeSnapshot: resolvedSanitizeSnapshot,
+    });
+  });
+  return useAskableSource(
+    id,
+    source$ ?? defaultSourceFactory,
+    {
+      enabled, ctx, ctx$, name, events, viewport, textExtractor,
+      sanitizeMeta, sanitizeText, sanitizeSource, maxHistory,
+    },
+  );
 }

--- a/packages/qwik/src/useAskableMultistepSource.ts
+++ b/packages/qwik/src/useAskableMultistepSource.ts
@@ -1,100 +1,142 @@
-import { useSignal } from '@builder.io/qwik';
+import { $, useSignal } from '@builder.io/qwik';
+import type { QRL } from '@builder.io/qwik';
 import { createAskableMultistepSource, buildMultistepSnapshot } from '@askable-ui/core';
 import type {
   AskableCreateMultistepSourceOptions,
   AskableMultistepStep,
   AskableMultistepSourceSnapshot,
 } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+import {
+  useAskableSource,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
 
 export type { AskableMultistepStep, AskableMultistepSourceSnapshot };
 
+type StepDefinition = Pick<
+  AskableMultistepStep,
+  'id' | 'label' | 'description' | 'optional'
+>;
+
 export interface UseAskableMultistepSourceOptions
   extends UseAskableSourceOptions,
-    Omit<AskableCreateMultistepSourceOptions, 'getSnapshot'> {
+    Omit<AskableCreateMultistepSourceOptions, 'describe' | 'getSnapshot'> {
   id?: string;
-  steps?: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[];
+  steps?: StepDefinition[];
   initialStep?: number;
+  /** Resume-safe source description callback. */
+  describe?: string | QRL<Extract<
+    NonNullable<AskableCreateMultistepSourceOptions['describe']>,
+    (...args: never[]) => unknown
+  >>;
 }
 
 export interface UseAskableMultistepSourceResult extends UseAskableSourceResult {
   snapshot: ReturnType<typeof useSignal<AskableMultistepSourceSnapshot | null>>;
-  next(): void;
-  prev(): void;
-  goTo(indexOrId: number | string): void;
-  setSteps(steps: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[]): void;
+  next: QRL<() => Promise<void>>;
+  prev: QRL<() => Promise<void>>;
+  goTo: QRL<(indexOrId: number | string) => Promise<void>>;
+  setSteps: QRL<(steps: StepDefinition[]) => Promise<void>>;
 }
 
-/**
- * Qwik hook that tracks wizard / stepper / checkout flow progress.
- *
- * ```tsx
- * export const Checkout = component$(() => {
- *   const wizard = useAskableMultistepSource({
- *     steps: [
- *       { id: 'cart', label: 'Cart' },
- *       { id: 'shipping', label: 'Shipping' },
- *       { id: 'payment', label: 'Payment' },
- *     ],
- *   });
- *   return (
- *     <div>
- *       <p>Step {wizard.snapshot.value?.currentIndex + 1}</p>
- *       <button onClick$={() => wizard.next()}>Next</button>
- *     </div>
- *   );
- * });
- * ```
- */
-export function useAskableMultistepSource(options: UseAskableMultistepSourceOptions = {}): UseAskableMultistepSourceResult {
-  const { id = 'multistep', steps: initialSteps = [], initialStep = 0, describe, kind, enabled, ctx, ctx$, name, events } = options;
+function makeSteps(definitions: StepDefinition[], activeIndex: number): AskableMultistepStep[] {
+  return definitions.map((step, index) => ({
+    id: step.id,
+    label: step.label,
+    description: step.description,
+    optional: step.optional,
+    completed: index < activeIndex,
+    active: index === activeIndex,
+  }));
+}
 
-  function makeSteps(defs: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[], activeIdx: number): AskableMultistepStep[] {
-    return defs.map((s, i) => ({
-      id: s.id,
-      label: s.label,
-      description: s.description,
-      optional: s.optional,
-      completed: i < activeIdx,
-      active: i === activeIdx,
-    }));
-  }
+function definitionsFromSnapshot(
+  snapshot: AskableMultistepSourceSnapshot | null,
+  fallback: StepDefinition[],
+): StepDefinition[] {
+  return snapshot?.steps.map((step) => ({
+    id: step.id,
+    label: step.label,
+    description: step.description,
+    optional: step.optional,
+  })) ?? fallback;
+}
+
+async function applyIndex(
+  snapshotSignal: ReturnType<typeof useSignal<AskableMultistepSourceSnapshot | null>>,
+  definitions: StepDefinition[],
+  index: number,
+  notifyChanged: QRL<() => void>,
+): Promise<void> {
+  if (index < 0 || index >= definitions.length) return;
+  snapshotSignal.value = buildMultistepSnapshot(makeSteps(definitions, index));
+  await notifyChanged();
+}
+
+/** Qwik hook that tracks wizard progress and exposes resumable actions. */
+export function useAskableMultistepSource(
+  options: UseAskableMultistepSourceOptions = {},
+): UseAskableMultistepSourceResult {
+  const {
+    id = 'multistep',
+    steps: initialSteps = [],
+    initialStep = 0,
+    describe,
+    kind,
+    enabled,
+    ctx,
+    ctx$,
+    name,
+    events,
+    viewport,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    maxHistory,
+  } = options;
 
   const snapshot = useSignal<AskableMultistepSourceSnapshot | null>(
-    initialSteps.length > 0 ? buildMultistepSnapshot(makeSteps(initialSteps, initialStep)) : null,
+    initialSteps.length > 0
+      ? buildMultistepSnapshot(makeSteps(initialSteps, initialStep))
+      : null,
   );
+  const sourceFactory = $(async () => createAskableMultistepSource({
+    describe: typeof describe === 'string' ? describe : await describe?.resolve(),
+    kind,
+    getSnapshot: () => snapshot.value,
+  }));
+  const result = useAskableSource(id, sourceFactory, {
+    enabled, ctx, ctx$, name, events, viewport, textExtractor,
+    sanitizeMeta, sanitizeText, sanitizeSource, maxHistory,
+  });
+  const notifyChanged = result.notifyChanged;
 
-  const source = createAskableMultistepSource({ describe, kind, getSnapshot: () => snapshot.value });
-  const result = useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+  const next = $(async (): Promise<void> => {
+    const definitions = definitionsFromSnapshot(snapshot.value, initialSteps);
+    const currentIndex = snapshot.value?.currentIndex ?? initialStep;
+    await applyIndex(snapshot, definitions, currentIndex + 1, notifyChanged);
+  });
 
-  function currentDefs(): Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[] {
-    return snapshot.value?.steps.map((s) => ({ id: s.id, label: s.label, description: s.description, optional: s.optional })) ?? initialSteps;
-  }
+  const prev = $(async (): Promise<void> => {
+    const definitions = definitionsFromSnapshot(snapshot.value, initialSteps);
+    const currentIndex = snapshot.value?.currentIndex ?? initialStep;
+    await applyIndex(snapshot, definitions, currentIndex - 1, notifyChanged);
+  });
 
-  function currentIndex(): number {
-    return snapshot.value?.currentIndex ?? initialStep;
-  }
+  const goTo = $(async (indexOrId: number | string): Promise<void> => {
+    const definitions = definitionsFromSnapshot(snapshot.value, initialSteps);
+    const index = typeof indexOrId === 'number'
+      ? indexOrId
+      : definitions.findIndex((step) => step.id === indexOrId);
+    await applyIndex(snapshot, definitions, index, notifyChanged);
+  });
 
-  function applyIndex(defs: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[], idx: number): void {
-    if (idx < 0 || idx >= defs.length) return;
-    snapshot.value = buildMultistepSnapshot(makeSteps(defs, idx));
-    result.notifyChanged();
-  }
-
-  function next(): void { applyIndex(currentDefs(), currentIndex() + 1); }
-  function prev(): void { applyIndex(currentDefs(), currentIndex() - 1); }
-
-  function goTo(indexOrId: number | string): void {
-    const defs = currentDefs();
-    if (typeof indexOrId === 'number') { applyIndex(defs, indexOrId); return; }
-    const idx = defs.findIndex((s) => s.id === indexOrId);
-    if (idx >= 0) applyIndex(defs, idx);
-  }
-
-  function setSteps(steps: Pick<AskableMultistepStep, 'id' | 'label' | 'description' | 'optional'>[]): void {
+  const setSteps = $(async (steps: StepDefinition[]): Promise<void> => {
     snapshot.value = buildMultistepSnapshot(makeSteps(steps, 0));
-    result.notifyChanged();
-  }
+    await notifyChanged();
+  });
 
-  return { ...result, snapshot, next, prev, goTo, setSteps };
+  return Object.assign(result, { snapshot, next, prev, goTo, setSteps });
 }

--- a/packages/qwik/src/useAskableNavigationSource.ts
+++ b/packages/qwik/src/useAskableNavigationSource.ts
@@ -1,26 +1,78 @@
+import { $ } from '@builder.io/qwik';
+import type { SyncQRL } from '@builder.io/qwik';
 import { createAskableNavigationSource } from '@askable-ui/core';
-import type { AskableCreateNavigationSourceOptions, AskableNavigationEntry } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
-
-export type { AskableNavigationEntry };
+import type { AskableCreateNavigationSourceOptions } from '@askable-ui/core';
+export type { AskableNavigationEntry } from '@askable-ui/core';
+import {
+  useAskableSource,
+  type AskableContextSourceFactory,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
 
 export interface UseAskableNavigationSourceOptions
   extends UseAskableSourceOptions,
-    AskableCreateNavigationSourceOptions {
+    Omit<
+      AskableCreateNavigationSourceOptions,
+      'getPath' | 'getTitle' | 'getParams' | 'describe'
+    > {
   id?: string;
+  getPath?: SyncQRL<NonNullable<AskableCreateNavigationSourceOptions['getPath']>>;
+  getTitle?: SyncQRL<NonNullable<AskableCreateNavigationSourceOptions['getTitle']>>;
+  getParams?: SyncQRL<NonNullable<AskableCreateNavigationSourceOptions['getParams']>>;
+  describe?: SyncQRL<NonNullable<AskableCreateNavigationSourceOptions['describe']>>;
+  /** Advanced resume-safe factory for router state that cannot use `sync$`. */
+  source$?: AskableContextSourceFactory;
 }
 
-export type UseAskableNavigationSourceResult = UseAskableSourceResult;
+export interface UseAskableNavigationSourceResult extends UseAskableSourceResult {}
 
-/**
- * Registers a navigation source that tracks page route history.
- *
- * ```tsx
- * useAskableNavigationSource({ maxEntries: 5 });
- * ```
- */
-export function useAskableNavigationSource(options: UseAskableNavigationSourceOptions = {}): UseAskableNavigationSourceResult {
-  const { id = 'navigation', enabled, ctx, ctx$, name, events, ...sourceOptions } = options;
-  const source = createAskableNavigationSource(sourceOptions);
-  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+/** Registers a navigation source with resume-safe callbacks and history. */
+export function useAskableNavigationSource(
+  options: UseAskableNavigationSourceOptions = {},
+): UseAskableNavigationSourceResult {
+  const {
+    id = 'navigation',
+    enabled,
+    ctx,
+    ctx$,
+    name,
+    events,
+    viewport,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    maxHistory,
+    getPath,
+    getTitle,
+    getParams,
+    describe,
+    source$,
+    ...sourceOptions
+  } = options;
+
+  const defaultSourceFactory = $(async () => {
+    const [resolvedPath, resolvedTitle, resolvedParams, resolvedDescribe] = await Promise.all([
+      getPath?.resolve(),
+      getTitle?.resolve(),
+      getParams?.resolve(),
+      describe?.resolve(),
+    ]);
+    return createAskableNavigationSource({
+      ...sourceOptions,
+      getPath: resolvedPath,
+      getTitle: resolvedTitle,
+      getParams: resolvedParams,
+      describe: resolvedDescribe,
+    });
+  });
+  return useAskableSource(
+    id,
+    source$ ?? defaultSourceFactory,
+    {
+      enabled, ctx, ctx$, name, events, viewport, textExtractor,
+      sanitizeMeta, sanitizeText, sanitizeSource, maxHistory,
+    },
+  );
 }

--- a/packages/qwik/src/useAskableNotificationSource.ts
+++ b/packages/qwik/src/useAskableNotificationSource.ts
@@ -1,26 +1,32 @@
-import { useSignal } from '@builder.io/qwik';
+import { $, useSignal } from '@builder.io/qwik';
+import type { QRL, SyncQRL } from '@builder.io/qwik';
 import { createAskableNotificationSource } from '@askable-ui/core';
 import type {
   AskableCreateNotificationSourceOptions,
   AskableNotification,
   AskableNotificationSeverity,
 } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+import {
+  useAskableSource,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
 
 export type { AskableNotification, AskableNotificationSeverity };
 
 export interface UseAskableNotificationSourceOptions
   extends UseAskableSourceOptions,
-    Pick<AskableCreateNotificationSourceOptions, 'describe' | 'kind'> {
+    Pick<AskableCreateNotificationSourceOptions, 'kind'> {
   id?: string;
   maxEntries?: number;
+  describe?: SyncQRL<NonNullable<AskableCreateNotificationSourceOptions['describe']>>;
 }
 
 export interface UseAskableNotificationSourceResult extends UseAskableSourceResult {
   notifications: ReturnType<typeof useSignal<AskableNotification[]>>;
-  push(notification: Omit<AskableNotification, 'id' | 'timestamp'>): void;
-  dismiss(id: string): void;
-  clear(): void;
+  push: QRL<(notification: Omit<AskableNotification, 'id' | 'timestamp'>) => Promise<void>>;
+  dismiss: QRL<(id: string) => Promise<void>>;
+  clear: QRL<() => Promise<void>>;
 }
 
 /**
@@ -28,45 +34,69 @@ export interface UseAskableNotificationSourceResult extends UseAskableSourceResu
  * banners so the AI can reference them.
  *
  * ```tsx
- * const { push, dismiss } = useAskableNotificationSource();
- * push({ message: 'Order placed!', severity: 'success' });
+ * const notifications = useAskableNotificationSource();
+ * <button onClick$={() => notifications.push({
+ *   message: 'Order placed!',
+ *   severity: 'success',
+ * })}>Notify</button>
  * ```
  */
 export function useAskableNotificationSource(
   options: UseAskableNotificationSourceOptions = {},
 ): UseAskableNotificationSourceResult {
-  const { id = 'notifications', enabled, ctx, ctx$, name, events, maxEntries = 20, describe, kind } = options;
-
-  const notifications = useSignal<AskableNotification[]>([]);
-  let nextId = 1;
-
-  const source = createAskableNotificationSource({
+  const {
+    id = 'notifications',
+    enabled,
+    ctx,
+    ctx$,
+    name,
+    events,
+    viewport,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    maxHistory,
+    maxEntries = 20,
     describe,
     kind,
-    getNotifications: () => notifications.value,
-  });
-  const result = useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+  } = options;
 
-  function push(notification: Omit<AskableNotification, 'id' | 'timestamp'>): void {
+  const notifications = useSignal<AskableNotification[]>([]);
+  const nextId = useSignal(1);
+  const sourceFactory = $(async () => createAskableNotificationSource({
+    describe: await describe?.resolve(),
+    kind,
+    getNotifications: () => notifications.value,
+  }));
+  const result = useAskableSource(id, sourceFactory, {
+    enabled, ctx, ctx$, name, events, viewport, textExtractor,
+    sanitizeMeta, sanitizeText, sanitizeSource, maxHistory,
+  });
+  const notifyChanged = result.notifyChanged;
+
+  const push = $(async (
+    notification: Omit<AskableNotification, 'id' | 'timestamp'>,
+  ): Promise<void> => {
     const entry: AskableNotification = {
       ...notification,
-      id: String(nextId++),
+      id: String(nextId.value++),
       timestamp: new Date().toISOString(),
     };
     const next = [entry, ...notifications.value];
     notifications.value = next.length > maxEntries ? next.slice(0, maxEntries) : next;
-    result.notifyChanged();
-  }
+    await notifyChanged();
+  });
 
-  function dismiss(id: string): void {
-    notifications.value = notifications.value.filter((n) => n.id !== id);
-    result.notifyChanged();
-  }
+  const dismiss = $(async (entryId: string): Promise<void> => {
+    notifications.value = notifications.value.filter((notification) => notification.id !== entryId);
+    await notifyChanged();
+  });
 
-  function clear(): void {
+  const clear = $(async (): Promise<void> => {
     notifications.value = [];
-    result.notifyChanged();
-  }
+    await notifyChanged();
+  });
 
-  return { ...result, notifications, push, dismiss, clear };
+  return Object.assign(result, { notifications, push, dismiss, clear });
 }

--- a/packages/qwik/src/useAskablePageSource.ts
+++ b/packages/qwik/src/useAskablePageSource.ts
@@ -1,28 +1,98 @@
+import { $, noSerialize, useSignal } from '@builder.io/qwik';
+import type { NoSerialize, QRL, SyncQRL } from '@builder.io/qwik';
 import { createAskablePageSource } from '@askable-ui/core';
 import type { AskableCreatePageSourceOptions } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+import {
+  useAskableSource,
+  type AskableContextSourceFactory,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
+
+type PageDescription = Extract<
+  NonNullable<AskableCreatePageSourceOptions['describe']>,
+  (...args: never[]) => unknown
+>;
 
 export interface UseAskablePageSourceOptions
-  extends Omit<UseAskableSourceOptions, 'textExtractor'>,
-    AskableCreatePageSourceOptions {
+  extends UseAskableSourceOptions,
+    Omit<
+      AskableCreatePageSourceOptions,
+      'describe' | 'textExtractor' | 'sanitizeText'
+    > {
   id?: string;
+  /** Direct DOM roots remain supported for client-only mounts. */
+  root?: Document | HTMLElement;
+  /** Resolve a DOM root after browser resume. Defaults to the global document. */
+  root$?: QRL<() => Document | HTMLElement | undefined>;
+  describe?: string | QRL<PageDescription>;
+  textExtractor?: SyncQRL<NonNullable<AskableCreatePageSourceOptions['textExtractor']>>;
+  sanitizeText?: SyncQRL<NonNullable<AskableCreatePageSourceOptions['sanitizeText']>>;
+  /** Advanced resume-safe factory for custom page integrations. */
+  source$?: AskableContextSourceFactory;
 }
 
-export type UseAskablePageSourceResult = UseAskableSourceResult;
+export interface UseAskablePageSourceResult extends UseAskableSourceResult {}
 
 /**
- * Registers a page source that captures the current document title, URL,
- * meta description, headings, and optionally links.
- *
- * ```tsx
- * export const Layout = component$(() => {
- *   useAskablePageSource();
- *   return <Slot />;
- * });
- * ```
+ * Registers a page source that snapshots page text, selection, headings, and
+ * optional links. DOM roots and callbacks use QRLs so the source can be
+ * reconstructed after SSR resume.
  */
-export function useAskablePageSource(options: UseAskablePageSourceOptions = {}): UseAskablePageSourceResult {
-  const { id = 'page', enabled, ctx, ctx$, name, events, describe, kind, root, includeLinks, maxLinks, maxHeadings, maxTextLength, textExtractor, sanitizeText } = options;
-  const source = createAskablePageSource({ describe, kind, root, includeLinks, maxLinks, maxHeadings, maxTextLength, textExtractor, sanitizeText });
-  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+export function useAskablePageSource(
+  options: UseAskablePageSourceOptions = {},
+): UseAskablePageSourceResult {
+  const {
+    id = 'page',
+    enabled,
+    ctx,
+    ctx$,
+    name,
+    events,
+    viewport,
+    sanitizeMeta,
+    sanitizeSource,
+    maxHistory,
+    root,
+    root$,
+    describe,
+    textExtractor,
+    sanitizeText,
+    source$,
+    ...sourceOptions
+  } = options;
+
+  const directRoot = useSignal<NoSerialize<{ value: Document | HTMLElement }>>(
+    root ? noSerialize({ value: root }) : undefined,
+  );
+  const hasDirectRoot = root !== undefined;
+
+  const sourceFactory = $(async () => {
+    const resolvedRoot = await root$?.() ?? directRoot.value?.value;
+    if (hasDirectRoot && !resolvedRoot) {
+      throw new Error(
+        'Askable page root was not available after Qwik resume; pass a QRL root$ instead',
+      );
+    }
+    const [resolvedDescribe, resolvedTextExtractor, resolvedSanitizeText] = await Promise.all([
+      typeof describe === 'string' ? describe : describe?.resolve(),
+      textExtractor?.resolve(),
+      sanitizeText?.resolve(),
+    ]);
+    return createAskablePageSource({
+      ...sourceOptions,
+      root: resolvedRoot,
+      describe: resolvedDescribe,
+      textExtractor: resolvedTextExtractor,
+      sanitizeText: resolvedSanitizeText,
+    });
+  });
+  return useAskableSource(
+    id,
+    source$ ?? sourceFactory,
+    {
+      enabled, ctx, ctx$, name, events, viewport,
+      sanitizeMeta, sanitizeSource, maxHistory,
+    },
+  );
 }

--- a/packages/qwik/src/useAskableSource.ts
+++ b/packages/qwik/src/useAskableSource.ts
@@ -1,4 +1,4 @@
-import { noSerialize, useSignal, useVisibleTask$ } from '@builder.io/qwik';
+import { $, noSerialize, useSignal, useVisibleTask$ } from '@builder.io/qwik';
 import type { NoSerialize, QRL } from '@builder.io/qwik';
 import type {
   AskableAsyncPromptContextOptions,
@@ -10,21 +10,24 @@ import type {
 } from '@askable-ui/core';
 import { getAskableContext } from './contextRef.js';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
+import type { AskableContextRef } from './contextRef.js';
 
 export interface UseAskableSourceOptions extends Omit<UseAskableOptions, never> {
   enabled?: boolean;
 }
 
 export interface UseAskableSourceResult {
+  /** Stable resumable reference populated when the browser lifecycle mounts. */
+  ctxRef: AskableContextRef;
   ctx: AskableContext;
   sourceId: string;
-  resolve(request?: Omit<AskableContextSourceRequest, 'id'>): Promise<AskableResolvedContextSource>;
-  toPromptContext(
+  resolve: QRL<(request?: Omit<AskableContextSourceRequest, 'id'>) => Promise<AskableResolvedContextSource>>;
+  toPromptContext: QRL<(
     options?: Omit<AskableAsyncPromptContextOptions, 'sources'>
       & { source?: Omit<AskableContextSourceRequest, 'id'> },
-  ): Promise<string>;
-  notifyChanged(): void;
-  unregister(): void;
+  ) => Promise<string>>;
+  notifyChanged: QRL<() => void>;
+  unregister: QRL<() => void>;
 }
 
 export type AskableContextSourceFactory = QRL<
@@ -34,7 +37,9 @@ export type AskableContextSourceFactory = QRL<
 /**
  * Qwik hook that registers an arbitrary context source on the shared
  * AskableContext. The source is registered once the component mounts in the
- * browser and unregistered on cleanup.
+ * browser and unregistered on cleanup. Pass a QRL factory for a source that
+ * must be reconstructed after SSR resume; the direct object form is retained
+ * for client-only compatibility.
  */
 export function useAskableSource(
   id: string,
@@ -47,14 +52,20 @@ export function useAskableSource(
   const clientSource = typeof source === 'function' ? undefined : noSerialize(source);
 
   const handleRef = useSignal<NoSerialize<AskableContextSourceHandle>>();
+  const generationRef = useSignal(0);
 
   // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(async ({ cleanup, track }) => {
+    const generation = ++generationRef.value;
     let disposed = false;
+    let taskHandle: AskableContextSourceHandle | undefined;
     cleanup(() => {
       disposed = true;
-      handleRef.value?.unregister();
-      handleRef.value = undefined;
+      if (generationRef.value === generation) generationRef.value++;
+      if (handleRef.value === taskHandle) {
+        handleRef.value = undefined;
+        taskHandle?.unregister();
+      }
     });
 
     const ctx = track(() => ctxRef.value);
@@ -64,33 +75,44 @@ export function useAskableSource(
     try {
       resolvedSource = sourceFactory ? await sourceFactory() : clientSource;
     } catch (error) {
-      if (disposed) return;
+      if (disposed || generationRef.value !== generation) return;
       throw error;
     }
+    if (disposed || generationRef.value !== generation) return;
     if (!resolvedSource) {
       throw new Error(
         'Askable source was not available after Qwik resume; pass a QRL source factory instead',
       );
     }
-    if (disposed) return;
-    handleRef.value = noSerialize(ctx.registerSource(id.trim(), resolvedSource));
+    taskHandle = ctx.registerSource(id.trim(), resolvedSource);
+    handleRef.value = noSerialize(taskHandle);
+  });
+
+  const resolve = $((request?: Omit<AskableContextSourceRequest, 'id'>) =>
+    getAskableContext(ctxRef).resolveSource(id, request));
+  const toPromptContext = $((opts?: Omit<AskableAsyncPromptContextOptions, 'sources'>
+    & { source?: Omit<AskableContextSourceRequest, 'id'> }) => {
+    const { source: sourceRequest, ...rest } = opts ?? {};
+    return getAskableContext(ctxRef).toPromptContextAsync({
+      ...rest,
+      sources: [{ id, ...sourceRequest }],
+    });
+  });
+  const notifyChanged = $(() => handleRef.value?.notifyChanged());
+  const unregister = $(() => {
+    generationRef.value++;
+    const handle = handleRef.value;
+    handleRef.value = undefined;
+    handle?.unregister();
   });
 
   return {
+    ctxRef,
     get ctx() { return ctxRef.value!; },
     sourceId: id,
-    resolve: (request?) => getAskableContext(ctxRef).resolveSource(id, request),
-    toPromptContext: (opts?) => {
-      const { source: sourceRequest, ...rest } = opts ?? {};
-      return getAskableContext(ctxRef).toPromptContextAsync({
-        ...rest,
-        sources: [{ id, ...sourceRequest }],
-      });
-    },
-    notifyChanged: () => handleRef.value?.notifyChanged(),
-    unregister: () => {
-      handleRef.value?.unregister();
-      handleRef.value = undefined;
-    },
+    resolve,
+    toPromptContext,
+    notifyChanged,
+    unregister,
   };
 }

--- a/packages/qwik/src/useAskableStream.ts
+++ b/packages/qwik/src/useAskableStream.ts
@@ -1,34 +1,49 @@
-import { useSignal } from '@builder.io/qwik';
+import { $, noSerialize, useSignal, useTask$ } from '@builder.io/qwik';
+import type { NoSerialize, QRL } from '@builder.io/qwik';
 import type { AskableAgentRequest, AskableAgentRequestOptions, AskableContext } from '@askable-ui/core';
 import { getAskableContext } from './contextRef.js';
+import type { AskableContextRef } from './contextRef.js';
 import { useAskable, type UseAskableOptions } from './useAskable.js';
 
 export type AskableStreamStatus = 'idle' | 'streaming' | 'success' | 'error';
 
-export type AskableStreamHandler = (
+export type AskableStreamHandler = QRL<(
   request: AskableAgentRequest,
   emit: (chunk: string) => void,
-) => Promise<void>;
+  signal: AbortSignal,
+) => void | Promise<void>>;
 
-export interface UseAskableStreamOptions extends Omit<UseAskableOptions, 'inspector'> {
-  onRequest?: (request: AskableAgentRequest) => AskableAgentRequest | void | undefined;
-  onChunk?: (chunk: string, content: string) => void;
-  onSuccess?: (content: string, request: AskableAgentRequest) => void;
-  onError?: (error: unknown, request: AskableAgentRequest) => void;
+export interface UseAskableStreamOptions extends UseAskableOptions {
+  onRequest?: QRL<(
+    request: AskableAgentRequest,
+  ) => AskableAgentRequest | void | undefined | Promise<AskableAgentRequest | void | undefined>>;
+  onChunk?: QRL<(chunk: string, content: string) => void | Promise<void>>;
+  onSuccess?: QRL<(
+    content: string,
+    request: AskableAgentRequest,
+  ) => void | Promise<void>>;
+  onError?: QRL<(error: unknown, request: AskableAgentRequest) => void | Promise<void>>;
   requestOptions?: AskableAgentRequestOptions;
-  ctx?: AskableContext;
 }
 
 export interface UseAskableStreamResult {
-  stream(question: string, handler: AskableStreamHandler): Promise<string | undefined>;
-  streamFrom(question: string, source: ReadableStream<string> | AsyncIterable<string>): Promise<string | undefined>;
+  stream: QRL<(
+    question: string,
+    handler: AskableStreamHandler,
+  ) => Promise<string | undefined>>;
+  streamFrom: QRL<(
+    question: string,
+    source: ReadableStream<string> | AsyncIterable<string>,
+  ) => Promise<string | undefined>>;
   status: ReturnType<typeof useSignal<AskableStreamStatus>>;
   content: ReturnType<typeof useSignal<string>>;
   error: ReturnType<typeof useSignal<unknown>>;
   lastRequest: ReturnType<typeof useSignal<AskableAgentRequest | null>>;
   isStreaming: ReturnType<typeof useSignal<boolean>>;
-  reset(): void;
-  abort(): void;
+  reset: QRL<() => void>;
+  abort: QRL<() => void>;
+  /** Stable resumable reference populated when the browser lifecycle mounts. */
+  ctxRef: AskableContextRef;
   ctx: AskableContext;
 }
 
@@ -36,24 +51,31 @@ export interface UseAskableStreamResult {
  * Qwik hook for streaming LLM responses. Reactive `content.value` updates as
  * each chunk arrives, driving progressive rendering.
  *
+ * Handler and callback functions are QRLs so the returned actions can be
+ * captured safely by resumable Qwik event handlers.
+ *
  * ```tsx
  * export const Chat = component$(() => {
  *   const { stream, content, isStreaming } = useAskableStream();
+ *   const handler = $(async (req, emit, signal) => {
+ *     const res = await fetch('/api/chat', {
+ *       method: 'POST',
+ *       body: JSON.stringify(req),
+ *       signal,
+ *     });
+ *     const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+ *     while (true) {
+ *       const { done, value } = await reader.read();
+ *       if (done) break;
+ *       emit(value);
+ *     }
+ *   });
+ *
  *   return (
  *     <>
  *       {isStreaming.value && <span>Thinking…</span>}
  *       <p>{content.value}</p>
- *       <button onClick$={() =>
- *         stream('Explain this chart', async (req, emit) => {
- *           const res = await fetch('/api/chat', { method: 'POST', body: JSON.stringify(req) });
- *           const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
- *           while (true) {
- *             const { done, value } = await reader.read();
- *             if (done) break;
- *             emit(value);
- *           }
- *         })
- *       }>Ask AI</button>
+ *       <button onClick$={() => stream('Explain this chart', handler)}>Ask AI</button>
  *     </>
  *   );
  * });
@@ -68,76 +90,132 @@ export function useAskableStream(options: UseAskableStreamOptions = {}): UseAska
   const error = useSignal<unknown>(null);
   const lastRequest = useSignal<AskableAgentRequest | null>(null);
   const isStreaming = useSignal(false);
+  const abortControllerRef = useSignal<NoSerialize<AbortController>>();
 
-  let abortController: AbortController | null = null;
+  useTask$(({ cleanup }) => {
+    cleanup(() => abortControllerRef.value?.abort());
+  });
 
-  function reset(): void {
+  const reset = $(() => {
+    abortControllerRef.value?.abort();
+    abortControllerRef.value = undefined;
     status.value = 'idle';
     content.value = '';
     error.value = null;
     lastRequest.value = null;
     isStreaming.value = false;
-  }
+  });
 
-  function abort(): void {
-    abortController?.abort();
-    abortController = null;
+  const abort = $(() => {
+    abortControllerRef.value?.abort();
+    abortControllerRef.value = undefined;
     isStreaming.value = false;
     status.value = 'idle';
-  }
+  });
 
-  async function stream(question: string, handler: AskableStreamHandler): Promise<string | undefined> {
-    abort();
-    abortController = new AbortController();
-    const ctx = getAskableContext(ctxRef);
-    let req = await ctx.toAgentRequest(question, requestOptions);
-    if (onRequest) { const override = onRequest(req); if (override) req = override; }
-
-    lastRequest.value = req;
+  const stream = $(async (
+    question: string,
+    handler: AskableStreamHandler,
+  ): Promise<string | undefined> => {
+    abortControllerRef.value?.abort();
+    const controller = new AbortController();
+    abortControllerRef.value = noSerialize(controller);
     status.value = 'streaming';
     isStreaming.value = true;
     content.value = '';
     error.value = null;
 
+    const chunkCallbacks: Promise<void>[] = [];
+    let req: AskableAgentRequest | undefined;
+    const isCurrent = () => (
+      !controller.signal.aborted && abortControllerRef.value === controller
+    );
+
     try {
-      await handler(req, (chunk) => {
-        content.value += chunk;
-        onChunk?.(chunk, content.value);
-      });
-      status.value = 'success';
-      onSuccess?.(content.value, req);
-      return content.value;
-    } catch (e) {
-      if ((e as Error)?.name !== 'AbortError') {
-        error.value = e;
-        status.value = 'error';
-        onError?.(e, req);
+      const ctx = getAskableContext(ctxRef);
+      req = await ctx.toAgentRequest(question, requestOptions);
+      if (!isCurrent()) return undefined;
+      if (onRequest) {
+        const override = await onRequest(req);
+        if (!isCurrent()) return undefined;
+        if (override) req = override;
       }
+
+      lastRequest.value = req;
+      await handler(req, (chunk) => {
+        if (!isCurrent()) return;
+        content.value += chunk;
+        if (onChunk) chunkCallbacks.push(onChunk(chunk, content.value));
+      }, controller.signal);
+      await Promise.all(chunkCallbacks);
+
+      if (!isCurrent()) return undefined;
+      const result = content.value;
+      status.value = 'success';
+      await onSuccess?.(result, req);
+      if (!isCurrent()) return undefined;
+      return result;
+    } catch (caught) {
+      if (!isCurrent() || (caught as Error)?.name === 'AbortError') {
+        if (abortControllerRef.value === controller) status.value = 'idle';
+        return undefined;
+      }
+      error.value = caught;
+      status.value = 'error';
+      if (req) await onError?.(caught, req);
       return undefined;
     } finally {
-      isStreaming.value = false;
-      abortController = null;
+      if (abortControllerRef.value === controller) {
+        abortControllerRef.value = undefined;
+        isStreaming.value = false;
+      }
     }
-  }
+  });
 
-  async function streamFrom(question: string, source: ReadableStream<string> | AsyncIterable<string>): Promise<string | undefined> {
-    return stream(question, async (_req, emit) => {
+  const streamFrom = $(async (
+    question: string,
+    source: ReadableStream<string> | AsyncIterable<string>,
+  ): Promise<string | undefined> => {
+    const consumeSource = (async (
+      _request: AskableAgentRequest,
+      emit: (chunk: string) => void,
+      signal: AbortSignal,
+    ) => {
       if (source instanceof ReadableStream) {
         const reader = source.getReader();
+        const abortReader = () => void reader.cancel().catch(() => undefined);
+        signal.addEventListener('abort', abortReader, { once: true });
         try {
-          while (true) {
+          while (!signal.aborted) {
             const { done, value } = await reader.read();
             if (done) break;
             emit(value);
           }
         } finally {
+          signal.removeEventListener('abort', abortReader);
           reader.releaseLock();
         }
       } else {
-        for await (const chunk of source) emit(chunk);
+        for await (const chunk of source) {
+          if (signal.aborted) break;
+          emit(chunk);
+        }
       }
-    });
-  }
+    }) as unknown as AskableStreamHandler;
+    return stream(question, consumeSource);
+  });
 
-  return { stream, streamFrom, status, content, error, lastRequest, isStreaming, reset, abort, get ctx() { return ctxRef.value!; } };
+  return {
+    stream,
+    streamFrom,
+    status,
+    content,
+    error,
+    lastRequest,
+    isStreaming,
+    reset,
+    abort,
+    ctxRef,
+    get ctx() { return ctxRef.value!; },
+  };
 }

--- a/packages/qwik/src/useAskableTableSource.ts
+++ b/packages/qwik/src/useAskableTableSource.ts
@@ -1,52 +1,96 @@
+import { $ } from '@builder.io/qwik';
+import type { QRL, SyncQRL } from '@builder.io/qwik';
 import { createAskableCollectionSource } from '@askable-ui/core';
 import type {
-  AskableCreateCollectionSourceOptions,
+  AskableCollectionItemId,
   AskableContextSourceMode,
+  AskableContextSourceResolveRequest,
+  AskableCreateCollectionSourceOptions,
+  AskableResolvedContextSource,
 } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+import {
+  useAskableSource,
+  type AskableContextSourceFactory,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
+
+type TableDescription = Extract<
+  NonNullable<AskableCreateCollectionSourceOptions['describe']>,
+  (...args: never[]) => unknown
+>;
 
 export interface UseAskableTableSourceOptions<TRow = unknown, TState = unknown>
-  extends UseAskableSourceOptions {
+  extends UseAskableSourceOptions,
+    Omit<
+      AskableCreateCollectionSourceOptions<TRow, TState>,
+      | 'describe'
+      | 'getState'
+      | 'getItems'
+      | 'getVisibleItems'
+      | 'getSelectedItems'
+      | 'getItemId'
+      | 'getSelectionItemId'
+      | 'getSummary'
+      | 'resolve'
+      | 'sanitizeItem'
+      | 'sanitize'
+    > {
   id?: string;
-  /** Function returning all rows. */
-  rows?: () => readonly TRow[];
-  /** Function returning rows visible on screen. */
-  visibleRows?: () => readonly TRow[];
-  /** Function returning selected rows. */
-  selectedRows?: () => readonly TRow[];
-  /** Function returning table state (filters, sort, page, search). */
-  state?: () => TState;
-  /** Stable row identifier. */
-  getRowId?: AskableCreateCollectionSourceOptions<TRow, TState>['getItemId'];
-  /** Summary override. Computed from rows when omitted. */
-  getSummary?: () => unknown;
+  /** QRL returning all rows. Legacy table-oriented alias for `getItems`. */
+  rows?: QRL<() => readonly TRow[] | Promise<readonly TRow[]>>;
+  /** QRL returning rows visible on screen. Alias for `getVisibleItems`. */
+  visibleRows?: QRL<() => readonly TRow[] | Promise<readonly TRow[]>>;
+  /** QRL returning selected rows. Alias for `getSelectedItems`. */
+  selectedRows?: QRL<() => readonly TRow[] | Promise<readonly TRow[]>>;
+  /** QRL returning table state. Alias for `getState`. */
+  state?: QRL<() => TState | Promise<TState>>;
+  /** Synchronous QRL returning a stable row identifier. Alias for `getItemId`. */
+  getRowId?: SyncQRL<(
+    row: TRow,
+    request: AskableContextSourceResolveRequest,
+  ) => AskableCollectionItemId | null | undefined>;
   /** Maximum rows included in resolutions. Defaults to 100. */
   maxRows?: number;
-  /** Redact or transform each row before serialization. */
-  sanitizeRow?: (row: TRow) => unknown;
-  /** Human-readable description. Defaults to "Data table". */
-  describe?: string | (() => string | Promise<string>);
-  /** Source category. Defaults to "table". */
+  /** QRL that redacts or transforms each row. Alias for `sanitizeItem`. */
+  sanitizeRow?: QRL<(row: TRow) => unknown | Promise<unknown>>;
+
+  /** Core-oriented aliases, supported in addition to the table API. */
+  getState?: QRL<() => TState | Promise<TState>>;
+  getItems?: QRL<() => readonly TRow[] | Promise<readonly TRow[]>>;
+  getVisibleItems?: QRL<() => readonly TRow[] | Promise<readonly TRow[]>>;
+  getSelectedItems?: QRL<(
+    request: AskableContextSourceResolveRequest,
+  ) => readonly TRow[] | Promise<readonly TRow[]>>;
+  getItemId?: SyncQRL<(
+    item: TRow,
+    request: AskableContextSourceResolveRequest,
+  ) => AskableCollectionItemId | null | undefined>;
+  getSelectionItemId?: SyncQRL<(
+    item: unknown,
+    request: AskableContextSourceResolveRequest,
+  ) => AskableCollectionItemId | null | undefined>;
+  getSummary?: QRL<(request: AskableContextSourceResolveRequest) => unknown | Promise<unknown>>;
+  resolve?: QRL<(request: AskableContextSourceResolveRequest) => unknown | Promise<unknown>>;
+  sanitizeItem?: QRL<(
+    item: TRow,
+    request: AskableContextSourceResolveRequest,
+  ) => unknown | Promise<unknown>>;
+  sanitize?: QRL<(
+    source: AskableResolvedContextSource,
+  ) => AskableResolvedContextSource | Promise<AskableResolvedContextSource>>;
+  describe?: string | QRL<TableDescription>;
   kind?: string;
-  /** Additional modes to advertise. */
   advertisedModes?: readonly AskableContextSourceMode[];
+  /** Advanced resume-safe factory for custom collection integrations. */
+  source$?: AskableContextSourceFactory;
 }
 
-export type UseAskableTableSourceResult = UseAskableSourceResult;
+export interface UseAskableTableSourceResult extends UseAskableSourceResult {}
 
 /**
- * Registers a table (collection) source so AI assistants can see rows,
- * selections, filters, sort state, and summary statistics.
- *
- * ```tsx
- * const rows = useSignal(allOrders);
- *
- * useAskableTableSource({
- *   id: 'orders',
- *   rows: () => rows.value,
- *   sanitizeRow: ({ id, date, amount }) => ({ id, date, amount }),
- * });
- * ```
+ * Registers a table source with the established table aliases and defaults.
+ * Provider callbacks are QRLs so the source can be reconstructed after resume.
  */
 export function useAskableTableSource<TRow = unknown, TState = unknown>(
   options: UseAskableTableSourceOptions<TRow, TState> = {},
@@ -58,9 +102,19 @@ export function useAskableTableSource<TRow = unknown, TState = unknown>(
     selectedRows,
     state,
     getRowId,
-    getSummary,
     maxRows = 100,
     sanitizeRow,
+    getState,
+    getItems,
+    getVisibleItems,
+    getSelectedItems,
+    getItemId,
+    getSelectionItemId,
+    getSummary,
+    resolve,
+    sanitizeItem,
+    sanitize,
+    maxItems,
     describe = 'Data table',
     kind = 'table',
     advertisedModes,
@@ -69,27 +123,81 @@ export function useAskableTableSource<TRow = unknown, TState = unknown>(
     ctx$,
     name,
     events,
+    viewport,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    maxHistory,
+    source$,
   } = options;
 
-  const source = createAskableCollectionSource<TRow, TState>({
-    kind,
-    describe,
-    advertisedModes,
-    maxItems: maxRows,
-    getState: state,
-    getItems: rows,
-    getVisibleItems: visibleRows,
-    getSelectedItems: selectedRows,
-    getItemId: getRowId,
-    getSummary: getSummary ?? (rows
-      ? () => ({
-          totalRows: rows().length,
-          visibleRows: visibleRows?.().length,
-          selectedRows: selectedRows?.().length,
+  const items$ = getItems ?? rows;
+  const visibleItems$ = getVisibleItems ?? visibleRows;
+  const selectedItems$ = getSelectedItems ?? selectedRows;
+  const state$ = getState ?? state;
+  const itemId$ = getItemId ?? getRowId;
+  const sanitizeItem$ = sanitizeItem ?? sanitizeRow;
+  const defaultSourceFactory = $(async () => {
+    const [
+      resolvedState,
+      resolvedItems,
+      resolvedVisibleItems,
+      resolvedSelectedItems,
+      resolvedItemId,
+      resolvedSelectionItemId,
+      resolvedSummary,
+      resolvedResolve,
+      resolvedSanitizeItem,
+      resolvedSanitize,
+      resolvedDescribe,
+    ] = await Promise.all([
+      state$?.resolve(),
+      items$?.resolve(),
+      visibleItems$?.resolve(),
+      selectedItems$?.resolve(),
+      itemId$?.resolve(),
+      getSelectionItemId?.resolve(),
+      getSummary?.resolve(),
+      resolve?.resolve(),
+      sanitizeItem$?.resolve(),
+      sanitize?.resolve(),
+      typeof describe === 'string' ? describe : describe?.resolve(),
+    ]);
+    const resolvedDefaultSummary = resolvedSummary ?? (resolvedItems
+      ? async (request: AskableContextSourceResolveRequest) => ({
+          totalRows: (await resolvedItems()).length,
+          visibleRows: resolvedVisibleItems ? (await resolvedVisibleItems()).length : undefined,
+          selectedRows: resolvedSelectedItems
+            ? (await resolvedSelectedItems(request)).length
+            : undefined,
         })
-      : undefined),
-    sanitizeItem: sanitizeRow ? (row) => sanitizeRow(row) : undefined,
+      : undefined);
+
+    return createAskableCollectionSource<TRow, TState>({
+      kind,
+      describe: resolvedDescribe,
+      advertisedModes,
+      maxItems: maxItems ?? maxRows,
+      getState: resolvedState,
+      getItems: resolvedItems,
+      getVisibleItems: resolvedVisibleItems,
+      getSelectedItems: resolvedSelectedItems,
+      getItemId: resolvedItemId,
+      getSelectionItemId: resolvedSelectionItemId,
+      getSummary: resolvedDefaultSummary,
+      resolve: resolvedResolve,
+      sanitizeItem: resolvedSanitizeItem,
+      sanitize: resolvedSanitize,
+    });
   });
 
-  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+  return useAskableSource(
+    id,
+    source$ ?? defaultSourceFactory,
+    {
+      enabled, ctx, ctx$, name, events, viewport, textExtractor,
+      sanitizeMeta, sanitizeText, sanitizeSource, maxHistory,
+    },
+  );
 }

--- a/packages/qwik/src/useAskableUserSource.ts
+++ b/packages/qwik/src/useAskableUserSource.ts
@@ -1,28 +1,76 @@
+import { $ } from '@builder.io/qwik';
+import type { QRL, SyncQRL } from '@builder.io/qwik';
 import { createAskableUserSource } from '@askable-ui/core';
 import type { AskableCreateUserSourceOptions, AskableUserProfile } from '@askable-ui/core';
-import { useAskableSource, type UseAskableSourceOptions, type UseAskableSourceResult } from './useAskableSource.js';
+export type { AskableUserProfile } from '@askable-ui/core';
+import {
+  useAskableSource,
+  type AskableContextSourceFactory,
+  type UseAskableSourceOptions,
+  type UseAskableSourceResult,
+} from './useAskableSource.js';
 
-export type { AskableUserProfile };
+type UserDescription = Extract<
+  NonNullable<AskableCreateUserSourceOptions['describe']>,
+  (...args: never[]) => unknown
+>;
 
 export interface UseAskableUserSourceOptions
   extends UseAskableSourceOptions,
-    AskableCreateUserSourceOptions {
+    Omit<AskableCreateUserSourceOptions, 'describe' | 'getUser' | 'sanitize'> {
   id?: string;
+  describe?: string | QRL<UserDescription>;
+  getUser: QRL<() => AskableUserProfile | null | undefined | Promise<AskableUserProfile | null | undefined>>;
+  sanitize?: SyncQRL<NonNullable<AskableCreateUserSourceOptions['sanitize']>>;
+  /** Advanced resume-safe factory for custom identity integrations. */
+  source$?: AskableContextSourceFactory;
 }
 
-export type UseAskableUserSourceResult = UseAskableSourceResult;
+export interface UseAskableUserSourceResult extends UseAskableSourceResult {}
 
-/**
- * Registers a user source that exposes authenticated user identity
- * (name, email, roles, preferences) to the AI.
- *
- * ```tsx
- * // In your root component (after auth resolves):
- * useAskableUserSource({ getUser: () => session.value?.user ?? null });
- * ```
- */
-export function useAskableUserSource(options: UseAskableUserSourceOptions): UseAskableUserSourceResult {
-  const { id = 'user', enabled, ctx, ctx$, name, events, ...sourceOptions } = options;
-  const source = createAskableUserSource(sourceOptions);
-  return useAskableSource(id, source, { enabled, ctx, ctx$, name, events });
+/** Registers a user profile source with resume-safe data providers. */
+export function useAskableUserSource(
+  options: UseAskableUserSourceOptions,
+): UseAskableUserSourceResult {
+  const {
+    id = 'user',
+    enabled,
+    ctx,
+    ctx$,
+    name,
+    events,
+    viewport,
+    textExtractor,
+    sanitizeMeta,
+    sanitizeText,
+    sanitizeSource,
+    maxHistory,
+    describe,
+    getUser,
+    sanitize,
+    source$,
+    ...sourceOptions
+  } = options;
+
+  const defaultSourceFactory = $(async () => {
+    const [resolvedDescribe, resolvedGetUser, resolvedSanitize] = await Promise.all([
+      typeof describe === 'string' ? describe : describe?.resolve(),
+      getUser.resolve(),
+      sanitize?.resolve(),
+    ]);
+    return createAskableUserSource({
+      ...sourceOptions,
+      describe: resolvedDescribe,
+      getUser: resolvedGetUser,
+      sanitize: resolvedSanitize,
+    });
+  });
+  return useAskableSource(
+    id,
+    source$ ?? defaultSourceFactory,
+    {
+      enabled, ctx, ctx$, name, events, viewport, textExtractor,
+      sanitizeMeta, sanitizeText, sanitizeSource, maxHistory,
+    },
+  );
 }

--- a/site/docs/guide/qwik.md
+++ b/site/docs/guide/qwik.md
@@ -65,10 +65,12 @@ because that reads before the visible task runs. Read `askable.ctx` from browser
 actions, or use the stable `ctxRef` signal in lifecycle-aware code:
 
 ```tsx
+import { $ } from '@builder.io/qwik';
+
 const askable = useAskable();
 
 // Browser action after mount
-const readPrompt = () => askable.ctx.toPromptContext();
+const readPrompt = $(() => askable.ctx.toPromptContext());
 
 // Visible task or other reactive lifecycle code
 const ctx = askable.ctxRef.value;
@@ -191,7 +193,7 @@ const { addError, clearErrors } = useAskableErrorSource();
 try {
   await submitOrder();
 } catch (e) {
-  addError({ key: 'submit', message: (e as Error).message, severity: 'error' });
+  await addError({ key: 'submit', message: (e as Error).message, severity: 'error' });
 }
 ```
 
@@ -214,11 +216,25 @@ try {
 ### `useAskableStream`
 
 ```tsx
-import { component$ } from '@builder.io/qwik';
+import { $, component$ } from '@builder.io/qwik';
 import { useAskableStream } from '@askable-ui/qwik';
 
 export const AskButton = component$(() => {
   const { stream, content, isStreaming, status } = useAskableStream();
+  const handler = $(async (req, emit, signal) => {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+      signal,
+    });
+    const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      emit(value);
+    }
+  });
 
   return (
     <>
@@ -226,21 +242,7 @@ export const AskButton = component$(() => {
       {content.value && <p>{content.value}</p>}
       <button
         disabled={isStreaming.value}
-        onClick$={() =>
-          stream('Explain what I am looking at', async (req, emit) => {
-            const res = await fetch('/api/chat', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(req),
-            });
-            const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) break;
-              emit(value);
-            }
-          })
-        }
+        onClick$={() => stream('Explain what I am looking at', handler)}
       >
         Ask AI
       </button>
@@ -252,12 +254,26 @@ export const AskButton = component$(() => {
 ### `useAskableChat`
 
 ```tsx
-import { component$ } from '@builder.io/qwik';
+import { $, component$ } from '@builder.io/qwik';
 import { useAskableChat } from '@askable-ui/qwik';
 
 export const ChatPanel = component$(() => {
   const { messages, append, isStreaming, clearMessages } = useAskableChat({
-    systemPrompt: (ctx) => `You are a helpful UI assistant.\n\nCurrent UI context:\n${ctx}`,
+    systemPrompt: $((ctx) => `You are a helpful UI assistant.\n\nCurrent UI context:\n${ctx}`),
+  });
+  const handler = $(async (req, _messages, emit, signal) => {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+      signal,
+    });
+    const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      emit(value);
+    }
   });
 
   return (
@@ -272,21 +288,7 @@ export const ChatPanel = component$(() => {
 
       <button
         disabled={isStreaming.value}
-        onClick$={() =>
-          append('What is this page about?', async (req, _msgs, emit) => {
-            const res = await fetch('/api/chat', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(req),
-            });
-            const reader = res.body!.pipeThrough(new TextDecoderStream()).getReader();
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) break;
-              emit(value);
-            }
-          })
-        }
+        onClick$={() => append('What is this page about?', handler)}
       >
         Ask
       </button>
@@ -295,6 +297,45 @@ export const ChatPanel = component$(() => {
   );
 });
 ```
+
+### Resumable actions and callbacks
+
+Qwik hook actions such as `stream`, `append`, `send`, `resolve`, `reset`, and
+the mutable source-helper actions are QRLs. They can be captured directly by
+`onClick$` and other lazy event handlers. Any handler or callback passed to
+those actions must also be created with `$()`.
+
+Asynchronous source providers such as table `getItems`, user `getUser`, and
+context `sanitizeSource` use `$()`. Synchronous DOM transforms, context
+sanitizers, text extractors, and router getters use `sync$()` because the
+underlying source reads them synchronously. `sync$()` requires Qwik 1.6 or
+newer and cannot capture lexical state. For router integrations that need
+to capture component-local state, pass a `source$` factory instead:
+
+```tsx
+import { $, component$ } from '@builder.io/qwik';
+import { createAskableNavigationSource } from '@askable-ui/core';
+import { useAskableNavigationSource } from '@askable-ui/qwik';
+
+export const RouteContext = component$(() => {
+  useAskableNavigationSource({
+    source$: $(() => createAskableNavigationSource({
+      getPath: () => window.location.pathname,
+    })),
+  });
+  return null;
+});
+```
+
+`stream` and `append` handlers receive an `AbortSignal` as their final
+argument. Pass it to `fetch` or another cancellable transport so `abort()` and
+overlapping requests stop the underlying work as well as suppressing stale
+chunks.
+
+QRL invocation is asynchronous, so await mutation actions before immediately
+reading their updated signals. `streamFrom()` is runtime-only: create its
+`ReadableStream` or `AsyncIterable` in the browser event that invokes it rather
+than attempting to serialize the stream into an SSR snapshot.
 
 ## Focus history
 
@@ -317,7 +358,12 @@ export const HistoryPanel = component$(() => {
 
 ## Server-side rendering
 
-`useAskable` returns empty signals on the server — `focus.value` is `null` and `promptContext.value` is `''`. All DOM observation and source registration happens inside `useVisibleTask$`, which is browser-only. Qwik City apps with SSR are safe to use with any askable-ui hook.
+`useAskable` returns empty signals on the server — `focus.value` is `null` and
+`promptContext.value` is `''`. DOM observation and source registration happen
+inside browser-only visible tasks. Use QRL callback and source factories when
+the integration must be reconstructed after resume. Direct DOM roots, form
+elements, context objects, and source objects remain client-only compatibility
+options and are intentionally unavailable after an SSR snapshot is resumed.
 
 ## Agent requests
 


### PR DESCRIPTION
## Summary

- make imperative Qwik hook actions optimizer-safe QRLs and require QRL-compatible callback contracts
- reconstruct contexts and source helpers across browser resume while keeping runtime-only state behind `NoSerialize`
- harden stream/chat ownership, abort, cleanup, and async source registration behavior
- document `$()` / `sync$()` usage and raise the Qwik peer floor to 1.6 for public `SyncQRL` support
- add optimizer-backed event and lifecycle regressions across stream, chat, agent, generic sources, and mutable source helpers

## Testing

- `npm run build`
- `npm test`
- `npm run test:e2e`
- `npm run build` (site/docs)
- `npm pack --dry-run -w @askable-ui/qwik`
- packed consumer typecheck and runtime import with Qwik 1.6.0

Closes #388