### PR TITLE
chore(release): bump packages to 0.17.1

### DIFF
--- a/examples/analytics-dashboard-react/package-lock.json
+++ b/examples/analytics-dashboard-react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-project",
       "version": "0.1.0",
       "dependencies": {
-        "@askable-ui/react": "^0.16.0",
+        "@askable-ui/react": "^0.17.0",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-alert-dialog": "1.1.15",
@@ -84,27 +84,27 @@
       }
     },
     "node_modules/@askable-ui/context": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.16.0.tgz",
-      "integrity": "sha512-3mWfOCukOY5oEQcmzYHcjG4dJsuXY66jq0hxOWGRLTHnKahjAZUpqsLKsYUBtx9L5dDhSBog0Hfw7ShpzANN+A==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.17.1.tgz",
+      "integrity": "sha512-Iow8LqDEIyC5HOcRfXU4ecq1SZtK8UnW9vxIgy8X7DAMnWJcIIzKJUsRSB2DZH26cjg4cOV+UqkBRFV743DqQg==",
       "license": "MIT"
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-lEvRZSmqN71PaZziKK9jFMYRyZAswBzR2rgyKTTKBK+8ebQXFJCrx287C7NcSa+wIquaWQZ5DJj1d2hHRgzBkQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-7uATJLpNyLVDSPJBHO9cX2JP3oR1J/XTWy56PubVPxCO3leKAYM5BFmmbrkFjSYzvEp7PbFRB+E1e5+/hLB9gQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.16.0"
+        "@askable-ui/context": "^0.17.0"
       }
     },
     "node_modules/@askable-ui/react": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.16.0.tgz",
-      "integrity": "sha512-cR6DVVR5nhzZVpd/pehQvol7qQYTZ2crXesNy64ZwQbDbUlTS3AXcLhe6r4n8aKyyCBEx5pth1yTkdw0AvwwHg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.17.0.tgz",
+      "integrity": "sha512-W0QbHPZ422ipo7C/qtj/u9XHuZCPykiuN0je/T4vwoNutxrL6UnDDZgjSTjAaFSgoW0uh++0BEWNpMMcKmRtuw==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.16.0",
+    "@askable-ui/react": "^0.17.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/angular-dashboard/package.json
+++ b/examples/angular-dashboard/package.json
@@ -15,7 +15,7 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
-    "@askable-ui/angular": "^0.16.0",
+    "@askable-ui/angular": "^0.17.0",
     "rxjs": "^7.8.1",
     "zone.js": "^0.15.0"
   },

--- a/examples/mcp-server/package.json
+++ b/examples/mcp-server/package.json
@@ -9,7 +9,7 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "@askable-ui/mcp": "^0.16.0",
+    "@askable-ui/mcp": "^0.17.0",
     "express": "^4.21.0"
   }
 }

--- a/examples/nextjs-app-router/package.json
+++ b/examples/nextjs-app-router/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",
-    "@askable-ui/react": "^0.16.0",
+    "@askable-ui/react": "^0.17.0",
     "ai": "^4.3.15",
     "next": "^15.3.3",
     "react": "^19.0.0",

--- a/examples/react-native-expo/package-lock.json
+++ b/examples/react-native-expo/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@askable-ui/example-react-native-expo",
       "version": "0.12.0",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0",
-        "@askable-ui/react-native": "^0.16.0",
+        "@askable-ui/core": "^0.17.0",
+        "@askable-ui/react-native": "^0.17.0",
         "@react-navigation/native": "^7.2.5",
         "@react-navigation/native-stack": "^7.16.0",
         "expo": "^55.0.26",
@@ -25,27 +25,27 @@
       }
     },
     "node_modules/@askable-ui/context": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.16.0.tgz",
-      "integrity": "sha512-3mWfOCukOY5oEQcmzYHcjG4dJsuXY66jq0hxOWGRLTHnKahjAZUpqsLKsYUBtx9L5dDhSBog0Hfw7ShpzANN+A==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.17.1.tgz",
+      "integrity": "sha512-Iow8LqDEIyC5HOcRfXU4ecq1SZtK8UnW9vxIgy8X7DAMnWJcIIzKJUsRSB2DZH26cjg4cOV+UqkBRFV743DqQg==",
       "license": "MIT"
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-lEvRZSmqN71PaZziKK9jFMYRyZAswBzR2rgyKTTKBK+8ebQXFJCrx287C7NcSa+wIquaWQZ5DJj1d2hHRgzBkQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-7uATJLpNyLVDSPJBHO9cX2JP3oR1J/XTWy56PubVPxCO3leKAYM5BFmmbrkFjSYzvEp7PbFRB+E1e5+/hLB9gQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.16.0"
+        "@askable-ui/context": "^0.17.0"
       }
     },
     "node_modules/@askable-ui/react-native": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.16.0.tgz",
-      "integrity": "sha512-KQKhaXmaiHWW1rByACQkno1Uj/4mquOBq57sB9rIVpIWGQ2zLOVc33mZNDrxhHRUT4XkHY+6qjJfKreSPcuNLA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.17.0.tgz",
+      "integrity": "sha512-EPEsZjuSlhZxl0PqJ77ir0ZFVP09Pyw00+9UPQ5Pa8YxrTWxD/ubL0H5M4UJl0UQcIiD4Nev49ho5hNbDigXxw==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.16.0"
+        "@askable-ui/core": "^0.17.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0"

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.16.0",
-    "@askable-ui/react-native": "^0.16.0",
+    "@askable-ui/core": "^0.17.0",
+    "@askable-ui/react-native": "^0.17.0",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/examples/solid-dashboard/package.json
+++ b/examples/solid-dashboard/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/solid": "^0.16.0",
+    "@askable-ui/solid": "^0.17.0",
     "solid-js": "^1.9.7"
   },
   "devDependencies": {

--- a/examples/svelte-dashboard/package.json
+++ b/examples/svelte-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/svelte": "^0.16.0",
+    "@askable-ui/svelte": "^0.17.0",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/examples/vercel-ai-sdk/package.json
+++ b/examples/vercel-ai-sdk/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.16.0",
+    "@askable-ui/react": "^0.17.0",
     "ai": "^4.3.16",
     "@ai-sdk/openai": "^1.3.22",
     "next": "^15.3.3",

--- a/examples/vue-dashboard/package.json
+++ b/examples/vue-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/vue": "^0.16.0",
+    "@askable-ui/vue": "^0.17.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "askable",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "askable",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "workspaces": [
         "packages/*"
       ],
@@ -8755,10 +8755,10 @@
     },
     "packages/angular": {
       "name": "@askable-ui/angular",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "devDependencies": {
         "@analogjs/vite-plugin-angular": "^1.18.3",
@@ -10104,10 +10104,10 @@
     },
     "packages/bridge": {
       "name": "@askable-ui/bridge",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.17.0"
+        "@askable-ui/context": "^0.17.1"
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -10116,7 +10116,7 @@
     },
     "packages/context": {
       "name": "@askable-ui/context",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -10125,10 +10125,10 @@
     },
     "packages/core": {
       "name": "@askable-ui/core",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.17.0"
+        "@askable-ui/context": "^0.17.1"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",
@@ -10138,7 +10138,7 @@
     },
     "packages/create-askable-app": {
       "name": "@askable-ui/create-app",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "bin": {
         "create-askable-app": "bin/create-askable-app.js"
@@ -10146,16 +10146,16 @@
     },
     "packages/mcp": {
       "name": "@askable-ui/mcp",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.17.0",
-        "@askable-ui/core": "^0.17.0",
+        "@askable-ui/context": "^0.17.1",
+        "@askable-ui/core": "^0.17.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
       "bin": {
-        "askable-mcp": "dist/cli.js"
+        "askable-mcp": "./dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.2",
@@ -10165,10 +10165,10 @@
     },
     "packages/qwik": {
       "name": "@askable-ui/qwik",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "devDependencies": {
         "@builder.io/qwik": "^1.14.1",
@@ -10790,10 +10790,10 @@
     },
     "packages/react": {
       "name": "@askable-ui/react",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -10813,10 +10813,10 @@
     },
     "packages/react-native": {
       "name": "@askable-ui/react-native",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "devDependencies": {
         "@types/react": "^19.2.17",
@@ -10870,10 +10870,10 @@
     },
     "packages/solid": {
       "name": "@askable-ui/solid",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "devDependencies": {
         "@solidjs/testing-library": "^0.8.10",
@@ -10889,10 +10889,10 @@
     },
     "packages/svelte": {
       "name": "@askable-ui/svelte",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -10908,10 +10908,10 @@
     },
     "packages/vue": {
       "name": "@askable-ui/vue",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "devDependencies": {
         "@vue/test-utils": "^2.4.11",
@@ -10926,10 +10926,10 @@
     },
     "packages/web-component": {
       "name": "@askable-ui/web-component",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "devDependencies": {
         "jsdom": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askable",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/angular",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Angular service and directive to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -55,7 +55,7 @@
     "@angular/core": ">=16.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.17.0"
+    "@askable-ui/core": "^0.17.1"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^1.18.3",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/bridge",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Provider-neutral bridge for sending Askable context to chat surfaces, browser extensions, local MCP bridges, and webhooks",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.17.0"
+    "@askable-ui/context": "^0.17.1"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/context",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Open Context packet types and schema for AI-native interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/core",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Give AI assistants real-time context about what users see and select in your UI",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.17.0"
+    "@askable-ui/context": "^0.17.1"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/packages/create-askable-app/package.json
+++ b/packages/create-askable-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/create-app",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Scaffold an AI-native app with askable-ui — React, Vue, Svelte, SolidJS, or Next.js in one command",
   "type": "module",
   "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/mcp",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "MCP server and page bridge to expose UI context to Claude Desktop, Cursor, and any MCP client",
   "mcpName": "io.github.askable-ui/askable",
   "type": "module",
@@ -48,8 +48,8 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/context": "^0.17.0",
-    "@askable-ui/core": "^0.17.0",
+    "@askable-ui/context": "^0.17.1",
+    "@askable-ui/core": "^0.17.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.askable-ui/askable",
   "description": "Expose live UI context as structured Context Packets to Claude, Cursor, and other MCP clients.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "status": "active",
   "repository": {
     "url": "https://github.com/askable-ui/askable",
@@ -15,7 +15,7 @@
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@askable-ui/mcp",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/qwik",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Qwik hooks and components to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "@builder.io/qwik": ">=1.6.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.17.0"
+    "@askable-ui/core": "^0.17.1"
   },
   "devDependencies": {
     "@builder.io/qwik": "^1.14.1",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react-native",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "React Native hooks to give AI assistants real-time scroll context for mobile apps",
   "type": "module",
   "main": "./dist/index.js",
@@ -43,7 +43,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.17.0"
+    "@askable-ui/core": "^0.17.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.17",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/react",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "React hooks to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -54,7 +54,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.17.0"
+    "@askable-ui/core": "^0.17.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/solid",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "SolidJS primitives to give AI assistants real-time context about what users see and interact with",
   "type": "module",
   "main": "./dist/index.js",
@@ -57,7 +57,7 @@
     "solid-js": ">=1.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.17.0"
+    "@askable-ui/core": "^0.17.1"
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/svelte",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Svelte 4 & 5 stores and runes to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -143,7 +143,7 @@
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.17.0"
+    "@askable-ui/core": "^0.17.1"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/vue",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Vue 3 composables to give AI assistants real-time context about what users see and select",
   "type": "module",
   "main": "./dist/index.js",
@@ -54,7 +54,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.17.0"
+    "@askable-ui/core": "^0.17.1"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.4.11",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askable-ui/web-component",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Zero-dependency custom element <askable-context> that works in any framework or vanilla HTML",
   "type": "module",
   "main": "./dist/index.js",
@@ -44,7 +44,7 @@
   "homepage": "https://askable-ui.com",
   "license": "MIT",
   "dependencies": {
-    "@askable-ui/core": "^0.17.0"
+    "@askable-ui/core": "^0.17.1"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/site/docs/api/versioning.md
+++ b/site/docs/api/versioning.md
@@ -8,14 +8,14 @@ askable-ui supports two kinds of docs URLs:
 
 ## Current version
 
-- Latest stable: `v0.17.0`
-- Versioned current docs URL: `/docs/v0.17.0/`
+- Latest stable: `v0.17.1`
+- Versioned current docs URL: `/docs/v0.17.1/`
 
 ## Archived versions
 
 No archived major versions yet.
 
-The current release is rebuilt at both `/docs/` and `/docs/v0.17.0/` on every
+The current release is rebuilt at both `/docs/` and `/docs/v0.17.1/` on every
 deployment. Only versions listed under `archived` are copied from frozen
 snapshots.
 

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Pick your framework
 
-> Current npm release: **v0.17.0**.
+> Current npm release: **v0.17.1**.
 >
 > Latest docs live at `/docs/`. Version-specific docs are published at `/docs/<version>/` for breaking releases.
 

--- a/site/docs/guide/whats-new.md
+++ b/site/docs/guide/whats-new.md
@@ -1,12 +1,22 @@
-# What’s New in v0.17.0
+# What’s New in v0.17.1
 
-askable-ui v0.17.0 adds `@askable-ui/bridge`, a provider-neutral way to move
-Context packets from the page into app chat, browser extensions, iframes, local
-MCP companions, and webhooks. It also keeps the release pipeline clean by
-covering the new package in preview/release publishing and refreshing audit
-dependencies that were blocking CI.
+askable-ui v0.17.1 completes the bridge package release after npm rejected the first
+new-package trusted-publisher publish. It keeps all Askable packages aligned and
+makes `@askable-ui/bridge` installable from npm.
 
 ## Highlights
+
+### Bridge package availability
+
+`@askable-ui/bridge` is now available from npm at the same version line as the
+rest of Askable. Use this patch if you want to install the provider-neutral
+bridge package.
+
+```bash
+npm install @askable-ui/bridge@^0.17.1
+```
+
+## Also in v0.17.0
 
 ### Provider-neutral context bridge
 
@@ -70,14 +80,14 @@ This release also:
 Keep all Askable packages on the same release line:
 
 ```bash
-npm install @askable-ui/core@^0.17.0 @askable-ui/react@^0.17.0
-npm install @askable-ui/bridge@^0.17.0
+npm install @askable-ui/core@^0.17.1 @askable-ui/react@^0.17.1
+npm install @askable-ui/bridge@^0.17.1
 ```
 
 The current docs are published at both:
 
 - `/docs/`
-- `/docs/v0.17.0/`
+- `/docs/v0.17.1/`
 
 ## Also in v0.16.0
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: toPromptContext() returns a plain string, while toContextPacket() returns structured Context packets for app chat, browser extensions, MCP clients, and agent runtimes.
 ---
 
-> Current npm release: **v0.17.0**.
+> Current npm release: **v0.17.1**.
 >
 > Need a breaking-release upgrade path? See [Migration Guides](/guide/migrations). Versioned docs are available at `/docs/<version>/`.
 
@@ -59,7 +59,7 @@ features:
   </video>
 </div>
 
-## Latest in v0.17.0
+## Latest in v0.17.1
 
 - **Provider-neutral bridge package** — new `@askable-ui/bridge` sends Context packets to app chat, browser extensions, `postMessage` targets, local MCP companions, and HTTP endpoints without binding Askable to one chatbot SDK
 - **Bridge docs and API reference** — new guide/API pages show function, browser extension, iframe, webhook, and MCP handoff patterns
@@ -125,7 +125,7 @@ Every pattern can produce a prompt string with `toPromptContext()` or a structur
 
 Start here:
 
-- [What’s New in v0.17.0](/guide/whats-new)
+- [What’s New in v0.17.1](/guide/whats-new)
 - [Context Packets](/guide/context)
 - [The Context Packet Protocol (spec)](/guide/protocol)
 - [Bridge context to chat](/guide/bridge)

--- a/site/docs/versions.json
+++ b/site/docs/versions.json
@@ -1,7 +1,7 @@
 {
   "current": {
-    "label": "v0.17.0",
-    "slug": "v0.17.0"
+    "label": "v0.17.1",
+    "slug": "v0.17.1"
   },
   "archived": []
 }

--- a/site/docs/versions/README.md
+++ b/site/docs/versions/README.md
@@ -2,10 +2,10 @@
 
 This directory stores frozen **built** docs snapshots for archived major versions.
 
-The current release (`v0.17.0`) is built on every deploy and published to both:
+The current release (`v0.17.1`) is built on every deploy and published to both:
 
 - `/docs/` (latest stable)
-- `/docs/v0.17.0/` (version-specific URL)
+- `/docs/v0.17.1/` (version-specific URL)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- bump Askable packages, internal ranges, MCP manifest, docs version references, and examples for the 0.17.1 recovery release
- document the bridge package availability fix in What's New
- refresh example Askable package ranges from the previous stable line

## npm recovery
- manually published @askable-ui/bridge@0.17.1 after the first new-package publish produced an uninstallable registry record
- manually published @askable-ui/context@0.17.1 so bridge dependency resolution works immediately
- verified a clean public install of @askable-ui/bridge@0.17.1 with an isolated npm cache

## Verification
- npm view @askable-ui/bridge version --json
- npm install @askable-ui/bridge@0.17.1 --ignore-scripts with isolated npm cache
- node scripts/check-mcp-server-manifest.mjs
- node scripts/check-publish-package-coverage.mjs
- node scripts/check-example-askable-versions.mjs
- npm audit --omit=dev --audit-level=high
- npm --prefix site/docs audit --package-lock-only --audit-level=high
- npm run build --workspaces --if-present
- npm run test --workspaces --if-present
- npm run build in site/docs
- git diff --check
