### PR TITLE
chore(release): bump packages to 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "workspaces": [
         "packages/*"
       ],
@@ -8755,10 +8755,10 @@
     },
     "packages/angular": {
       "name": "@askable-ui/angular",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "devDependencies": {
         "@analogjs/vite-plugin-angular": "^1.18.3",
@@ -10104,10 +10104,10 @@
     },
     "packages/bridge": {
       "name": "@askable-ui/bridge",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.16.0"
+        "@askable-ui/context": "^0.17.0"
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -10116,7 +10116,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -10125,10 +10125,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.16.0"
+        "@askable-ui/context": "^0.17.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -10138,7 +10138,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -10146,11 +10146,11 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.16.0",
-        "@askable-ui/core": "^0.16.0",
+        "@askable-ui/context": "^0.17.0",
+        "@askable-ui/core": "^0.17.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
@@ -10165,10 +10165,10 @@
     },
     "packages/qwik": {
       "name": "@askable-ui/qwik",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "devDependencies": {
         "@builder.io/qwik": "^1.14.1",
@@ -10790,10 +10790,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -10813,10 +10813,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.17",
@@ -10870,10 +10870,10 @@
     },
     "packages/solid": {
       "name": "@askable-ui/solid",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "devDependencies": {
         "@solidjs/testing-library": "^0.8.10",
@@ -10889,10 +10889,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -10908,10 +10908,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "devDependencies": {
         "@vue/test-utils": "^2.4.11",
@@ -10926,10 +10926,10 @@
     },
     "packages/web-component": {
       "name": "@askable-ui/web-component",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/angular",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Angular service and directive to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -55,7 +55,7 @@
     "@angular/core": ">=16.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.16.0"
+    "@askable-ui/core": "^0.17.0"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^1.18.3",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/bridge",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Provider-neutral bridge for sending Askable context to chat surfaces, browser extensions, local MCP bridges, and webhooks",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.16.0"
+    "@askable-ui/context": "^0.17.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Give AI assistants real-time context about what users see and select in your UI",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.16.0"
+    "@askable-ui/context": "^0.17.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Scaffold an AI-native app with askable-ui — React, Vue, Svelte, SolidJS, or Next.js in one command",
   "type": "module",
   "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "MCP server and page bridge to expose UI context to Claude Desktop, Cursor, and any MCP client",
   "mcpName": "io.github.askable-ui/askable",
   "type": "module",
@@ -48,8 +48,8 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.16.0",
-    "@askable-ui/core": "^0.16.0",
+    "@askable-ui/context": "^0.17.0",
+    "@askable-ui/core": "^0.17.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.askable-ui/askable",
   "description": "Expose live UI context as structured Context Packets to Claude, Cursor, and other MCP clients.",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "status": "active",
   "repository": {
     "url": "https://github.com/askable-ui/askable",
@@ -15,7 +15,7 @@
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@askable-ui/mcp",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/qwik",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Qwik hooks and components to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "@builder.io/qwik": ">=1.6.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.16.0"
+    "@askable-ui/core": "^0.17.0"
   },
   "devDependencies": {
     "@builder.io/qwik": "^1.14.1",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "React Native hooks to give AI assistants real-time scroll context for mobile apps",
   "type": "module",
   "main": "./dist/index.js",
@@ -43,7 +43,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.16.0"
+    "@askable-ui/core": "^0.17.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.17",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "React hooks to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -54,7 +54,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.16.0"
+    "@askable-ui/core": "^0.17.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/solid",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "SolidJS primitives to give AI assistants real-time context about what users see and interact with",
   "type": "module",
   "main": "./dist/index.js",
@@ -57,7 +57,7 @@
     "solid-js": ">=1.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.16.0"
+    "@askable-ui/core": "^0.17.0"
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Svelte 4 & 5 stores and runes to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -143,7 +143,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.16.0"
+    "@askable-ui/core": "^0.17.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Vue 3 composables to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -54,7 +54,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.16.0"
+    "@askable-ui/core": "^0.17.0"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.4.11",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/web-component",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Zero-dependency custom element <askable-context> that works in any framework or vanilla HTML",
   "type": "module",
   "main": "./dist/index.js",
@@ -44,7 +44,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/core": "^0.16.0"
+    "@askable-ui/core": "^0.17.0"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -8,14 +8,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.16.0`
-- Versioned current docs URL: `/docs/v0.16.0/`
+- Latest stable: `v0.17.0`
+- Versioned current docs URL: `/docs/v0.17.0/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is rebuilt at both `/docs/` and `/docs/v0.16.0/` on every
+The current release is rebuilt at both `/docs/` and `/docs/v0.17.0/` on every
 deployment. Only versions listed under `archived` are copied from frozen
 snapshots.
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.16.0**.
+> Current npm release: **v0.17.0**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,4 +1,85 @@
-# What’s New in v0.16.0
+# What’s New in v0.17.0
+
+askable-ui v0.17.0 adds `@askable-ui/bridge`, a provider-neutral way to move
+Context packets from the page into app chat, browser extensions, iframes, local
+MCP companions, and webhooks. It also keeps the release pipeline clean by
+covering the new package in preview/release publishing and refreshing audit
+dependencies that were blocking CI.
+
+## Highlights
+
+### Provider-neutral context bridge
+
+`@askable-ui/bridge` gives Askable a transport layer between captured UI context
+and the place the user wants to ask a question. It works with the open Context
+packet format and stays independent of any single chatbot SDK.
+
+```ts
+import { createAskableBridge, createFunctionTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: {
+    getPacket: () => ctx.toContextPacket(),
+    formatPrompt: () => ctx.toPromptContext(),
+  },
+  transports: [
+    createFunctionTransport(async ({ payload }) => {
+      await sendChatMessage({
+        question: payload.question,
+        context: payload.prompt,
+        packet: payload.packet,
+      });
+    }),
+  ],
+});
+
+await bridge.sendPrompt('Explain this selected account.');
+```
+
+The package ships function, browser extension, `postMessage`, and HTTP
+transports. Custom transports can forward the same envelope to side panels,
+workers, native shells, local MCP companions, or provider-specific chat adapters.
+
+See [Bridge Context to Chat](/guide/bridge) and the
+[`@askable-ui/bridge` API reference](/api/bridge) for the full contract.
+
+### Bridge and MCP together
+
+Use `@askable-ui/bridge` to move packets out of the page. Use `@askable-ui/mcp`
+when those packets should be exposed as MCP tools and resources for Claude,
+ChatGPT connectors, Cursor, or local clients.
+
+Most browser-local MCP setups use both:
+
+- the bridge sends the current packet from the page to a trusted extension or
+  local companion;
+- MCP exposes that packet as `get_current_context`,
+  `format_context_for_prompt`, and `askable://current`.
+
+### Release and audit maintenance
+
+This release also:
+
+- includes `@askable-ui/bridge` in preview package publishing;
+- includes `@askable-ui/bridge` in trusted-publisher release publishing;
+- updates MCP transitive dependencies that were failing the production audit;
+- updates the docs lockfile dependency that was failing the docs audit.
+
+## Upgrade
+
+Keep all Askable packages on the same release line:
+
+```bash
+npm install @askable-ui/core@^0.17.0 @askable-ui/react@^0.17.0
+npm install @askable-ui/bridge@^0.17.0
+```
+
+The current docs are published at both:
+
+- `/docs/`
+- `/docs/v0.17.0/`
+
+## Also in v0.16.0
 
 askable-ui v0.16.0 makes Qwik integrations genuinely resumable, expands the MCP
 package into a command-line server with live resources, and publishes the
@@ -6,7 +87,7 @@ Context Packet Protocol as a first-class specification. It also includes a
 broad reliability and security pass across the framework adapters, MCP bridge,
 and browser sources.
 
-## Highlights
+### v0.16.0 highlights
 
 ### Resumable Qwik actions
 
@@ -88,7 +169,7 @@ The React, Vue, Svelte, SolidJS, and Qwik packages also re-export
 `a11yTextExtractor` so accessible text extraction is discoverable without a
 separate core import.
 
-## Reliability and security
+### v0.16.0 reliability and security
 
 This release includes fixes for:
 
@@ -101,7 +182,7 @@ This release includes fixes for:
 - verified issues across create-app, Svelte, React, Vue, MCP, and Context packet
   handling.
 
-## Upgrade
+### v0.16.0 upgrade notes
 
 Keep all Askable packages on the same release line:
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for app chat, browser extensions, MCP clients, and agent runtimes.
 ---
 
-> Current npm release: **v0.16.0**.
+> Current npm release: **v0.17.0**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,7 +59,14 @@ features:
   </video>
 </div>
 
-## Latest in v0.16.0
+## Latest in v0.17.0
+
+- **Provider-neutral bridge package** — new `@askable-ui/bridge` sends Context packets to app chat, browser extensions, `postMessage` targets, local MCP companions, and HTTP endpoints without binding Askable to one chatbot SDK
+- **Bridge docs and API reference** — new guide/API pages show function, browser extension, iframe, webhook, and MCP handoff patterns
+- **Release coverage for bridge** — preview and release publishing now include `@askable-ui/bridge` as a first-class public package
+- **Audit fixes** — production MCP transitive dependencies and docs dependencies were refreshed so CI audit gates pass cleanly
+
+## Also in v0.16.0
 
 - **Resumable Qwik actions** — optimizer-safe `QRL` actions, `$()` / `sync$()` callback contracts, race-safe stream/chat ownership, and hardened source cleanup
 - **MCP CLI and live resources** — a stdio command for MCP clients, `askable://current`, `list_context_sources`, and registry-ready metadata
@@ -118,7 +125,7 @@ Every pattern can produce a prompt string with `toPromptContext()` or a structur
 
 Start here:
 
-- [What’s New in v0.16.0](/guide/whats-new)
+- [What’s New in v0.17.0](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [The Context Packet Protocol (spec)](/guide/protocol)
 - [Bridge context to chat](/guide/bridge)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.16.0",
-    "slug": "v0.16.0"
+    "label": "v0.17.0",
+    "slug": "v0.17.0"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.16.0`) is built on every deploy and published to both:
+The current release (`v0.17.0`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.16.0/` (version-specific URL)
+- `/docs/v0.17.0/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- bump all public Askable packages and internal ranges to 0.17.0
- update MCP registry metadata for 0.17.0
- update current docs/version pages and v0.17.0 release notes for the bridge package

## Verification
- node scripts/check-mcp-server-manifest.mjs
- node scripts/check-publish-package-coverage.mjs
- node scripts/check-example-askable-versions.mjs
- npm audit --omit=dev --audit-level=high
- npm --prefix site/docs audit --package-lock-only --audit-level=high
- npm run build --workspaces --if-present
- npm run test --workspaces --if-present
- npm run build (site/docs)
- git diff --check