### PR TITLE
feat(bridge): add provider-neutral context bridge

### DIFF
--- a/.github/workflows/publish_preview.yml
+++ b/.github/workflows/publish_preview.yml
@@ -51,4 +51,4 @@ jobs:
         run: npm run build --workspaces --if-present
 
       - name: Publish preview packages
-        run: npx pkg-pr-new publish ./packages/context ./packages/core ./packages/mcp ./packages/react ./packages/vue ./packages/svelte ./packages/react-native ./packages/solid ./packages/angular ./packages/qwik ./packages/web-component ./packages/create-askable-app
+        run: npx pkg-pr-new publish ./packages/context ./packages/core ./packages/bridge ./packages/mcp ./packages/react ./packages/vue ./packages/svelte ./packages/react-native ./packages/solid ./packages/angular ./packages/qwik ./packages/web-component ./packages/create-askable-app

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -110,6 +110,7 @@ jobs:
 
           publish_package packages/context
           publish_package packages/core
+          publish_package packages/bridge
           publish_package packages/react
           publish_package packages/vue
           publish_package packages/svelte

--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ The format lives in [`@askable-ui/context`](https://www.npmjs.com/package/@askab
 | [Anthropic SDK](https://github.com/anthropic-ai/sdk-python) | Pass `promptContext` to `system` in `messages.create` |
 | [OpenAI SDK](https://github.com/openai/openai-node) | Pass `promptContext` to the system message |
 | [LangChain.js](https://js.langchain.com/) | Inject via `SystemMessage` |
+| Any chat surface, iframe, extension, or webhook | Use `@askable-ui/bridge` to send Context packets through provider-neutral transports |
 | Any MCP client | Use `@askable-ui/mcp` to expose as MCP tools |
 
 **Frameworks**
@@ -755,6 +756,7 @@ Or open [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html)
 |---|---|---|
 | [`@askable-ui/core`](https://www.npmjs.com/package/@askable-ui/core) | [![npm](https://img.shields.io/npm/v/@askable-ui/core?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/core) | Framework-agnostic core. Zero runtime deps. |
 | [`@askable-ui/context`](https://www.npmjs.com/package/@askable-ui/context) | [![npm](https://img.shields.io/npm/v/@askable-ui/context?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/context) | Context packet types, schema, validators |
+| [`@askable-ui/bridge`](https://www.npmjs.com/package/@askable-ui/bridge) | [![npm](https://img.shields.io/npm/v/@askable-ui/bridge?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/bridge) | Provider-neutral transports for app chat, browser extensions, MCP companions, and webhooks |
 | [`@askable-ui/react`](https://www.npmjs.com/package/@askable-ui/react) | [![npm](https://img.shields.io/npm/v/@askable-ui/react?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/react) | React 18+ hooks and components |
 | [`@askable-ui/vue`](https://www.npmjs.com/package/@askable-ui/vue) | [![npm](https://img.shields.io/npm/v/@askable-ui/vue?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/vue) | Vue 3 composables and components |
 | [`@askable-ui/svelte`](https://www.npmjs.com/package/@askable-ui/svelte) | [![npm](https://img.shields.io/npm/v/@askable-ui/svelte?color=4f46e5)](https://www.npmjs.com/package/@askable-ui/svelte) | Svelte 4 & 5 stores and components |

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,6 +266,10 @@
       "resolved": "packages/angular",
       "link": true
     },
+    "node_modules/@askable-ui/bridge": {
+      "resolved": "packages/bridge",
+      "link": true
+    },
     "node_modules/@askable-ui/context": {
       "resolved": "packages/context",
       "link": true
@@ -10093,6 +10097,18 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "packages/bridge": {
+      "name": "@askable-ui/bridge",
+      "version": "0.16.0",
+      "license": "MIT",
+      "dependencies": {
+        "@askable-ui/context": "^0.16.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.8"
       }
     },
     "packages/context": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,11 +1310,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1637,12 +1638,12 @@
       ]
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -5004,9 +5005,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5016,7 +5017,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -5295,9 +5297,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5436,9 +5439,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -1,0 +1,120 @@
+# @askable-ui/bridge
+
+Provider-neutral bridge for sending Askable context to chat surfaces, browser
+extensions, local MCP companions, and webhooks.
+
+```bash
+npm install @askable-ui/bridge @askable-ui/context
+```
+
+## Why this package exists
+
+`@askable-ui/context` defines the packet. `@askable-ui/core` captures it.
+`@askable-ui/mcp` exposes it as MCP tools and resources.
+
+`@askable-ui/bridge` is the transport layer between those packets and the place
+the user wants to ask a question. It does not depend on React, MCP, or a
+specific chatbot provider.
+
+## Send context to an in-app chat
+
+```ts
+import { createAskableBridge, createFunctionTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: {
+    getPacket: () => ctx.toContextPacket(),
+    formatPrompt: () => ctx.toPromptContext(),
+  },
+  transports: [
+    createFunctionTransport(async ({ payload }) => {
+      await sendChatMessage({
+        question: payload.question,
+        context: payload.prompt,
+        packet: payload.packet,
+      });
+    }),
+  ],
+});
+
+await bridge.sendPrompt('Why did this account churn?');
+```
+
+## Send context to a browser extension
+
+```ts
+import { createAskableBridge, createBrowserExtensionTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: { getPacket: () => ctx.toContextPacket() },
+  transports: [createBrowserExtensionTransport()],
+});
+
+await bridge.sendCurrent({
+  destination: { kind: 'browser-extension', label: 'Local AI companion' },
+});
+```
+
+The extension receives a message with a versioned `AskableBridgeEnvelope`:
+
+```ts
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type !== 'askable:bridge:context') return;
+  console.log(message.envelope.payload.packet);
+});
+```
+
+## Send context over `postMessage`
+
+```ts
+import { createAskableBridge, createPostMessageTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: { getPacket: () => ctx.toContextPacket() },
+  transports: [
+    createPostMessageTransport({
+      targetOrigin: 'https://chat.example.com',
+      targetWindow: iframe.contentWindow!,
+    }),
+  ],
+});
+```
+
+## Send context to an HTTP endpoint
+
+```ts
+import { createAskableBridge, createHttpTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: { getPacket: () => ctx.toContextPacket() },
+  transports: [
+    createHttpTransport({
+      url: '/api/askable/context',
+      headers: () => ({ authorization: `Bearer ${sessionToken}` }),
+    }),
+  ],
+});
+```
+
+## Envelope shape
+
+Every transport receives the same envelope:
+
+```ts
+{
+  protocol: 'askable.bridge',
+  version: '0.1',
+  channel: 'askable:bridge',
+  requestId: '...',
+  timestamp: '...',
+  consent: 'explicit',
+  payload: {
+    packet,
+    prompt: 'Prompt-ready context',
+    question: 'What should I do next?'
+  }
+}
+```
+
+Use `isAskableBridgeEnvelope(value)` at extension, iframe, worker, webhook, and
+storage boundaries before trusting the payload.

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@askable-ui/bridge",
+  "version": "0.16.0",
+  "description": "Provider-neutral bridge for sending Askable context to chat surfaces, browser extensions, local MCP bridges, and webhooks",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/askable-ui/askable.git",
+    "directory": "packages/bridge"
+  },
+  "scripts": {
+    "prebuild": "npm run build -w @askable-ui/context",
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run --passWithNoTests"
+  },
+  "keywords": [
+    "ai",
+    "llm",
+    "chatbot",
+    "browser-extension",
+    "mcp",
+    "model-context-protocol",
+    "context",
+    "claude",
+    "chatgpt",
+    "copilot",
+    "web",
+    "selection",
+    "data-askable",
+    "agentic"
+  ],
+  "homepage": "https://askable-ui.com",
+  "license": "MIT",
+  "dependencies": {
+    "@askable-ui/context": "^0.16.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/bridge/src/__tests__/index.test.ts
+++ b/packages/bridge/src/__tests__/index.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWebContextPacket } from '@askable-ui/context';
+import {
+  ASKABLE_BRIDGE_CHANNEL,
+  ASKABLE_BRIDGE_PROTOCOL,
+  ASKABLE_BRIDGE_VERSION,
+  createAskableBridge,
+  createAskableBridgeEnvelope,
+  createBrowserExtensionTransport,
+  createFunctionTransport,
+  createHttpTransport,
+  createPostMessageTransport,
+  isAskableBridgeEnvelope,
+} from '../index';
+
+const packet = createWebContextPacket({
+  capture: { mode: 'element-focus', gesture: 'click' },
+  target: {
+    label: 'Revenue card',
+    text: '$24k MRR',
+    metadata: { metric: 'mrr', value: 24000 },
+  },
+  privacy: { consent: 'explicit', redacted: true },
+});
+
+describe('@askable-ui/bridge', () => {
+  it('creates a versioned bridge envelope around a context packet', () => {
+    const envelope = createAskableBridgeEnvelope(packet, {
+      requestId: 'req_1',
+      question: 'What changed?',
+      prompt: 'Use the selected revenue card.',
+      destination: { kind: 'app-chat', label: 'Support chat' },
+    });
+
+    expect(envelope).toMatchObject({
+      protocol: ASKABLE_BRIDGE_PROTOCOL,
+      version: ASKABLE_BRIDGE_VERSION,
+      channel: ASKABLE_BRIDGE_CHANNEL,
+      requestId: 'req_1',
+      consent: 'explicit',
+      destination: { kind: 'app-chat', label: 'Support chat' },
+      payload: {
+        packet,
+        question: 'What changed?',
+        prompt: 'Use the selected revenue card.',
+      },
+    });
+    expect(isAskableBridgeEnvelope(envelope)).toBe(true);
+  });
+
+  it('sends current context through registered transports', async () => {
+    const handler = vi.fn();
+    const bridge = createAskableBridge({
+      provider: {
+        getPacket: () => packet,
+        formatPrompt: (current) => `Current selection: ${current.target?.label}`,
+      },
+      transports: [createFunctionTransport(handler, { id: 'capture' })],
+    });
+
+    const result = await bridge.sendPrompt('Summarize this', { requestId: 'req_2' });
+
+    expect(result).toEqual([{ ok: true, requestId: 'req_2', transportId: 'capture', response: undefined }]);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'req_2',
+        payload: expect.objectContaining({
+          question: 'Summarize this',
+          prompt: 'Current selection: Revenue card',
+        }),
+      }),
+      expect.objectContaining({ requestId: 'req_2', question: 'Summarize this' }),
+    );
+  });
+
+  it('posts bridge messages to a supplied window target', async () => {
+    const postMessage = vi.fn();
+    const transport = createPostMessageTransport({
+      targetWindow: { postMessage } as unknown as Window,
+      targetOrigin: 'https://example.com',
+    });
+
+    const ack = await transport.send(createAskableBridgeEnvelope(packet, { requestId: 'req_3' }));
+
+    expect(ack).toEqual({ ok: true, requestId: 'req_3', transportId: 'postmessage' });
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: 'askable:bridge:context',
+        envelope: expect.objectContaining({ requestId: 'req_3' }),
+      },
+      'https://example.com',
+    );
+  });
+
+  it('sends context through browser extension runtimes', async () => {
+    const runtime = {
+      sendMessage: vi.fn().mockResolvedValue({ received: true }),
+    };
+    const transport = createBrowserExtensionTransport({ runtime });
+
+    const ack = await transport.send(createAskableBridgeEnvelope(packet, { requestId: 'req_4' }));
+
+    expect(runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'askable:bridge:context',
+      envelope: expect.objectContaining({ requestId: 'req_4' }),
+    });
+    expect(ack).toEqual({
+      ok: true,
+      requestId: 'req_4',
+      transportId: 'browser-extension',
+      response: { received: true },
+    });
+  });
+
+  it('sends context to HTTP destinations', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ accepted: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const transport = createHttpTransport({
+      url: 'https://api.example.com/context',
+      headers: { authorization: 'Bearer secret' },
+      fetch: fetchMock,
+    });
+
+    const ack = await transport.send(createAskableBridgeEnvelope(packet, { requestId: 'req_5' }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/context',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: 'Bearer secret',
+          'content-type': 'application/json',
+        }),
+      }),
+    );
+    expect(ack).toEqual({
+      ok: true,
+      requestId: 'req_5',
+      transportId: 'http',
+      response: { accepted: true },
+    });
+  });
+});

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -1,0 +1,358 @@
+import type { WebContextPacket } from '@askable-ui/context';
+import { isWebContextPacket } from '@askable-ui/context';
+
+export const ASKABLE_BRIDGE_PROTOCOL = 'askable.bridge';
+export const ASKABLE_BRIDGE_VERSION = '0.1';
+export const ASKABLE_BRIDGE_CHANNEL = 'askable:bridge';
+
+export type AskableBridgeDestinationKind =
+  | 'app-chat'
+  | 'browser-extension'
+  | 'local-mcp'
+  | 'remote-mcp'
+  | 'webhook'
+  | 'clipboard'
+  | 'custom';
+
+export interface AskableBridgeDestination {
+  id?: string;
+  kind: AskableBridgeDestinationKind;
+  label?: string;
+  target?: string;
+}
+
+export interface AskableBridgeSource {
+  id?: string;
+  app?: string;
+  route?: string;
+  url?: string;
+}
+
+export interface AskableBridgePayload {
+  packet: WebContextPacket;
+  prompt?: string;
+  question?: string;
+}
+
+export interface AskableBridgeEnvelope {
+  protocol: typeof ASKABLE_BRIDGE_PROTOCOL;
+  version: typeof ASKABLE_BRIDGE_VERSION;
+  channel: typeof ASKABLE_BRIDGE_CHANNEL;
+  requestId: string;
+  timestamp: string;
+  source?: AskableBridgeSource;
+  destination?: AskableBridgeDestination;
+  consent: WebContextPacket['privacy']['consent'];
+  payload: AskableBridgePayload;
+}
+
+export interface AskableBridgeAck {
+  ok: boolean;
+  requestId: string;
+  transportId: string;
+  message?: string;
+  response?: unknown;
+}
+
+export interface AskableBridgeSendOptions {
+  requestId?: string;
+  source?: AskableBridgeSource;
+  destination?: AskableBridgeDestination;
+  question?: string;
+  prompt?: string;
+  signal?: AbortSignal;
+}
+
+export interface AskableBridgeTransport {
+  id: string;
+  send(envelope: AskableBridgeEnvelope, options?: AskableBridgeSendOptions): Promise<AskableBridgeAck>;
+}
+
+export interface AskableBridgeContextProvider {
+  getPacket(): WebContextPacket | Promise<WebContextPacket>;
+  formatPrompt?(packet: WebContextPacket, options?: AskableBridgeSendOptions): string | Promise<string>;
+}
+
+export interface AskableBridgeOptions {
+  provider?: AskableBridgeContextProvider;
+  transports?: AskableBridgeTransport[];
+  source?: AskableBridgeSource;
+  destination?: AskableBridgeDestination;
+}
+
+export interface AskableBridge {
+  send(packet: WebContextPacket, options?: AskableBridgeSendOptions): Promise<AskableBridgeAck[]>;
+  sendCurrent(options?: AskableBridgeSendOptions): Promise<AskableBridgeAck[]>;
+  sendPrompt(question: string, options?: AskableBridgeSendOptions): Promise<AskableBridgeAck[]>;
+  registerTransport(transport: AskableBridgeTransport): () => void;
+  dispose(): void;
+}
+
+export interface AskableFunctionTransportOptions {
+  id?: string;
+}
+
+export interface AskablePostMessageTransportOptions {
+  id?: string;
+  targetWindow?: Window;
+  targetOrigin?: string;
+  messageType?: string;
+}
+
+export interface AskableBrowserRuntime {
+  sendMessage(message: unknown): Promise<unknown> | void;
+}
+
+export interface AskableBrowserExtensionTransportOptions {
+  id?: string;
+  runtime?: AskableBrowserRuntime;
+  messageType?: string;
+}
+
+export interface AskableHttpTransportOptions {
+  id?: string;
+  url: string;
+  method?: 'POST' | 'PUT' | 'PATCH';
+  headers?: HeadersInit | (() => HeadersInit | Promise<HeadersInit>);
+  fetch?: typeof fetch;
+}
+
+export type AskableFunctionTransportHandler = (
+  envelope: AskableBridgeEnvelope,
+  options?: AskableBridgeSendOptions,
+) => unknown | Promise<unknown>;
+
+export function createAskableBridgeEnvelope(
+  packet: WebContextPacket,
+  options: AskableBridgeSendOptions = {},
+): AskableBridgeEnvelope {
+  assertWebContextPacket(packet);
+
+  return {
+    protocol: ASKABLE_BRIDGE_PROTOCOL,
+    version: ASKABLE_BRIDGE_VERSION,
+    channel: ASKABLE_BRIDGE_CHANNEL,
+    requestId: options.requestId ?? createRequestId(),
+    timestamp: new Date().toISOString(),
+    ...(options.source ? { source: options.source } : {}),
+    ...(options.destination ? { destination: options.destination } : {}),
+    consent: packet.privacy.consent,
+    payload: {
+      packet,
+      ...(options.prompt ? { prompt: options.prompt } : {}),
+      ...(options.question ? { question: options.question } : {}),
+    },
+  };
+}
+
+export function isAskableBridgeEnvelope(value: unknown): value is AskableBridgeEnvelope {
+  if (!isRecord(value)) return false;
+  if (value.protocol !== ASKABLE_BRIDGE_PROTOCOL) return false;
+  if (value.version !== ASKABLE_BRIDGE_VERSION) return false;
+  if (value.channel !== ASKABLE_BRIDGE_CHANNEL) return false;
+  if (typeof value.requestId !== 'string') return false;
+  if (typeof value.timestamp !== 'string') return false;
+  if (!isRecord(value.payload)) return false;
+  return isWebContextPacket(value.payload.packet);
+}
+
+export function createAskableBridge(options: AskableBridgeOptions = {}): AskableBridge {
+  const transports = new Map<string, AskableBridgeTransport>();
+
+  for (const transport of options.transports ?? []) {
+    transports.set(transport.id, transport);
+  }
+
+  const send = async (packet: WebContextPacket, sendOptions: AskableBridgeSendOptions = {}) => {
+    assertWebContextPacket(packet);
+
+    if (transports.size === 0) {
+      throw new Error('Askable bridge has no transports. Register a transport before sending context.');
+    }
+
+    const envelope = createAskableBridgeEnvelope(packet, {
+      ...sendOptions,
+      source: sendOptions.source ?? options.source,
+      destination: sendOptions.destination ?? options.destination,
+    });
+
+    return Promise.all([...transports.values()].map((transport) => transport.send(envelope, sendOptions)));
+  };
+
+  const sendCurrent = async (sendOptions: AskableBridgeSendOptions = {}) => {
+    if (!options.provider) {
+      throw new Error('Askable bridge sendCurrent() requires a context provider.');
+    }
+
+    const packet = await options.provider.getPacket();
+    const prompt =
+      sendOptions.prompt ??
+      (options.provider.formatPrompt ? await options.provider.formatPrompt(packet, sendOptions) : undefined);
+
+    return send(packet, { ...sendOptions, prompt });
+  };
+
+  const sendPrompt = async (question: string, sendOptions: AskableBridgeSendOptions = {}) => {
+    return sendCurrent({ ...sendOptions, question });
+  };
+
+  return {
+    send,
+    sendCurrent,
+    sendPrompt,
+    registerTransport(transport) {
+      transports.set(transport.id, transport);
+      return () => {
+        transports.delete(transport.id);
+      };
+    },
+    dispose() {
+      transports.clear();
+    },
+  };
+}
+
+export function createFunctionTransport(
+  handler: AskableFunctionTransportHandler,
+  options: AskableFunctionTransportOptions = {},
+): AskableBridgeTransport {
+  const id = options.id ?? 'function';
+
+  return {
+    id,
+    async send(envelope, sendOptions) {
+      const response = await handler(envelope, sendOptions);
+      return { ok: true, requestId: envelope.requestId, transportId: id, response };
+    },
+  };
+}
+
+export function createPostMessageTransport(options: AskablePostMessageTransportOptions = {}): AskableBridgeTransport {
+  const id = options.id ?? 'postmessage';
+  const messageType = options.messageType ?? 'askable:bridge:context';
+
+  return {
+    id,
+    async send(envelope) {
+      const targetWindow = options.targetWindow ?? getWindow();
+      if (!targetWindow) {
+        throw new Error('PostMessage transport requires a browser window or explicit targetWindow.');
+      }
+
+      targetWindow.postMessage({ type: messageType, envelope }, options.targetOrigin ?? '*');
+      return { ok: true, requestId: envelope.requestId, transportId: id };
+    },
+  };
+}
+
+export function createBrowserExtensionTransport(
+  options: AskableBrowserExtensionTransportOptions = {},
+): AskableBridgeTransport {
+  const id = options.id ?? 'browser-extension';
+  const messageType = options.messageType ?? 'askable:bridge:context';
+
+  return {
+    id,
+    async send(envelope) {
+      const runtime = options.runtime ?? getBrowserRuntime();
+      if (!runtime) {
+        throw new Error('Browser extension transport requires chrome.runtime, browser.runtime, or explicit runtime.');
+      }
+
+      const response = await runtime.sendMessage({ type: messageType, envelope });
+      return { ok: true, requestId: envelope.requestId, transportId: id, response };
+    },
+  };
+}
+
+export function createHttpTransport(options: AskableHttpTransportOptions): AskableBridgeTransport {
+  const id = options.id ?? 'http';
+  const method = options.method ?? 'POST';
+
+  return {
+    id,
+    async send(envelope, sendOptions) {
+      const fetchImpl = options.fetch ?? getFetch();
+      if (!fetchImpl) {
+        throw new Error('HTTP transport requires fetch or an explicit fetch implementation.');
+      }
+
+      const headers = await resolveHeaders(options.headers);
+      const response = await fetchImpl(options.url, {
+        method,
+        headers: {
+          'content-type': 'application/json',
+          ...headers,
+        },
+        body: JSON.stringify(envelope),
+        signal: sendOptions?.signal,
+      });
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          requestId: envelope.requestId,
+          transportId: id,
+          message: `HTTP ${response.status} ${response.statusText}`.trim(),
+        };
+      }
+
+      return {
+        ok: true,
+        requestId: envelope.requestId,
+        transportId: id,
+        response: await readResponseBody(response),
+      };
+    },
+  };
+}
+
+function assertWebContextPacket(packet: unknown): asserts packet is WebContextPacket {
+  if (!isWebContextPacket(packet)) {
+    throw new TypeError('Expected a valid Askable WebContextPacket.');
+  }
+}
+
+function createRequestId() {
+  const cryptoImpl = getCrypto();
+  if (cryptoImpl?.randomUUID) return cryptoImpl.randomUUID();
+  return `askable_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+}
+
+function getWindow(): Window | undefined {
+  return typeof window === 'undefined' ? undefined : window;
+}
+
+function getFetch(): typeof fetch | undefined {
+  return typeof fetch === 'undefined' ? undefined : fetch;
+}
+
+function getCrypto(): Crypto | undefined {
+  return typeof crypto === 'undefined' ? undefined : crypto;
+}
+
+function getBrowserRuntime(): AskableBrowserRuntime | undefined {
+  const globalValue = globalThis as typeof globalThis & {
+    browser?: { runtime?: AskableBrowserRuntime };
+    chrome?: { runtime?: AskableBrowserRuntime };
+  };
+
+  return globalValue.browser?.runtime ?? globalValue.chrome?.runtime;
+}
+
+async function resolveHeaders(headers: AskableHttpTransportOptions['headers']): Promise<HeadersInit> {
+  if (!headers) return {};
+  return typeof headers === 'function' ? headers() : headers;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response.text();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/bridge/tsconfig.json
+++ b/packages/bridge/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,9 @@ MCP bridge for exposing structured Context packets to AI agents.
 
 Host applications provide a context provider. The package registers MCP tools
 that return the current packet, the packet schema, and a prompt-ready text
-rendering.
+rendering. Use `@askable-ui/bridge` when the same Context packets need to move
+through app chat, browser extensions, iframes, or webhooks before they reach an
+MCP companion.
 
 ```ts
 import { createAskableContext } from '@askable-ui/core';

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
             { text: 'Prompt Serialization', link: '/guide/serialization' },
             { text: 'Context Packets', link: '/guide/context' },
             { text: 'The Context Packet Protocol', link: '/guide/protocol' },
+            { text: 'Bridge Context to Chat', link: '/guide/bridge' },
             { text: 'Migration Guides', link: '/guide/migrations' },
             { text: 'SSR Safety', link: '/guide/ssr' },
             { text: 'Browser Support', link: '/guide/browser-support' },
@@ -107,6 +108,7 @@ export default defineConfig({
           items: [
             { text: '@askable-ui/core', link: '/api/core' },
             { text: '@askable-ui/context', link: '/api/context' },
+            { text: '@askable-ui/bridge', link: '/api/bridge' },
             { text: '@askable-ui/mcp', link: '/api/mcp' },
             { text: '@askable-ui/react', link: '/api/react' },
             { text: '@askable-ui/react-native', link: '/api/react-native' },

--- a/site/docs/api/bridge.md
+++ b/site/docs/api/bridge.md
@@ -1,0 +1,123 @@
+# @askable-ui/bridge
+
+Provider-neutral transports for sending Context packets to chat surfaces,
+browser extensions, local MCP companions, and webhooks.
+
+```bash
+npm install @askable-ui/bridge
+```
+
+## Constants
+
+| Constant | Value |
+|---|---|
+| `ASKABLE_BRIDGE_PROTOCOL` | `askable.bridge` |
+| `ASKABLE_BRIDGE_VERSION` | `0.1` |
+| `ASKABLE_BRIDGE_CHANNEL` | `askable:bridge` |
+
+## `createAskableBridge(options)`
+
+Creates a bridge with a context provider and one or more transports.
+
+```ts
+import { createAskableBridge, createFunctionTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: {
+    getPacket: () => ctx.toContextPacket(),
+    formatPrompt: () => ctx.toPromptContext(),
+  },
+  transports: [
+    createFunctionTransport(({ payload }) => {
+      console.log(payload.packet, payload.prompt, payload.question);
+    }),
+  ],
+});
+```
+
+Methods:
+
+| Method | Description |
+|---|---|
+| `send(packet, options?)` | Sends a provided `WebContextPacket` |
+| `sendCurrent(options?)` | Reads the provider's current packet and sends it |
+| `sendPrompt(question, options?)` | Sends current context with a user question |
+| `registerTransport(transport)` | Adds a transport and returns an unregister function |
+| `dispose()` | Removes all registered transports |
+
+## `createAskableBridgeEnvelope(packet, options?)`
+
+Wraps a `WebContextPacket` in the bridge envelope.
+
+```ts
+const envelope = createAskableBridgeEnvelope(packet, {
+  requestId: 'req_123',
+  question: 'What changed here?',
+  destination: { kind: 'app-chat', label: 'Support assistant' },
+});
+```
+
+## `isAskableBridgeEnvelope(value)`
+
+Runtime guard for validating messages at iframe, extension, worker, webhook, and
+storage boundaries.
+
+```ts
+if (isAskableBridgeEnvelope(message.envelope)) {
+  consume(message.envelope.payload.packet);
+}
+```
+
+## Transports
+
+### `createFunctionTransport(handler, options?)`
+
+Use for in-process chat UIs or tests.
+
+```ts
+createFunctionTransport(async ({ payload }) => {
+  await sendMessage(payload.question, payload.prompt);
+});
+```
+
+### `createPostMessageTransport(options?)`
+
+Sends envelopes with `window.postMessage()`.
+
+```ts
+createPostMessageTransport({
+  targetWindow: iframe.contentWindow!,
+  targetOrigin: 'https://chat.example.com',
+});
+```
+
+### `createBrowserExtensionTransport(options?)`
+
+Sends envelopes through `chrome.runtime.sendMessage()` or
+`browser.runtime.sendMessage()`.
+
+```ts
+createBrowserExtensionTransport();
+```
+
+### `createHttpTransport(options)`
+
+Sends envelopes to a server endpoint with `fetch()`.
+
+```ts
+createHttpTransport({
+  url: '/api/askable/context',
+  headers: () => ({ authorization: `Bearer ${token}` }),
+});
+```
+
+## Types
+
+| Type | Description |
+|---|---|
+| `AskableBridgeEnvelope` | Versioned message sent to all transports |
+| `AskableBridgePayload` | Context packet plus optional prompt and question |
+| `AskableBridgeTransport` | Transport interface |
+| `AskableBridgeContextProvider` | Provider for current packet and optional prompt text |
+| `AskableBridgeAck` | Transport acknowledgement |
+| `AskableBridgeSendOptions` | Per-send request id, source, destination, question, prompt, signal |

--- a/site/docs/guide/bridge.md
+++ b/site/docs/guide/bridge.md
@@ -1,0 +1,151 @@
+# Bridge Context to Chat
+
+`@askable-ui/bridge` sends the current Context packet to wherever the user wants
+to ask a question: an in-app chat panel, an iframe, a browser extension, a local
+MCP companion, or a server endpoint.
+
+Use it when the chat surface is not the same code path that captured the
+context.
+
+## Install
+
+```bash
+npm install @askable-ui/bridge @askable-ui/core
+```
+
+## In-app chat
+
+```ts
+import { createAskableContext } from '@askable-ui/core';
+import { createAskableBridge, createFunctionTransport } from '@askable-ui/bridge';
+
+const ctx = createAskableContext();
+ctx.observe(document);
+
+const bridge = createAskableBridge({
+  provider: {
+    getPacket: () => ctx.toContextPacket(),
+    formatPrompt: () => ctx.toPromptContext(),
+  },
+  transports: [
+    createFunctionTransport(async ({ payload }) => {
+      await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          question: payload.question,
+          context: payload.prompt,
+          packet: payload.packet,
+        }),
+      });
+    }),
+  ],
+});
+
+await bridge.sendPrompt('Explain this selected account.');
+```
+
+## Browser extension handoff
+
+A browser extension can receive Askable context without the host app knowing
+which chatbot the user prefers.
+
+```ts
+import { createAskableBridge, createBrowserExtensionTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: { getPacket: () => ctx.toContextPacket() },
+  transports: [createBrowserExtensionTransport()],
+});
+
+await bridge.sendCurrent({
+  destination: { kind: 'browser-extension', label: 'Local assistant' },
+});
+```
+
+In the extension:
+
+```ts
+import { isAskableBridgeEnvelope } from '@askable-ui/bridge';
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type !== 'askable:bridge:context') return;
+  if (!isAskableBridgeEnvelope(message.envelope)) return;
+
+  const packet = message.envelope.payload.packet;
+  // Forward packet to a side panel, local app, or MCP companion.
+});
+```
+
+## Iframe or same-window bridge
+
+Use `postMessage` when a chat surface is embedded in an iframe or a sibling
+window.
+
+```ts
+import { createAskableBridge, createPostMessageTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: { getPacket: () => ctx.toContextPacket() },
+  transports: [
+    createPostMessageTransport({
+      targetWindow: chatFrame.contentWindow!,
+      targetOrigin: 'https://chat.example.com',
+    }),
+  ],
+});
+```
+
+## Webhook or backend handoff
+
+```ts
+import { createAskableBridge, createHttpTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: {
+    getPacket: () => ctx.toContextPacket(),
+    formatPrompt: () => ctx.toPromptContext(),
+  },
+  transports: [
+    createHttpTransport({
+      url: '/api/askable/context',
+      headers: () => ({ authorization: `Bearer ${sessionToken}` }),
+    }),
+  ],
+});
+```
+
+## Bridge vs MCP
+
+| Need | Use |
+|---|---|
+| Send context into your own chat UI, extension, iframe, or webhook | `@askable-ui/bridge` |
+| Expose context as MCP tools and resources for Claude, ChatGPT connectors, Cursor, or local clients | `@askable-ui/mcp` |
+| Define or validate the open packet format | `@askable-ui/context` |
+
+Most browser-local MCP setups use both packages: `@askable-ui/bridge` moves the
+packet out of the page, and `@askable-ui/mcp` exposes that packet to the local
+MCP client.
+
+## Envelope
+
+Every transport receives the same versioned envelope:
+
+```ts
+{
+  protocol: 'askable.bridge',
+  version: '0.1',
+  channel: 'askable:bridge',
+  requestId: '...',
+  timestamp: '...',
+  consent: 'explicit',
+  payload: {
+    packet,
+    prompt: 'Prompt-ready context',
+    question: 'What should I do next?'
+  }
+}
+```
+
+Use `isAskableBridgeEnvelope(value)` before trusting messages from extensions,
+iframes, workers, storage, or webhooks.

--- a/site/docs/guide/index.md
+++ b/site/docs/guide/index.md
@@ -32,7 +32,7 @@ The LLM now knows exactly what the user is looking at. The answer goes from *"re
 - **Annotate** — Add `data-askable` to any element. The value can be a JSON object or a plain string.
 - **Observe** — One `ctx.observe(document)` call covers the entire page. A `MutationObserver` automatically picks up dynamically rendered elements.
 - **Capture** — Use clicks, hover, keyboard focus, Ask AI buttons, region selection, circle selection, lasso selection, highlighted text, or app events to decide what context the user means.
-- **Inject** — `ctx.toPromptContext()` returns a string ready for any LLM system prompt. `ctx.toContextPacket()` returns a structured packet for MCP bridges, browser extensions, and agent runtimes.
+- **Inject** — `ctx.toPromptContext()` returns a string ready for any LLM system prompt. `ctx.toContextPacket()` returns a structured packet for app chat, MCP bridges, browser extensions, and agent runtimes.
 
 ## What it is not
 
@@ -71,4 +71,5 @@ All of these feed the same `AskableContext`, so your chat surface can read one c
 - [Getting Started](/guide/getting-started) — install and wire up in 5 minutes
 - [How It Works](/guide/how-it-works) — internals and architecture
 - [Context Packets](/guide/context) — structured packets for agents and MCP
+- [Bridge Context to Chat](/guide/bridge) — send packets to app chat, extensions, local companions, and webhooks
 - [API Reference](/api/core) — full method signatures and options

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -36,8 +36,8 @@ features:
     details: Capture implicit focus, explicit Ask AI buttons, highlighted text, rectangular regions, circles, and freehand lasso selections as one structured context model.
 
   - icon: 🔌
-    title: Works with agents and MCP
-    details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for MCP bridges, browser tools, and agent runtimes.
+    title: Bridge to chat and MCP
+    details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for app chat, browser extensions, MCP clients, and agent runtimes.
 ---
 
 > Current npm release: **v0.16.0**.
@@ -121,6 +121,7 @@ Start here:
 - [What’s New in v0.16.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [The Context Packet Protocol (spec)](/guide/protocol)
+- [Bridge context to chat](/guide/bridge)
 - [React interaction patterns](/guide/react#region-circle-and-lasso-capture)
 - [Angular guide](/guide/angular)
 - [React Native guide](/guide/react-native)

--- a/site/docs/package-lock.json
+++ b/site/docs/package-lock.json
@@ -2351,9 +2351,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2361,6 +2361,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },


### PR DESCRIPTION
## Summary
- add @askable-ui/bridge for sending Context packets to app chat, browser extensions, postMessage targets, and HTTP endpoints
- document bridge usage in package README, docs guide, API reference, and landing pages
- include the bridge package in preview and release publish workflows

## Verification
- npm run build -w @askable-ui/bridge
- npm run test -w @askable-ui/bridge
- npm run build --workspaces --if-present
- npm run test --workspaces --if-present
- npm run build (site/docs)
- node scripts/check-publish-package-coverage.mjs
- npm pack --dry-run -w @askable-ui/bridge
- git diff --check