### PR TITLE
chore(examples): consume Askable 0.16.0

### DIFF
--- a/examples/analytics-dashboard-react/package-lock.json
+++ b/examples/analytics-dashboard-react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-project",
       "version": "0.1.0",
       "dependencies": {
-        "@askable-ui/react": "^0.15.0",
+        "@askable-ui/react": "^0.16.0",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-alert-dialog": "1.1.15",
@@ -84,27 +84,27 @@
       }
     },
     "node_modules/@askable-ui/context": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.15.0.tgz",
-      "integrity": "sha512-pW+zFwBSb7WHEbY30EceVzoJJnmAUBkFsec+6SOSvcaLX3Mfe+6E0guQeLxC+hzWkkVXwy4E0Vf3/Qa+/a8rBg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.16.0.tgz",
+      "integrity": "sha512-3mWfOCukOY5oEQcmzYHcjG4dJsuXY66jq0hxOWGRLTHnKahjAZUpqsLKsYUBtx9L5dDhSBog0Hfw7ShpzANN+A==",
       "license": "MIT"
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-imYWO0CFX2Qb435h5ajSzNT35mqsF63PpEjS1iEQDuvHrdEqUA3wh/N2zhLhAnCGuz+q6lkaDImzT9GZ1YTcHA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-lEvRZSmqN71PaZziKK9jFMYRyZAswBzR2rgyKTTKBK+8ebQXFJCrx287C7NcSa+wIquaWQZ5DJj1d2hHRgzBkQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.15.0"
+        "@askable-ui/context": "^0.16.0"
       }
     },
     "node_modules/@askable-ui/react": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.15.0.tgz",
-      "integrity": "sha512-o2wZuPGrGkvjyp9b0BaWBXfBmnmoixgTualPG84qaHIBMWeH9vS6x9Wzz/P6SMy1Y4zLfhpkEH9es8TEsAYcZg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.16.0.tgz",
+      "integrity": "sha512-cR6DVVR5nhzZVpd/pehQvol7qQYTZ2crXesNy64ZwQbDbUlTS3AXcLhe6r4n8aKyyCBEx5pth1yTkdw0AvwwHg==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.15.0",
+    "@askable-ui/react": "^0.16.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/analytics-dashboard-react/pnpm-lock.yaml
+++ b/examples/analytics-dashboard-react/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@askable-ui/react':
-        specifier: ^0.15.0
-        version: 0.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.16.0
+        version: 0.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.72.1(react@19.2.6))
@@ -193,14 +193,14 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@askable-ui/context@0.15.0':
-    resolution: {integrity: sha512-pW+zFwBSb7WHEbY30EceVzoJJnmAUBkFsec+6SOSvcaLX3Mfe+6E0guQeLxC+hzWkkVXwy4E0Vf3/Qa+/a8rBg==}
+  '@askable-ui/context@0.16.0':
+    resolution: {integrity: sha512-3mWfOCukOY5oEQcmzYHcjG4dJsuXY66jq0hxOWGRLTHnKahjAZUpqsLKsYUBtx9L5dDhSBog0Hfw7ShpzANN+A==}
 
-  '@askable-ui/core@0.15.0':
-    resolution: {integrity: sha512-imYWO0CFX2Qb435h5ajSzNT35mqsF63PpEjS1iEQDuvHrdEqUA3wh/N2zhLhAnCGuz+q6lkaDImzT9GZ1YTcHA==}
+  '@askable-ui/core@0.16.0':
+    resolution: {integrity: sha512-lEvRZSmqN71PaZziKK9jFMYRyZAswBzR2rgyKTTKBK+8ebQXFJCrx287C7NcSa+wIquaWQZ5DJj1d2hHRgzBkQ==}
 
-  '@askable-ui/react@0.15.0':
-    resolution: {integrity: sha512-o2wZuPGrGkvjyp9b0BaWBXfBmnmoixgTualPG84qaHIBMWeH9vS6x9Wzz/P6SMy1Y4zLfhpkEH9es8TEsAYcZg==}
+  '@askable-ui/react@0.16.0':
+    resolution: {integrity: sha512-cR6DVVR5nhzZVpd/pehQvol7qQYTZ2crXesNy64ZwQbDbUlTS3AXcLhe6r4n8aKyyCBEx5pth1yTkdw0AvwwHg==}
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
@@ -1774,15 +1774,15 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@askable-ui/context@0.15.0': {}
+  '@askable-ui/context@0.16.0': {}
 
-  '@askable-ui/core@0.15.0':
+  '@askable-ui/core@0.16.0':
     dependencies:
-      '@askable-ui/context': 0.15.0
+      '@askable-ui/context': 0.16.0
 
-  '@askable-ui/react@0.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@askable-ui/react@0.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@askable-ui/core': 0.15.0
+      '@askable-ui/core': 0.16.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 

--- a/examples/angular-dashboard/package.json
+++ b/examples/angular-dashboard/package.json
@@ -15,7 +15,7 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
-    "@askable-ui/angular": "^0.15.0",
+    "@askable-ui/angular": "^0.16.0",
     "rxjs": "^7.8.1",
     "zone.js": "^0.15.0"
   },

--- a/examples/mcp-server/package.json
+++ b/examples/mcp-server/package.json
@@ -9,7 +9,7 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "@askable-ui/mcp": "^0.15.0",
+    "@askable-ui/mcp": "^0.16.0",
     "express": "^4.21.0"
   }
 }

--- a/examples/nextjs-app-router/package.json
+++ b/examples/nextjs-app-router/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",
-    "@askable-ui/react": "^0.15.0",
+    "@askable-ui/react": "^0.16.0",
     "ai": "^4.3.15",
     "next": "^15.3.3",
     "react": "^19.0.0",

--- a/examples/react-native-expo/package-lock.json
+++ b/examples/react-native-expo/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@askable-ui/example-react-native-expo",
       "version": "0.12.0",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0",
-        "@askable-ui/react-native": "^0.15.0",
+        "@askable-ui/core": "^0.16.0",
+        "@askable-ui/react-native": "^0.16.0",
         "@react-navigation/native": "^7.2.5",
         "@react-navigation/native-stack": "^7.16.0",
         "expo": "^55.0.26",
@@ -25,27 +25,27 @@
       }
     },
     "node_modules/@askable-ui/context": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.15.0.tgz",
-      "integrity": "sha512-pW+zFwBSb7WHEbY30EceVzoJJnmAUBkFsec+6SOSvcaLX3Mfe+6E0guQeLxC+hzWkkVXwy4E0Vf3/Qa+/a8rBg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.16.0.tgz",
+      "integrity": "sha512-3mWfOCukOY5oEQcmzYHcjG4dJsuXY66jq0hxOWGRLTHnKahjAZUpqsLKsYUBtx9L5dDhSBog0Hfw7ShpzANN+A==",
       "license": "MIT"
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-imYWO0CFX2Qb435h5ajSzNT35mqsF63PpEjS1iEQDuvHrdEqUA3wh/N2zhLhAnCGuz+q6lkaDImzT9GZ1YTcHA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-lEvRZSmqN71PaZziKK9jFMYRyZAswBzR2rgyKTTKBK+8ebQXFJCrx287C7NcSa+wIquaWQZ5DJj1d2hHRgzBkQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.15.0"
+        "@askable-ui/context": "^0.16.0"
       }
     },
     "node_modules/@askable-ui/react-native": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.15.0.tgz",
-      "integrity": "sha512-D/mraVBi1C3YVi0QRQPLvzV/K4DoJzU6HWN4PIvgQ+9l2Mz+CbKyXhtfuJtmvd5nivPBl3hH6LyFvTjojUQXqA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.16.0.tgz",
+      "integrity": "sha512-KQKhaXmaiHWW1rByACQkno1Uj/4mquOBq57sB9rIVpIWGQ2zLOVc33mZNDrxhHRUT4XkHY+6qjJfKreSPcuNLA==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.15.0"
+        "@askable-ui/core": "^0.16.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0"

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.15.0",
-    "@askable-ui/react-native": "^0.15.0",
+    "@askable-ui/core": "^0.16.0",
+    "@askable-ui/react-native": "^0.16.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/examples/solid-dashboard/package.json
+++ b/examples/solid-dashboard/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/solid": "^0.15.0",
+    "@askable-ui/solid": "^0.16.0",
     "solid-js": "^1.9.7"
   },
   "devDependencies": {

--- a/examples/svelte-dashboard/package.json
+++ b/examples/svelte-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/svelte": "^0.15.0",
+    "@askable-ui/svelte": "^0.16.0",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/examples/vercel-ai-sdk/package.json
+++ b/examples/vercel-ai-sdk/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.15.0",
+    "@askable-ui/react": "^0.16.0",
     "ai": "^4.3.16",
     "@ai-sdk/openai": "^1.3.22",
     "next": "^15.3.3",

--- a/examples/vue-dashboard/package.json
+++ b/examples/vue-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/vue": "^0.15.0",
+    "@askable-ui/vue": "^0.16.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- update every example Askable dependency to the now-published ^0.16.0 line
- regenerate the analytics npm/pnpm locks and React Native npm lock from the published tarballs

## Validation

- example version consistency check
- analytics production build after a clean install
- full workspace build followed by React Native example typecheck
- lockfiles resolve published Askable 0.16.0 packages with registry integrity metadata
