### PR TITLE
chore(release): bump packages to 0.16.0

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Check publish workflow package coverage
         run: node scripts/check-publish-package-coverage.mjs
 
+      - name: Check MCP Registry manifest
+        run: node scripts/check-mcp-server-manifest.mjs
+
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
 

--- a/examples/analytics-dashboard-react/package-lock.json
+++ b/examples/analytics-dashboard-react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-project",
       "version": "0.1.0",
       "dependencies": {
-        "@askable-ui/react": "^0.11.0",
+        "@askable-ui/react": "^0.15.0",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-alert-dialog": "1.1.15",
@@ -84,27 +84,27 @@
       }
     },
     "node_modules/@askable-ui/context": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.11.0.tgz",
-      "integrity": "sha512-IC0THMXbESyACSxTmtSt10KC9KZFoDy5oBhm4vDAlZojjN797Hqot4GWO2DJEjaN8EkofU+aeLhS/2YMm34cug==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.15.0.tgz",
+      "integrity": "sha512-pW+zFwBSb7WHEbY30EceVzoJJnmAUBkFsec+6SOSvcaLX3Mfe+6E0guQeLxC+hzWkkVXwy4E0Vf3/Qa+/a8rBg==",
       "license": "MIT"
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-d/JaH+ghlEI8k6hlK23rKqp0UcCOLSABAaysbWNjOzJnWoSC8uzhZYqQgYhgaQU3KGGx9OlKMYNUtq4tuWUcmg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-imYWO0CFX2Qb435h5ajSzNT35mqsF63PpEjS1iEQDuvHrdEqUA3wh/N2zhLhAnCGuz+q6lkaDImzT9GZ1YTcHA==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.11.0"
+        "@askable-ui/context": "^0.15.0"
       }
     },
     "node_modules/@askable-ui/react": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.11.0.tgz",
-      "integrity": "sha512-Bnu/W3okP5WqY1coRdM/NzuN0wnh0yg7CWpUTvXTIGapi/AOiJXpb6LUxU2wef0dd/M56VhjCWtL5YCl28yMeA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.15.0.tgz",
+      "integrity": "sha512-o2wZuPGrGkvjyp9b0BaWBXfBmnmoixgTualPG84qaHIBMWeH9vS6x9Wzz/P6SMy1Y4zLfhpkEH9es8TEsAYcZg==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.11.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",

--- a/examples/analytics-dashboard-react/pnpm-lock.yaml
+++ b/examples/analytics-dashboard-react/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@askable-ui/react':
-        specifier: ^0.11.0
-        version: 0.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.15.0
+        version: 0.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.72.1(react@19.2.6))
@@ -193,14 +193,14 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@askable-ui/context@0.11.0':
-    resolution: {integrity: sha512-IC0THMXbESyACSxTmtSt10KC9KZFoDy5oBhm4vDAlZojjN797Hqot4GWO2DJEjaN8EkofU+aeLhS/2YMm34cug==}
+  '@askable-ui/context@0.15.0':
+    resolution: {integrity: sha512-pW+zFwBSb7WHEbY30EceVzoJJnmAUBkFsec+6SOSvcaLX3Mfe+6E0guQeLxC+hzWkkVXwy4E0Vf3/Qa+/a8rBg==}
 
-  '@askable-ui/core@0.11.0':
-    resolution: {integrity: sha512-d/JaH+ghlEI8k6hlK23rKqp0UcCOLSABAaysbWNjOzJnWoSC8uzhZYqQgYhgaQU3KGGx9OlKMYNUtq4tuWUcmg==}
+  '@askable-ui/core@0.15.0':
+    resolution: {integrity: sha512-imYWO0CFX2Qb435h5ajSzNT35mqsF63PpEjS1iEQDuvHrdEqUA3wh/N2zhLhAnCGuz+q6lkaDImzT9GZ1YTcHA==}
 
-  '@askable-ui/react@0.11.0':
-    resolution: {integrity: sha512-Bnu/W3okP5WqY1coRdM/NzuN0wnh0yg7CWpUTvXTIGapi/AOiJXpb6LUxU2wef0dd/M56VhjCWtL5YCl28yMeA==}
+  '@askable-ui/react@0.15.0':
+    resolution: {integrity: sha512-o2wZuPGrGkvjyp9b0BaWBXfBmnmoixgTualPG84qaHIBMWeH9vS6x9Wzz/P6SMy1Y4zLfhpkEH9es8TEsAYcZg==}
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
@@ -1774,15 +1774,15 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@askable-ui/context@0.11.0': {}
+  '@askable-ui/context@0.15.0': {}
 
-  '@askable-ui/core@0.11.0':
+  '@askable-ui/core@0.15.0':
     dependencies:
-      '@askable-ui/context': 0.11.0
+      '@askable-ui/context': 0.15.0
 
-  '@askable-ui/react@0.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@askable-ui/react@0.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@askable-ui/core': 0.11.0
+      '@askable-ui/core': 0.15.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 

--- a/examples/react-native-expo/package-lock.json
+++ b/examples/react-native-expo/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@askable-ui/example-react-native-expo",
       "version": "0.12.0",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0",
-        "@askable-ui/react-native": "^0.14.0",
+        "@askable-ui/core": "^0.15.0",
+        "@askable-ui/react-native": "^0.15.0",
         "@react-navigation/native": "^7.2.5",
         "@react-navigation/native-stack": "^7.16.0",
         "expo": "^55.0.26",
@@ -25,27 +25,27 @@
       }
     },
     "node_modules/@askable-ui/context": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.14.0.tgz",
-      "integrity": "sha512-VVNPkemI5tzuKla9rbJ74JuTNoD2xRJ6/Wurunx69e/dyiS7CxOl+xGmdFAc0GOuqUm+qVHACzd+TG2z7FEOPA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.15.0.tgz",
+      "integrity": "sha512-pW+zFwBSb7WHEbY30EceVzoJJnmAUBkFsec+6SOSvcaLX3Mfe+6E0guQeLxC+hzWkkVXwy4E0Vf3/Qa+/a8rBg==",
       "license": "MIT"
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-0CiXYWQhILkvz0+yl8KrxEXUiMkCnGwB9YWWkwd3MlRYyfRwUEyALTlYPcYjkNNKtA81PoWLsP3UzuWN1Lwa+w==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-imYWO0CFX2Qb435h5ajSzNT35mqsF63PpEjS1iEQDuvHrdEqUA3wh/N2zhLhAnCGuz+q6lkaDImzT9GZ1YTcHA==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.14.0"
+        "@askable-ui/context": "^0.15.0"
       }
     },
     "node_modules/@askable-ui/react-native": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.14.0.tgz",
-      "integrity": "sha512-HlCpcduKafXbODe9zprDtkGyD4jc0bTcKGdUoNOSmqm2yth9tqWGGPZPFTlugoGTeezNkEeYRmDmZostwAUsSA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.15.0.tgz",
+      "integrity": "sha512-D/mraVBi1C3YVi0QRQPLvzV/K4DoJzU6HWN4PIvgQ+9l2Mz+CbKyXhtfuJtmvd5nivPBl3hH6LyFvTjojUQXqA==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.14.0"
+        "@askable-ui/core": "^0.15.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "workspaces": [
         "packages/*"
       ],
@@ -2161,7 +2161,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -2204,7 +2203,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2226,7 +2224,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2248,7 +2245,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2270,7 +2266,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2292,7 +2287,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2314,7 +2308,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2336,7 +2329,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2358,7 +2350,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2380,7 +2371,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2402,7 +2392,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2424,7 +2413,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2446,7 +2434,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2468,7 +2455,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2483,8 +2469,7 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -8763,10 +8748,10 @@
     },
     "packages/angular": {
       "name": "@askable-ui/angular",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "devDependencies": {
         "@analogjs/vite-plugin-angular": "^1.18.3",
@@ -10112,7 +10097,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -10121,10 +10106,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.15.0"
+        "@askable-ui/context": "^0.16.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -10134,7 +10119,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -10142,11 +10127,11 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.15.0",
-        "@askable-ui/core": "^0.15.0",
+        "@askable-ui/context": "^0.16.0",
+        "@askable-ui/core": "^0.16.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -10161,10 +10146,10 @@
     },
     "packages/qwik": {
       "name": "@askable-ui/qwik",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "devDependencies": {
         "@builder.io/qwik": "^1.14.1",
@@ -10786,10 +10771,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -10809,10 +10794,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.17",
@@ -10866,10 +10851,10 @@
     },
     "packages/solid": {
       "name": "@askable-ui/solid",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "devDependencies": {
         "@solidjs/testing-library": "^0.8.10",
@@ -10885,10 +10870,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -10904,10 +10889,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "devDependencies": {
         "@vue/test-utils": "^2.4.11",
@@ -10922,10 +10907,10 @@
     },
     "packages/web-component": {
       "name": "@askable-ui/web-component",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/angular",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Angular service and directive to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -55,7 +55,7 @@
     "@angular/core": ">=16.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.15.0"
+    "@askable-ui/core": "^0.16.0"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^1.18.3",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Give AI assistants real-time context about what users see and select in your UI",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.15.0"
+    "@askable-ui/context": "^0.16.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Scaffold an AI-native app with askable-ui — React, Vue, Svelte, SolidJS, or Next.js in one command",
   "type": "module",
   "bin": {

--- a/packages/create-askable-app/src/scaffold.js
+++ b/packages/create-askable-app/src/scaffold.js
@@ -8,7 +8,7 @@ const pkg = JSON.parse(
 
 // Sourced from this package's own version so every scaffolded app pins the
 // current release. Never hardcode this — the integrity test asserts it matches
-// the package version, which is how the 0.14.0/0.15.0 skew is prevented.
+// the package version, preventing scaffold/package release skew.
 export const ASKABLE_VERSION = pkg.version;
 const COPILOTKIT_VERSION = '1.59.2';
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "MCP server and page bridge to expose UI context to Claude Desktop, Cursor, and any MCP client",
   "mcpName": "io.github.askable-ui/askable",
   "type": "module",
@@ -17,7 +17,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "server.json"
   ],
   "repository": {
     "type": "git",
@@ -47,8 +48,8 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.15.0",
-    "@askable-ui/core": "^0.15.0",
+    "@askable-ui/context": "^0.16.0",
+    "@askable-ui/core": "^0.16.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,21 +1,25 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.askable-ui/askable",
-  "description": "Expose your web app's live UI context — what the user is looking at, as structured Context Packets — to Claude Desktop, Cursor, and any MCP client.",
+  "description": "Expose live UI context as structured Context Packets to Claude, Cursor, and other MCP clients.",
+  "version": "0.16.0",
   "status": "active",
   "repository": {
     "url": "https://github.com/askable-ui/askable",
-    "source": "github"
+    "source": "github",
+    "subfolder": "packages/mcp"
   },
-  "version_detail": {
-    "version": "0.15.0"
-  },
+  "website_url": "https://askable-ui.com/docs/guide/mcp",
   "packages": [
     {
-      "registry_name": "npm",
-      "name": "@askable-ui/mcp",
-      "version": "0.15.0",
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@askable-ui/mcp",
+      "version": "0.16.0",
       "runtime_hint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
       "package_arguments": [
         {
           "type": "named",
@@ -29,7 +33,7 @@
           "name": "--file",
           "description": "Path to a static Context packet JSON file (alternative to --url)",
           "is_required": false,
-          "format": "string"
+          "format": "filepath"
         },
         {
           "type": "named",

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/qwik",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Qwik hooks and components to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "@builder.io/qwik": ">=1.6.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.15.0"
+    "@askable-ui/core": "^0.16.0"
   },
   "devDependencies": {
     "@builder.io/qwik": "^1.14.1",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "React Native hooks to give AI assistants real-time scroll context for mobile apps",
   "type": "module",
   "main": "./dist/index.js",
@@ -43,7 +43,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.15.0"
+    "@askable-ui/core": "^0.16.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.17",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "React hooks to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -54,7 +54,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.15.0"
+    "@askable-ui/core": "^0.16.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/solid",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "SolidJS primitives to give AI assistants real-time context about what users see and interact with",
   "type": "module",
   "main": "./dist/index.js",
@@ -57,7 +57,7 @@
     "solid-js": ">=1.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.15.0"
+    "@askable-ui/core": "^0.16.0"
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Svelte 4 & 5 stores and runes to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -143,7 +143,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.15.0"
+    "@askable-ui/core": "^0.16.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Vue 3 composables to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -54,7 +54,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.15.0"
+    "@askable-ui/core": "^0.16.0"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.4.11",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/web-component",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Zero-dependency custom element <askable-context> that works in any framework or vanilla HTML",
   "type": "module",
   "main": "./dist/index.js",
@@ -44,7 +44,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/core": "^0.15.0"
+    "@askable-ui/core": "^0.16.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/scripts/check-example-askable-versions.mjs
+++ b/scripts/check-example-askable-versions.mjs
@@ -1,10 +1,19 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 const repoRoot = path.resolve(new URL('..', import.meta.url).pathname);
 const rootPkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
 const expectedRange = `^${rootPkg.version}`;
+const publishedVersion = JSON.parse(execFileSync(
+  'npm',
+  ['view', '@askable-ui/core', 'version', '--json'],
+  { encoding: 'utf8' },
+));
+const publishedRange = `^${publishedVersion}`;
+const releasePending = publishedVersion !== rootPkg.version;
+const requiredRange = releasePending ? publishedRange : expectedRange;
 
 const examplesDir = path.join(repoRoot, 'examples');
 const exampleDirs = fs
@@ -28,7 +37,7 @@ for (const exampleName of exampleDirs) {
     for (const [name, version] of Object.entries(deps)) {
       if (!name.startsWith('@askable-ui/')) continue;
       inspected.push(`${exampleName}:${section}:${name}=${version}`);
-      if (version !== expectedRange) {
+      if (version !== requiredRange) {
         failures.push({ exampleName, section, name, version });
       }
     }
@@ -36,11 +45,17 @@ for (const exampleName of exampleDirs) {
 }
 
 if (failures.length) {
-  console.error(`Expected all example @askable-ui/* dependency ranges to equal ${expectedRange}.`);
+  console.error(`Expected all example @askable-ui/* dependency ranges to equal ${requiredRange}.`);
   for (const failure of failures) {
     console.error(`- examples/${failure.exampleName}/package.json -> ${failure.section}.${failure.name} is ${failure.version}`);
   }
   process.exit(1);
 }
 
-console.log(`OK: ${inspected.length} example @askable-ui dependency entries match ${expectedRange}.`);
+if (releasePending) {
+  console.log(
+    `Release pending: packages are ${rootPkg.version}, while npm latest is ${publishedVersion}; `
+      + `examples correctly remain on ${publishedRange}.`,
+  );
+}
+console.log(`OK: ${inspected.length} example @askable-ui dependency entries match ${requiredRange}.`);

--- a/scripts/check-mcp-server-manifest.mjs
+++ b/scripts/check-mcp-server-manifest.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(new URL('..', import.meta.url).pathname);
+const rootPackage = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+const mcpPackage = JSON.parse(fs.readFileSync(path.join(repoRoot, 'packages/mcp/package.json'), 'utf8'));
+const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'packages/mcp/server.json'), 'utf8'));
+const expectedSchema = 'https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json';
+const errors = [];
+
+if (manifest.$schema !== expectedSchema) {
+  errors.push(`$schema must be ${expectedSchema}`);
+}
+if (manifest.version !== rootPackage.version || manifest.version !== mcpPackage.version) {
+  errors.push('root, MCP package, and MCP server manifest versions must match');
+}
+if (typeof manifest.description !== 'string' || manifest.description.length > 100) {
+  errors.push('description must be a string of at most 100 characters');
+}
+if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
+  errors.push('packages must contain at least one package entry');
+} else {
+  const npmPackage = manifest.packages.find((entry) => entry.identifier === mcpPackage.name);
+  if (!npmPackage) {
+    errors.push(`packages must include ${mcpPackage.name}`);
+  } else {
+    if (npmPackage.registry_type !== 'npm') errors.push('MCP package registry_type must be npm');
+    if (npmPackage.version !== mcpPackage.version) errors.push('MCP package entry version must match package.json');
+    if (npmPackage.transport?.type !== 'stdio') errors.push('MCP package transport must be stdio');
+  }
+}
+if (!mcpPackage.files?.includes('server.json')) {
+  errors.push('packages/mcp/package.json files must publish server.json');
+}
+
+if (errors.length) {
+  console.error('Invalid packages/mcp/server.json:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(`OK: MCP Registry manifest and package metadata align at ${manifest.version}.`);

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -3,18 +3,21 @@
 askable-ui supports two kinds of docs URLs:
 
 - `/docs/` — latest stable docs
-- `/docs/<version>/` — frozen version-specific docs snapshots
+- `/docs/<version>/` — a version-specific alias for the current release, or a
+  frozen snapshot after that version is archived
 
 ## Current version
 
-- Latest stable: `v0.15.0`
-- Versioned current docs URL: `/docs/v0.15.0/`
+- Latest stable: `v0.16.0`
+- Versioned current docs URL: `/docs/v0.16.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is also published at `/docs/v0.15.0/` so version-specific links work before the first breaking release.
+The current release is rebuilt at both `/docs/` and `/docs/v0.16.0/` on every
+deployment. Only versions listed under `archived` are copied from frozen
+snapshots.
 
 ## Breaking release workflow
 

--- a/site/docs/guide/annotating.md
+++ b/site/docs/guide/annotating.md
@@ -219,7 +219,9 @@ const ctx = createAskableContext({ textExtractor: a11yTextExtractor });
 
 This is useful for icon buttons, data cells with screen-reader-only labels, or any element whose visible text is less informative than its accessible name.
 
-`a11yTextExtractor` is re-exported from every web framework package, so you can pass it straight to the hook without importing from `@askable-ui/core`:
+`a11yTextExtractor` is re-exported from the React, Vue, Svelte, SolidJS, and
+Qwik packages, so those adapters can pass it straight to a hook without
+importing from `@askable-ui/core`:
 
 ```tsx
 // React (also Vue, Svelte, Solid, Qwik)

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.15.0**.
+> Current npm release: **v0.16.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/mcp.md
+++ b/site/docs/guide/mcp.md
@@ -17,7 +17,10 @@ npm install @askable-ui/mcp @askable-ui/core
 
 ## Browser-local page bridge
 
-The page bridge exposes a `read_current_resource` MCP tool and an `askable://current` resource. A local MCP companion (e.g. a browser extension with MCP proxy support) can call this to read the current UI context without a network round trip.
+The page bridge handles a `read_current_resource` window-message request and
+returns the `askable://current` resource payload. A local MCP companion (for
+example, a browser extension with MCP proxy support) can map that response to
+MCP `resources/read` without a network round trip.
 
 ```ts
 // In your app entry point (e.g. main.ts / index.ts)
@@ -149,11 +152,15 @@ Add your endpoint to `claude_desktop_config.json`:
 
 ### Claude.ai (claude.ai/code)
 
-In Claude.ai settings → Integrations, add the MCP server URL. Claude will call `read_current_resource` to read the current UI state whenever it needs page context.
+In Claude.ai settings → Integrations, add the MCP server URL. Claude can read
+`askable://current` through MCP `resources/read`, or call
+`get_current_context` when it needs the current UI state.
 
 ### ChatGPT plugins / connectors
 
-Point the ChatGPT connector at your `/api/mcp` endpoint. The MCP server exposes a `read_current_resource` tool that ChatGPT's function-calling layer will invoke.
+Point the ChatGPT connector at your `/api/mcp` endpoint. The server exposes
+`get_current_context` and `format_context_for_prompt` tools, plus the
+`askable://current` resource.
 
 ## Connect over stdio (CLI)
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,382 +1,125 @@
-# What’s New in v0.15.0
+# What’s New in v0.16.0
 
-askable-ui v0.15.0 ships two new context source families — ecommerce cart
-tracking and wizard/stepper progress — and updates all six framework packages
-(React, Vue, Svelte, SolidJS, Angular, web-component) in one release.
-
-## Highlights
-
-### Cart source
-
-`useAskableCartSource()` exposes real-time shopping cart state so AI assistants
-can answer questions about cart contents, totals, and discounts without any
-additional description from the developer.
-
-```ts
-import { useAskableCartSource } from ‘@askable-ui/react’;
-
-const { snapshot, addItem, removeItem, updateQuantity, setTotals, clearCart } =
-  useAskableCartSource({
-    items: [{ id: ‘sku-1’, name: ‘T-Shirt’, price: 29.99, quantity: 2 }],
-    totals: { tax: 5.40, shipping: 4.99, currency: ‘USD’ },
-  });
-
-// The assistant can now answer:
-// "How many items are in my cart?"
-// "What is my order total with tax?"
-// "Do I qualify for free shipping?"
-```
-
-The snapshot includes `items`, `itemCount`, `totalQuantity`, `subtotal`,
-`discount`, `tax`, `shipping`, `total` (clamped to ≥ 0), `currency`,
-`couponCode`, `isEmpty`, and `lastModifiedAt`.
-
-Mutators work the same across frameworks:
-
-| Method | Behaviour |
-|---|---|
-| `addItem(item)` | Add or replace by `id` |
-| `removeItem(id)` | Remove by `id` |
-| `updateQuantity(id, qty)` | Update quantity; removes when `qty ≤ 0` |
-| `setItems(items)` | Replace entire item list |
-| `setTotals(totals)` | Update discount, tax, shipping, currency, couponCode |
-| `clearCart()` | Empty cart, preserving currency |
-
-Angular apps use the `AskableCartSourceService` injectable with the same methods.
-
-### Multistep / wizard source
-
-`useAskableMultistepSource()` tracks wizard and stepper progress so the
-assistant always knows which step the user is on, how far they’ve come, and
-whether the flow is complete.
-
-```ts
-import { useAskableMultistepSource } from ‘@askable-ui/react’;
-
-const { snapshot, goTo, next, prev, complete, reset } = useAskableMultistepSource({
-  steps: [
-    { id: ‘account’, label: ‘Account details’ },
-    { id: ‘billing’, label: ‘Billing info’ },
-    { id: ‘confirm’, label: ‘Confirm order’ },
-  ],
-  currentId: ‘billing’,
-});
-// snapshot.progress === 50   (0–100)
-// snapshot.currentLabel === ‘Billing info’
-// snapshot.isComplete === false
-```
-
-The snapshot includes `steps`, `currentId`, `currentIndex`, `currentLabel`,
-`totalSteps`, `progress`, `isFirstStep`, `isLastStep`, and `isComplete`.
-
-Angular apps use the `AskableMultistepSourceService` injectable.
-
-## Also in v0.14.0
-
-# What’s New in v0.14.0
-
-askable-ui v0.14.0 adds browser-local MCP page resources, so trusted
-extensions and local companions can read approved page context as
-`askable://current` without scraping the DOM.
+askable-ui v0.16.0 makes Qwik integrations genuinely resumable, expands the MCP
+package into a command-line server with live resources, and publishes the
+Context Packet Protocol as a first-class specification. It also includes a
+broad reliability and security pass across the framework adapters, MCP bridge,
+and browser sources.
 
 ## Highlights
 
-### Browser-local MCP page resources
+### Resumable Qwik actions
 
-`@askable-ui/mcp` now supports `read_current_resource` in
-`createAskableMcpPageBridge()`. The page can answer a versioned
-`window.postMessage()` request with a resource-shaped payload that maps cleanly
-to MCP `resources/read` output.
-
-```ts
-window.postMessage({
-  protocol: 'askable.mcp.page_bridge',
-  version: '0.1',
-  channel: 'askable:mcp',
-  type: 'read_current_resource',
-  requestId: crypto.randomUUID(),
-  options: {
-    sources: ['accounts'],
-    resource: {
-      uri: 'askable://current',
-      format: 'packet',
-    },
-  },
-}, window.location.origin);
-```
-
-Set `resource.format` to `prompt` when the local companion needs `text/plain`
-prompt context instead of packet JSON. Resource options are stripped before the
-context provider runs, so existing providers continue to receive only normal
-context options.
-
-### Website and starter alignment
-
-The main website navigation now uses a compact split-pill header, and the WebMCP
-section calls out `read_current_resource` alongside hosted MCP. New starter apps
-now pin Askable packages to `^0.14.0`.
-
-## Also in v0.13.1
-
-askable-ui v0.13.1 adds production-ready Web MCP support and stronger agent
-request wiring, so approved Claude and ChatGPT clients can request selected UI
-context through a hosted MCP endpoint.
-
-### Web MCP endpoint support
-
-`@askable-ui/mcp` now ships `createAskableMcpWebHandler()`, a stateless
-Streamable HTTP `Request -> Response` handler for Next.js, Vercel, Cloudflare
-Workers, Bun, Deno, and Node 18+ runtimes.
-
-```ts
-import { createAskableMcpContextProvider, createAskableMcpWebHandler } from '@askable-ui/mcp';
-
-const handler = createAskableMcpWebHandler({
-  authorize: async (request) => {
-    const token = await verifyMcpToken(request);
-    if (!token) return false;
-    return {
-      authInfo: {
-        token: token.value,
-        clientId: token.clientId,
-        scopes: token.scopes,
-      },
-    };
-  },
-  cors: {
-    origin: ['https://app.example'],
-    headers: ['Authorization', 'Content-Type', 'MCP-Protocol-Version'],
-  },
-  maxRequestBodyBytes: 256 * 1024,
-  telemetry: (event) => metrics.timing('askable.mcp.duration', event.durationMs),
-  provider: createAskableMcpContextProvider(ctx, {
-    history: 3,
-    includeViewport: true,
-    sources: ['accounts'],
-  }),
-});
-
-export const GET = handler;
-export const POST = handler;
-export const DELETE = handler;
-```
-
-The web handler supports authorization, browser preflight handling, custom
-request body limits, response headers, default `no-store`/`nosniff` headers,
-and sanitized telemetry that omits request bodies, Context packets, prompt text,
-and query strings.
-
-`@askable-ui/mcp` also includes `createAskableMcpPageBridge()` for browser-local
-MCP workflows. This is the page-side handoff for trusted extensions or local
-companions: the page answers versioned `window.postMessage()` requests with a
-Context packet, prompt-ready text, or an `askable://current` resource while the
-extension or companion exposes the local MCP server.
-
-Related docs:
-
-- [@askable-ui/mcp API](/api/mcp)
-- [AI SDK integration patterns](/examples/ai-sdk)
-
-### Agent request validation
-
-`@askable-ui/core` now exports `isAskableAgentRequest()` so server routes can
-validate agent request payloads before using prompt context, packets, selected
-source options, or user questions.
-
-```ts
-import { isAskableAgentRequest } from '@askable-ui/core';
-
-if (!isAskableAgentRequest(body)) {
-  return new Response('Invalid Askable request', { status: 400 });
-}
-```
-
-Agent requests can also preserve packet-backed selections and source requests,
-which keeps app-owned context available to downstream AI handlers.
-
-## Also in v0.12.0
-
-askable-ui v0.12.0 adds generic app-owned context sources and refines explicit
-selection capture, so users can freehand lasso irregular areas, keep selected
-text highlighted, and send richer page context to agents.
-
-### Freehand lasso selection
-
-`createAskableRegionCapture()` supports `shape: 'lasso'`. Lasso packets use
-`capture.mode: 'lasso'`, set explicit consent, include selected bounds in
-`target.bounds`, and include the freehand point path in `target.metadata.points`.
-The overlay now renders as a solid gradient stroke instead of a dotted region,
-which makes it feel closer to a cursor-drawn visual selection.
-That gradient stroke is the library default, and apps can tune it with the
-`theme` option instead of rebuilding the overlay.
-
-```ts
-import {
-  ASKABLE_REGION_CAPTURE_THEME,
-  createAskableContext,
-  createAskableRegionCapture,
-} from '@askable-ui/core';
-
-const ctx = createAskableContext({ viewport: true });
-ctx.observe(document);
-
-const capture = createAskableRegionCapture(ctx, {
-  shape: 'lasso',
-  includeViewport: true,
-  intent: 'answer using this freehand-selected region',
-  theme: {
-    ...ASKABLE_REGION_CAPTURE_THEME,
-    lassoStrokeWidth: 4,
-  },
-  onCapture: (packet) => sendToAgent(packet),
-});
-
-capture.start();
-```
-
-Framework wrappers already expose the same `shape` override through
-`useAskableRegionCapture()` for React and Vue, plus
-`createAskableRegionCaptureStore()` for Svelte.
-
-Related docs:
-
-- [Context Packets](/guide/context)
-- [@askable-ui/core API](/api/core)
-- [@askable-ui/react API](/api/react)
-
-### App-owned context sources
-
-`registerSource()` lets apps expose data that is not fully represented in the
-DOM. This covers paginated tables, virtualized lists, documents, maps, charts,
-calendars, canvases, and custom product state.
-
-```ts
-import { createAskableCollectionSource } from '@askable-ui/core';
-
-ctx.registerSource('accounts', createAskableCollectionSource({
-  describe: 'Customer accounts matching the active filters',
-  getState: () => ({ filters, sort, page, pageSize, totalCount }),
-  getVisibleItems: () => table.getVisibleRows(),
-  getSelectedItems: ({ selection }) => getAccountsByIds(selection),
-  getItemId: (account) => account.id,
-  getItems: () => accountStore.getAllMatching({ filters, sort }),
-  getSummary: ({ maxItems }) => summarizeAccounts({ filters, sort, maxItems }),
-  sanitizeItem: redactAccountFields,
-}));
-
-const promptContext = await ctx.toPromptContextAsync({
-  sources: [{ id: 'accounts', mode: 'all', maxItems: 20 }],
-});
-
-const packet = await ctx.toContextPacketAsync({
-  sources: [{ id: 'accounts', mode: 'all', maxItems: 20 }],
-});
-```
-
-React apps can register the same source with component lifecycle:
+Imperative actions returned by `@askable-ui/qwik` hooks are now Qwik `QRL`
+values. They can be invoked safely from optimizer-generated event handlers and
+after browser resume without capturing non-serializable closures.
 
 ```tsx
-const accounts = useAskableSource('accounts', {
-  getState: () => ({ filters, sort, totalCount }),
-  resolve: async ({ mode, maxItems }) => {
-    if (mode === 'visible') return table.getRowModel().rows.map((row) => row.original);
-    return summarizeAccounts({ filters, sort, maxItems });
-  },
+import { $, component$, sync$ } from '@builder.io/qwik';
+import { useAskableStream, useAskableTableSource } from '@askable-ui/qwik';
+
+export default component$(() => {
+  const stream = useAskableStream({
+    sanitizeText: sync$((text) => text.trim()),
+  });
+  const table = useAskableTableSource({
+    rows: $(() => [{ id: 'order-1', total: 42 }]),
+  });
+
+  return (
+    <button onClick$={async () => {
+      await table.notifyChanged();
+      await stream.stream(
+        'Summarize the visible orders',
+        $(async (_request, emit, signal) => {
+          if (!signal.aborted) emit('Ready');
+        }),
+      );
+    }}>
+      Ask
+    </button>
+  );
 });
 ```
 
-Vue apps get the same lifecycle-managed source registration:
+Qwik callback options use `$()` for asynchronous callbacks and `sync$()` for
+synchronous callbacks. Mutation actions are asynchronous because a resumed QRL
+may need to load its implementation chunk. The package now requires Qwik 1.6 or
+newer so its public declarations can use `SyncQRL`.
 
-```ts
-const accounts = useAskableSource('accounts', {
-  getState: () => ({ filters: filters.value, sort: sort.value, totalCount: totalCount.value }),
-  resolve: async ({ mode, maxItems }) => {
-    if (mode === 'visible') return table.getRowModel().rows.map((row) => row.original);
-    return summarizeAccounts({ filters: filters.value, sort: sort.value, maxItems });
-  },
-});
+The Qwik lifecycle also now:
+
+- creates browser-owned contexts only from visible tasks;
+- keeps runtime objects behind `NoSerialize` references;
+- suppresses stale stream/chat results when a newer request takes ownership;
+- aborts active handlers during cleanup;
+- prevents late asynchronous source factories from registering after release;
+- unregisters source handles exactly once.
+
+See the [Qwik guide](/guide/qwik) for the complete callback and lifecycle model.
+
+### MCP command-line server and live resources
+
+`@askable-ui/mcp` now ships a stdio CLI for command-based MCP clients. Point it
+at an HTTP endpoint or a Context packet file:
+
+```bash
+npx @askable-ui/mcp --url http://localhost:3000/api/context
+npx @askable-ui/mcp --file ./context-packet.json --require-redacted
 ```
 
-Svelte apps can use the store-based source helper:
+The MCP server adds a live `askable://current` resource and a
+`list_context_sources` tool, while preserving prompt-ready formatting and
+redaction enforcement. The package also ships a schema-validated MCP Registry
+manifest for registry submission and downstream distribution.
 
-```ts
-const accounts = createAskableSourceStore('accounts', {
-  getState: () => ({ filters, sort, totalCount }),
-  resolve: async ({ mode, maxItems }) => {
-    if (mode === 'visible') return table.getRowModel().rows.map((row) => row.original);
-    return summarizeAccounts({ filters, sort, maxItems });
-  },
-});
+### Context Packet Protocol and source guides
+
+The documentation now treats Context packets as a versioned, framework-neutral
+protocol rather than only a library implementation detail. New guides cover:
+
+- the [Context Packet Protocol specification](/guide/protocol);
+- [custom context sources](/guide/sources);
+- [cart and multistep sources](/guide/cart-multistep);
+- [React Native integration](/guide/react-native);
+- browser-local and remote [MCP integration](/guide/mcp).
+
+The React, Vue, Svelte, SolidJS, and Qwik packages also re-export
+`a11yTextExtractor` so accessible text extraction is discoverable without a
+separate core import.
+
+## Reliability and security
+
+This release includes fixes for:
+
+- stale React navigation callbacks after option changes;
+- adapter context option leakage between independently configured hooks;
+- Qwik context access before the browser-visible lifecycle;
+- byte-based MCP request limits for multibyte payloads;
+- unsafe storage masking defaults and page-bridge target-origin handling;
+- production dependency vulnerabilities;
+- verified issues across create-app, Svelte, React, Vue, MCP, and Context packet
+  handling.
+
+## Upgrade
+
+Keep all Askable packages on the same release line:
+
+```bash
+npm install @askable-ui/core@^0.16.0 @askable-ui/react@^0.16.0
 ```
 
-This keeps Askable generic: interactions capture what the user meant, while
-source resolvers supply what the app knows.
+For Qwik applications:
 
-### Source-backed live subscriptions
-
-`subscribeAsync()` streams `toContextAsync()` output to chat transports while
-including registered sources. It debounces rapid focus changes and ignores stale
-resolver results if the user moves to newer context before an earlier source
-request finishes.
-
-```ts
-const unsubscribe = ctx.subscribeAsync(sendLiveContext, {
-  history: 5,
-  sources: [{ id: 'accounts', mode: 'summary', timeoutMs: 750 }],
-  debounce: 100,
-});
+```bash
+npm install @askable-ui/qwik@^0.16.0 @builder.io/qwik@^1.6.0
 ```
 
-`toAgentRequest()` packages a user question with `toContextAsync()` output,
-serialized focus, optional packet data, tracing metadata, and a timestamp:
+Update Qwik callback options to `$()` or `sync$()` and `await` imperative hook
+actions where ordering matters. No migration is required for the other
+framework packages beyond updating their aligned package versions.
 
-```ts
-const request = await ctx.toAgentRequest(question, {
-  requestId,
-  history: 3,
-  sources: ['accounts'],
-  packet: true,
-});
-```
-
-You can also pass a packet that came from a region, circle, lasso, or text
-selection capture. This supports a controlled UX where the user selects context,
-sees it pinned in the chat composer, then adds a question before sending.
-Set `contextFromPacket: true` when the prompt string should be generated from
-that pinned selection instead of the current hover or click focus.
-Set `selectionFromPacket: true` when registered sources should use that packet
-target to resolve selected app data that may not be visible in the DOM.
-String source includes use `mode: 'selected'` by default in this flow unless
-`sourceMode` is set explicitly.
-
-### Region, circle, lasso, and text capture together
-
-Askable now covers four explicit user selection patterns:
-
-- draw a rectangle with `createAskableRegionCapture()`
-- circle something on screen with `shape: 'circle'`
-- lasso an irregular shape with `shape: 'lasso'`
-- highlight copy with `createAskableTextSelectionCapture()`
-
-All four produce the same versioned Context packet format for MCP bridges,
-browser tools, and agent runtimes.
-
-### Starter and docs version alignment
-
-`npm create @askable-ui/app` now scaffolds projects pinned to `^0.14.0`, and the
-versioned docs have been advanced to `/docs/v0.14.0/`.
-
-## Recommended next step
-
-If you are integrating Askable into an AI or agent runtime, start here:
-
-1. [Getting Started](/guide/getting-started)
-2. [Context Packets](/guide/context)
-3. [@askable-ui/core API](/api/core)
-
-## Version note
-
-The current published docs track **v0.15.0** at both:
+The current docs are published at both:
 
 - `/docs/`
-- `/docs/v0.15.0/`
+- `/docs/v0.16.0/`

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
 ---
 
-> Current npm release: **v0.15.0**.
+> Current npm release: **v0.16.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,11 +59,18 @@ features:
   </video>
 </div>
 
-## Latest in v0.15.0
+## Latest in v0.16.0
 
-- **Cart source** — `useAskableCartSource()` with `addItem`, `removeItem`, `updateQuantity`, `setTotals`, `clearCart`; computes subtotal, tax, shipping, and total automatically
-- **Multistep source** — `useAskableMultistepSource()` tracks wizard progress: step name, index, progress %, `isComplete`; navigate with `next`, `prev`, `goTo`
-- All six framework packages (React, Vue, Svelte, SolidJS, Angular, web-component) updated
+- **Resumable Qwik actions** — optimizer-safe `QRL` actions, `$()` / `sync$()` callback contracts, race-safe stream/chat ownership, and hardened source cleanup
+- **MCP CLI and live resources** — a stdio command for MCP clients, `askable://current`, `list_context_sources`, and registry-ready metadata
+- **Context Packet Protocol** — a first-class protocol specification plus new custom-source, cart/multistep, React Native, and MCP guides
+- **Reliability and security** — fixes across adapter option isolation, React navigation freshness, MCP request limits, storage masking, and page-bridge origins
+
+## Also in v0.15.0
+
+- cart context sources with item, quantity, totals, discount, and currency tracking
+- multistep context sources for wizard progress and completion state
+- aligned cart and multistep APIs across the framework packages
 
 ## Also in v0.14.0
 
@@ -111,7 +118,7 @@ Every pattern can produce a prompt string with `toPromptContext()` or a structur
 
 Start here:
 
-- [What’s New in v0.15.0](/guide/whats-new)
+- [What’s New in v0.16.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [The Context Packet Protocol (spec)](/guide/protocol)
 - [React interaction patterns](/guide/react#region-circle-and-lasso-capture)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.15.0",
-    "slug": "v0.15.0"
+    "label": "v0.16.0",
+    "slug": "v0.16.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.15.0`) is built on every deploy and published to both:
+The current release (`v0.16.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.15.0/` (version-specific URL)
+- `/docs/v0.16.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary

- bump all 12 public packages and internal Askable dependency ranges to 0.16.0
- publish v0.16 release notes covering resumable Qwik actions, MCP CLI/resources, protocol documentation, and reliability fixes
- repair the MCP Registry manifest against its official schema, include it in the npm package, and add a CI consistency guard
- keep standalone examples on the latest actually published release during the release window, while repairing their stale 0.11/0.14 lockfiles to 0.15
- update current and versioned documentation references to v0.16.0

## Version choice

This is a minor release because the grouped delta since v0.15.0 includes user-facing MCP capabilities, framework exports, Qwik API behavior, and new protocol/source documentation in addition to fixes.

## Validation

- full monorepo build and all workspace tests
- browser E2E suite across Chromium, Firefox, and WebKit (134 passed, 1 skipped)
- versioned VitePress documentation build
- dry-run packaging for all 12 public workspaces
- production analytics example build and React Native example typecheck
- official MCP Registry JSON Schema validation plus repository release guards
- Qwik release-note snippet typecheck

## Post-release example sync

Examples intentionally remain on the currently published 0.15 line until 0.16.0 exists on npm, avoiding ETARGET during this PR. The registry-aware CI guard will require them to advance to ^0.16.0 immediately after publication, when their lockfiles can be regenerated with real integrity metadata.
