### PR TITLE
fix(bridge): harden transports, privacy gates, and envelope guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,43 @@ There's also a fetch-compatible HTTP handler (`createAskableMcpWebHandler`) for 
 
 ---
 
+## Bridge — your own chat UI, extensions, iframes, and webhooks
+
+Not every assistant is an MCP client. `@askable-ui/bridge` moves the same Context packet to wherever the user actually asks the question, through provider-neutral transports:
+
+```ts
+import { createAskableBridge, createFunctionTransport } from '@askable-ui/bridge';
+
+const bridge = createAskableBridge({
+  provider: {
+    getPacket: () => ctx.toContextPacketAsync(),
+    formatPrompt: () => ctx.toContextAsync(),
+  },
+  transports: [
+    createFunctionTransport(({ payload }) =>
+      sendChatMessage({ question: payload.question, context: payload.prompt, packet: payload.packet }),
+    ),
+  ],
+  requireRedacted: true,
+});
+
+await bridge.sendPrompt('Why did this account churn?');
+```
+
+Swap the transport, not the capture code: `createPostMessageTransport()` for iframes, `createBrowserExtensionTransport()` for `chrome.runtime`, `createHttpTransport()` for a webhook or backend. Every transport receives the same versioned envelope, guarded on the far side by `isAskableBridgeEnvelope()`.
+
+| Need | Use |
+|---|---|
+| Send context into your own chat UI, extension, iframe, or webhook | `@askable-ui/bridge` |
+| Expose context as MCP tools and resources for Claude, ChatGPT connectors, or Cursor | `@askable-ui/mcp` |
+| Define or validate the open packet format | `@askable-ui/context` |
+
+Browser-local MCP setups usually use both: the bridge moves the packet out of the page, and `@askable-ui/mcp` exposes it to the local MCP client.
+
+→ **[Bridge guide](https://askable-ui.com/docs/guide/bridge)**
+
+---
+
 ## How it works
 
 **1. Annotate** — your existing data, on your existing elements
@@ -783,6 +820,7 @@ Or open [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html)
 - **Explicit capture** — region, circle, lasso, and text-selection capture for user-directed AI
 - **Privacy & redaction** — strip sensitive fields before data leaves the page
 - **MCP bridge** — expose any context as `get_current_context` and `format_context_for_prompt` MCP tools
+- **Context transports** — send the same packet to app chat, iframes, extensions, or webhooks with `@askable-ui/bridge`
 - **Ask AI button** — `useAskableAgent()` packages context + question into a request payload in one call
 - **Streaming chat** — `useAskableChat()` multi-turn conversation with automatic context injection per turn
 - **Streaming primitives** — `useAskableStream()` for one-shot streaming with `abort()`, `content`, and status

--- a/examples/analytics-dashboard-react/package-lock.json
+++ b/examples/analytics-dashboard-react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-project",
       "version": "0.1.0",
       "dependencies": {
-        "@askable-ui/react": "^0.17.0",
+        "@askable-ui/react": "^0.17.1",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-alert-dialog": "1.1.15",
@@ -90,21 +90,21 @@
       "license": "MIT"
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-7uATJLpNyLVDSPJBHO9cX2JP3oR1J/XTWy56PubVPxCO3leKAYM5BFmmbrkFjSYzvEp7PbFRB+E1e5+/hLB9gQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.17.1.tgz",
+      "integrity": "sha512-3qDfHaQ0jgCCJPCXsHfawrRWZ4ef1v48R9E8J6CBgqXXZLj5L9r8y4+LOmAfQ+W0GU7CsU+Qu0+5xANqdBbiYQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.17.0"
+        "@askable-ui/context": "^0.17.1"
       }
     },
     "node_modules/@askable-ui/react": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.17.0.tgz",
-      "integrity": "sha512-W0QbHPZ422ipo7C/qtj/u9XHuZCPykiuN0je/T4vwoNutxrL6UnDDZgjSTjAaFSgoW0uh++0BEWNpMMcKmRtuw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react/-/react-0.17.1.tgz",
+      "integrity": "sha512-g5E/M14PEKvgyjcNoEpWien/HzELHT/XZzd+10MmP0gLRgjbP3B5r5bVoAi0bgx7u21tJ3qaRAvPMfa6Cv7GWQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "peerDependencies": {
         "react": ">=17.0.0",

--- a/examples/analytics-dashboard-react/package.json
+++ b/examples/analytics-dashboard-react/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.17.0",
+    "@askable-ui/react": "^0.17.1",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",

--- a/examples/analytics-dashboard-react/pnpm-lock.yaml
+++ b/examples/analytics-dashboard-react/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@askable-ui/react':
-        specifier: ^0.16.0
-        version: 0.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.17.1
+        version: 0.17.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.72.1(react@19.2.6))
@@ -193,14 +193,14 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@askable-ui/context@0.16.0':
-    resolution: {integrity: sha512-3mWfOCukOY5oEQcmzYHcjG4dJsuXY66jq0hxOWGRLTHnKahjAZUpqsLKsYUBtx9L5dDhSBog0Hfw7ShpzANN+A==}
+  '@askable-ui/context@0.17.1':
+    resolution: {integrity: sha512-Iow8LqDEIyC5HOcRfXU4ecq1SZtK8UnW9vxIgy8X7DAMnWJcIIzKJUsRSB2DZH26cjg4cOV+UqkBRFV743DqQg==}
 
-  '@askable-ui/core@0.16.0':
-    resolution: {integrity: sha512-lEvRZSmqN71PaZziKK9jFMYRyZAswBzR2rgyKTTKBK+8ebQXFJCrx287C7NcSa+wIquaWQZ5DJj1d2hHRgzBkQ==}
+  '@askable-ui/core@0.17.1':
+    resolution: {integrity: sha512-3qDfHaQ0jgCCJPCXsHfawrRWZ4ef1v48R9E8J6CBgqXXZLj5L9r8y4+LOmAfQ+W0GU7CsU+Qu0+5xANqdBbiYQ==}
 
-  '@askable-ui/react@0.16.0':
-    resolution: {integrity: sha512-cR6DVVR5nhzZVpd/pehQvol7qQYTZ2crXesNy64ZwQbDbUlTS3AXcLhe6r4n8aKyyCBEx5pth1yTkdw0AvwwHg==}
+  '@askable-ui/react@0.17.1':
+    resolution: {integrity: sha512-g5E/M14PEKvgyjcNoEpWien/HzELHT/XZzd+10MmP0gLRgjbP3B5r5bVoAi0bgx7u21tJ3qaRAvPMfa6Cv7GWQ==}
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
@@ -1774,15 +1774,15 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@askable-ui/context@0.16.0': {}
+  '@askable-ui/context@0.17.1': {}
 
-  '@askable-ui/core@0.16.0':
+  '@askable-ui/core@0.17.1':
     dependencies:
-      '@askable-ui/context': 0.16.0
+      '@askable-ui/context': 0.17.1
 
-  '@askable-ui/react@0.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@askable-ui/react@0.17.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@askable-ui/core': 0.16.0
+      '@askable-ui/core': 0.17.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 

--- a/examples/angular-dashboard/package.json
+++ b/examples/angular-dashboard/package.json
@@ -15,7 +15,7 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
-    "@askable-ui/angular": "^0.17.0",
+    "@askable-ui/angular": "^0.17.1",
     "rxjs": "^7.8.1",
     "zone.js": "^0.15.0"
   },

--- a/examples/mcp-server/package.json
+++ b/examples/mcp-server/package.json
@@ -9,7 +9,7 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "@askable-ui/mcp": "^0.17.0",
+    "@askable-ui/mcp": "^0.17.1",
     "express": "^4.21.0"
   }
 }

--- a/examples/nextjs-app-router/package.json
+++ b/examples/nextjs-app-router/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",
-    "@askable-ui/react": "^0.17.0",
+    "@askable-ui/react": "^0.17.1",
     "ai": "^4.3.15",
     "next": "^15.3.3",
     "react": "^19.0.0",

--- a/examples/react-native-expo/package-lock.json
+++ b/examples/react-native-expo/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@askable-ui/example-react-native-expo",
       "version": "0.12.0",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0",
-        "@askable-ui/react-native": "^0.17.0",
+        "@askable-ui/core": "^0.17.1",
+        "@askable-ui/react-native": "^0.17.1",
         "@react-navigation/native": "^7.2.5",
         "@react-navigation/native-stack": "^7.16.0",
         "expo": "^55.0.26",
@@ -31,21 +31,21 @@
       "license": "MIT"
     },
     "node_modules/@askable-ui/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-7uATJLpNyLVDSPJBHO9cX2JP3oR1J/XTWy56PubVPxCO3leKAYM5BFmmbrkFjSYzvEp7PbFRB+E1e5+/hLB9gQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.17.1.tgz",
+      "integrity": "sha512-3qDfHaQ0jgCCJPCXsHfawrRWZ4ef1v48R9E8J6CBgqXXZLj5L9r8y4+LOmAfQ+W0GU7CsU+Qu0+5xANqdBbiYQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/context": "^0.17.0"
+        "@askable-ui/context": "^0.17.1"
       }
     },
     "node_modules/@askable-ui/react-native": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.17.0.tgz",
-      "integrity": "sha512-EPEsZjuSlhZxl0PqJ77ir0ZFVP09Pyw00+9UPQ5Pa8YxrTWxD/ubL0H5M4UJl0UQcIiD4Nev49ho5hNbDigXxw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/react-native/-/react-native-0.17.1.tgz",
+      "integrity": "sha512-1D3cf2SxJUtyQh5yqtmkq2UMuVJu5NnjiC03Ppj9QVmBh82gTBOJHp6sGEqjonjz+L3x3aNTP5JUIcWxNG5tQQ==",
       "license": "MIT",
       "dependencies": {
-        "@askable-ui/core": "^0.17.0"
+        "@askable-ui/core": "^0.17.1"
       },
       "peerDependencies": {
         "react": ">=17.0.0"

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@askable-ui/core": "^0.17.0",
-    "@askable-ui/react-native": "^0.17.0",
+    "@askable-ui/core": "^0.17.1",
+    "@askable-ui/react-native": "^0.17.1",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "^55.0.26",

--- a/examples/solid-dashboard/package.json
+++ b/examples/solid-dashboard/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/solid": "^0.17.0",
+    "@askable-ui/solid": "^0.17.1",
     "solid-js": "^1.9.7"
   },
   "devDependencies": {

--- a/examples/svelte-dashboard/package.json
+++ b/examples/svelte-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/svelte": "^0.17.0",
+    "@askable-ui/svelte": "^0.17.1",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/examples/vercel-ai-sdk/package.json
+++ b/examples/vercel-ai-sdk/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@askable-ui/react": "^0.17.0",
+    "@askable-ui/react": "^0.17.1",
     "ai": "^4.3.16",
     "@ai-sdk/openai": "^1.3.22",
     "next": "^15.3.3",

--- a/examples/vue-dashboard/package.json
+++ b/examples/vue-dashboard/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@askable-ui/vue": "^0.17.0",
+    "@askable-ui/vue": "^0.17.1",
     "vue": "^3.5.0"
   },
   "devDependencies": {

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -23,8 +23,8 @@ import { createAskableBridge, createFunctionTransport } from '@askable-ui/bridge
 
 const bridge = createAskableBridge({
   provider: {
-    getPacket: () => ctx.toContextPacket(),
-    formatPrompt: () => ctx.toPromptContext(),
+    getPacket: () => ctx.toContextPacketAsync(),
+    formatPrompt: () => ctx.toContextAsync(),
   },
   transports: [
     createFunctionTransport(async ({ payload }) => {
@@ -40,13 +40,25 @@ const bridge = createAskableBridge({
 await bridge.sendPrompt('Why did this account churn?');
 ```
 
+`getPacket` may return a promise. Prefer `toContextPacketAsync()` — only the
+async form resolves sources registered with `ctx.registerSource()` into
+`surrounding.sources`.
+
+Already building requests with `ctx.toAgentRequest()`? Send them straight
+through, without resolving context a second time:
+
+```ts
+const request = await ctx.toAgentRequest('Why did this account churn?', { packet: true });
+await bridge.sendAgentRequest(request);
+```
+
 ## Send context to a browser extension
 
 ```ts
 import { createAskableBridge, createBrowserExtensionTransport } from '@askable-ui/bridge';
 
 const bridge = createAskableBridge({
-  provider: { getPacket: () => ctx.toContextPacket() },
+  provider: { getPacket: () => ctx.toContextPacketAsync() },
   transports: [createBrowserExtensionTransport()],
 });
 
@@ -60,6 +72,7 @@ The extension receives a message with a versioned `AskableBridgeEnvelope`:
 ```ts
 chrome.runtime.onMessage.addListener((message) => {
   if (message.type !== 'askable:bridge:context') return;
+  if (!isAskableBridgeEnvelope(message.envelope)) return;
   console.log(message.envelope.payload.packet);
 });
 ```
@@ -70,7 +83,7 @@ chrome.runtime.onMessage.addListener((message) => {
 import { createAskableBridge, createPostMessageTransport } from '@askable-ui/bridge';
 
 const bridge = createAskableBridge({
-  provider: { getPacket: () => ctx.toContextPacket() },
+  provider: { getPacket: () => ctx.toContextPacketAsync() },
   transports: [
     createPostMessageTransport({
       targetOrigin: 'https://chat.example.com',
@@ -80,13 +93,18 @@ const bridge = createAskableBridge({
 });
 ```
 
+Context packets are never broadcast to `'*'`. Without `targetOrigin` the
+transport falls back to the sending page's own origin, so cross-origin targets
+must be named explicitly. Pass `allowAnyOrigin: true` only when the packet
+carries nothing private.
+
 ## Send context to an HTTP endpoint
 
 ```ts
 import { createAskableBridge, createHttpTransport } from '@askable-ui/bridge';
 
 const bridge = createAskableBridge({
-  provider: { getPacket: () => ctx.toContextPacket() },
+  provider: { getPacket: () => ctx.toContextPacketAsync() },
   transports: [
     createHttpTransport({
       url: '/api/askable/context',
@@ -95,6 +113,33 @@ const bridge = createAskableBridge({
   ],
 });
 ```
+
+## Privacy gates
+
+The bridge is where context leaves the page, so it can refuse to send packets
+that fall short of your policy. Both checks run before any transport is touched.
+
+```ts
+const bridge = createAskableBridge({
+  provider: { getPacket: () => ctx.toContextPacketAsync() },
+  requireRedacted: true,
+  allowedConsent: ['explicit'],
+  maxEnvelopeBytes: 512 * 1024,
+  transports: [createHttpTransport({ url: '/api/askable/context' })],
+});
+```
+
+## Acks
+
+Each send resolves with one ack per transport, in registration order. A
+transport that throws becomes an `ok: false` ack instead of discarding the acks
+of the transports that succeeded.
+
+`ok: true` means the envelope was dispatched without error — not that a receiver
+consumed it. Only the HTTP transport sees a real response from the other side.
+
+Give each transport an explicit `id` when registering more than one of the same
+kind; duplicate ids throw instead of silently replacing the earlier transport.
 
 ## Envelope shape
 
@@ -111,10 +156,14 @@ Every transport receives the same envelope:
   payload: {
     packet,
     prompt: 'Prompt-ready context',
-    question: 'What should I do next?'
+    question: 'What should I do next?',
+    metadata: { surface: 'cmd-k' }
   }
 }
 ```
 
 Use `isAskableBridgeEnvelope(value)` at extension, iframe, worker, webhook, and
-storage boundaries before trusting the payload.
+storage boundaries before trusting the payload. It validates the protocol,
+channel, request id, consent value, and the nested packet, and accepts any
+envelope from the same major version so a minor protocol bump does not break
+every deployed receiver at once.

--- a/packages/bridge/src/__tests__/index.test.ts
+++ b/packages/bridge/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createWebContextPacket } from '@askable-ui/context';
 import {
   ASKABLE_BRIDGE_CHANNEL,
@@ -11,7 +11,9 @@ import {
   createHttpTransport,
   createPostMessageTransport,
   isAskableBridgeEnvelope,
+  isAskableBridgeVersionSupported,
 } from '../index';
+import type { AskableBridgeTransport } from '../index';
 
 const packet = createWebContextPacket({
   capture: { mode: 'element-focus', gesture: 'click' },
@@ -21,6 +23,19 @@ const packet = createWebContextPacket({
     metadata: { metric: 'mrr', value: 24000 },
   },
   privacy: { consent: 'explicit', redacted: true },
+});
+
+const unredactedPacket = createWebContextPacket({
+  capture: { mode: 'element-focus' },
+  privacy: { consent: 'implicit', redacted: false },
+});
+
+function stubTransport(id: string, send: AskableBridgeTransport['send']): AskableBridgeTransport {
+  return { id, send };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('@askable-ui/bridge', () => {
@@ -143,5 +158,332 @@ describe('@askable-ui/bridge', () => {
       transportId: 'http',
       response: { accepted: true },
     });
+  });
+});
+
+describe('postMessage target origin', () => {
+  it('falls back to the sending page origin instead of broadcasting', async () => {
+    const postMessage = vi.fn();
+    vi.stubGlobal('window', { location: { origin: 'https://app.example' } });
+
+    const transport = createPostMessageTransport({ targetWindow: { postMessage } as unknown as Window });
+    await transport.send(createAskableBridgeEnvelope(packet, { requestId: 'req_origin' }));
+
+    expect(postMessage).toHaveBeenCalledWith(expect.anything(), 'https://app.example');
+  });
+
+  it('throws rather than broadcasting when no origin can be determined', async () => {
+    const transport = createPostMessageTransport({
+      targetWindow: { postMessage: vi.fn() } as unknown as Window,
+    });
+
+    await expect(transport.send(createAskableBridgeEnvelope(packet))).rejects.toThrow(/target origin/i);
+  });
+
+  it('broadcasts to every origin only when explicitly opted in', async () => {
+    const postMessage = vi.fn();
+    const transport = createPostMessageTransport({
+      targetWindow: { postMessage } as unknown as Window,
+      allowAnyOrigin: true,
+    });
+
+    await transport.send(createAskableBridgeEnvelope(packet, { requestId: 'req_any' }));
+
+    expect(postMessage).toHaveBeenCalledWith(expect.anything(), '*');
+  });
+});
+
+describe('HTTP transport headers', () => {
+  const cases: Array<[string, HeadersInit]> = [
+    ['plain object', { authorization: 'Bearer secret' }],
+    ['Headers instance', new Headers({ authorization: 'Bearer secret' })],
+    ['entry array', [['authorization', 'Bearer secret']]],
+  ];
+
+  it.each(cases)('forwards auth headers supplied as a %s', async (_label, headers) => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const transport = createHttpTransport({ url: 'https://api.example.com', headers, fetch: fetchMock });
+    await transport.send(createAskableBridgeEnvelope(packet));
+
+    expect(fetchMock.mock.calls[0][1].headers).toMatchObject({
+      authorization: 'Bearer secret',
+      'content-type': 'application/json',
+    });
+  });
+
+  it('resolves headers returned from a function', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const transport = createHttpTransport({
+      url: 'https://api.example.com',
+      headers: () => new Headers({ authorization: 'Bearer rotated' }),
+      fetch: fetchMock,
+    });
+    await transport.send(createAskableBridgeEnvelope(packet));
+
+    expect(fetchMock.mock.calls[0][1].headers).toMatchObject({ authorization: 'Bearer rotated' });
+  });
+
+  it('reports the response body on a failed request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('token expired', { status: 403, statusText: 'Forbidden' }),
+    );
+
+    const transport = createHttpTransport({ url: 'https://api.example.com', fetch: fetchMock });
+    const ack = await transport.send(createAskableBridgeEnvelope(packet, { requestId: 'req_403' }));
+
+    expect(ack).toEqual({
+      ok: false,
+      requestId: 'req_403',
+      transportId: 'http',
+      message: 'HTTP 403 Forbidden: token expired',
+      response: 'token expired',
+    });
+  });
+
+  it('truncates long error bodies', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('x'.repeat(100), { status: 500 }));
+    const transport = createHttpTransport({
+      url: 'https://api.example.com',
+      fetch: fetchMock,
+      maxErrorBodyChars: 10,
+    });
+
+    const ack = await transport.send(createAskableBridgeEnvelope(packet));
+
+    expect(ack.response).toBe(`${'x'.repeat(10)}…`);
+  });
+});
+
+describe('transport registry', () => {
+  it('rejects duplicate transport ids instead of silently replacing', () => {
+    expect(() => createAskableBridge({
+      transports: [
+        createHttpTransport({ url: '/a', fetch: vi.fn() }),
+        createHttpTransport({ url: '/b', fetch: vi.fn() }),
+      ],
+    })).toThrow(/already has a transport with id "http"/);
+  });
+
+  it('accepts several transports of the same kind under distinct ids', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const bridge = createAskableBridge({
+      transports: [
+        createFunctionTransport(first, { id: 'chat' }),
+        createFunctionTransport(second, { id: 'audit' }),
+      ],
+    });
+
+    const acks = await bridge.send(packet);
+
+    expect(acks.map((ack) => ack.transportId)).toEqual(['chat', 'audit']);
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  it('unregisters by identity, not by id', async () => {
+    const original = createFunctionTransport(vi.fn(), { id: 'chat' });
+    const bridge = createAskableBridge({});
+    const unregister = bridge.registerTransport(original);
+
+    unregister();
+    const replacement = vi.fn();
+    bridge.registerTransport(createFunctionTransport(replacement, { id: 'chat' }));
+    unregister(); // stale handle must not remove the replacement
+
+    await bridge.send(packet);
+    expect(replacement).toHaveBeenCalledOnce();
+  });
+
+  it('throws when no transports are registered', async () => {
+    const bridge = createAskableBridge({});
+    await expect(bridge.send(packet)).rejects.toThrow(/no transports/i);
+  });
+});
+
+describe('partial transport failure', () => {
+  it('keeps acks from healthy transports when one throws', async () => {
+    const bridge = createAskableBridge({
+      transports: [
+        stubTransport('broken', async () => {
+          throw new Error('runtime unavailable');
+        }),
+        createFunctionTransport(() => 'delivered', { id: 'chat' }),
+      ],
+    });
+
+    const acks = await bridge.send(packet, { requestId: 'req_partial' });
+
+    expect(acks).toEqual([
+      { ok: false, requestId: 'req_partial', transportId: 'broken', message: 'runtime unavailable' },
+      { ok: true, requestId: 'req_partial', transportId: 'chat', response: 'delivered' },
+    ]);
+  });
+});
+
+describe('privacy policy', () => {
+  it('refuses unredacted packets when requireRedacted is set', async () => {
+    const handler = vi.fn();
+    const bridge = createAskableBridge({
+      requireRedacted: true,
+      transports: [createFunctionTransport(handler)],
+    });
+
+    await expect(bridge.send(unredactedPacket)).rejects.toThrow(/unredacted/i);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('refuses packets outside the allowed consent list', async () => {
+    const handler = vi.fn();
+    const bridge = createAskableBridge({
+      allowedConsent: ['explicit'],
+      transports: [createFunctionTransport(handler)],
+    });
+
+    await expect(bridge.send(unredactedPacket)).rejects.toThrow(/consent "implicit"/);
+    await expect(bridge.send(packet)).resolves.toHaveLength(1);
+  });
+
+  it('rejects envelopes over the configured size limit', async () => {
+    const handler = vi.fn();
+    const bridge = createAskableBridge({
+      maxEnvelopeBytes: 32,
+      transports: [createFunctionTransport(handler)],
+    });
+
+    await expect(bridge.send(packet)).rejects.toThrow(/over the 32 byte limit/);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('abort handling', () => {
+  it('does not dispatch when the caller signal is already aborted', async () => {
+    const handler = vi.fn();
+    const bridge = createAskableBridge({ transports: [createFunctionTransport(handler)] });
+    const controller = new AbortController();
+    controller.abort(new Error('user cancelled'));
+
+    await expect(bridge.send(packet, { signal: controller.signal })).rejects.toThrow('user cancelled');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('aborts in-flight sends on dispose', async () => {
+    let observed: AbortSignal | undefined;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const bridge = createAskableBridge({
+      transports: [
+        stubTransport('slow', async (envelope, options) => {
+          observed = options?.signal;
+          await gate;
+          return { ok: true, requestId: envelope.requestId, transportId: 'slow' };
+        }),
+      ],
+    });
+
+    const pending = bridge.send(packet);
+    await Promise.resolve();
+
+    expect(observed?.aborted).toBe(false);
+    bridge.dispose();
+    expect(observed?.aborted).toBe(true);
+
+    release();
+    await pending;
+  });
+});
+
+describe('agent request interop', () => {
+  it('sends a core toAgentRequest() payload without re-resolving context', async () => {
+    const handler = vi.fn();
+    const getPacket = vi.fn(() => packet);
+    const bridge = createAskableBridge({
+      provider: { getPacket },
+      transports: [createFunctionTransport(handler, { id: 'chat' })],
+    });
+
+    await bridge.sendAgentRequest({
+      requestId: 'req_agent',
+      question: 'Why did this account churn?',
+      context: 'Revenue card — $24k MRR',
+      packet,
+      metadata: { surface: 'cmd-k' },
+    });
+
+    expect(getPacket).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'req_agent',
+        payload: {
+          packet,
+          question: 'Why did this account churn?',
+          prompt: 'Revenue card — $24k MRR',
+          metadata: { surface: 'cmd-k' },
+        },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('falls back to the provider when the request carries no packet', async () => {
+    const handler = vi.fn();
+    const bridge = createAskableBridge({
+      provider: { getPacket: () => packet },
+      transports: [createFunctionTransport(handler, { id: 'chat' })],
+    });
+
+    await bridge.sendAgentRequest({ question: 'What is on screen?' });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ question: 'What is on screen?', packet }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('rejects a request without a question', async () => {
+    const bridge = createAskableBridge({ transports: [createFunctionTransport(vi.fn())] });
+
+    await expect(
+      bridge.sendAgentRequest({ question: undefined as unknown as string }),
+    ).rejects.toThrow(/question/);
+  });
+});
+
+describe('envelope validation', () => {
+  const envelope = createAskableBridgeEnvelope(packet, { requestId: 'req_guard' });
+
+  it('accepts envelopes from the same major version', () => {
+    expect(isAskableBridgeVersionSupported('0.1')).toBe(true);
+    expect(isAskableBridgeVersionSupported('0.9')).toBe(true);
+    expect(isAskableBridgeVersionSupported('1.0')).toBe(false);
+    expect(isAskableBridgeVersionSupported(undefined)).toBe(false);
+    expect(isAskableBridgeEnvelope({ ...envelope, version: '0.4' })).toBe(true);
+    expect(isAskableBridgeEnvelope({ ...envelope, version: '1.0' })).toBe(false);
+  });
+
+  it.each([
+    ['an array', []],
+    ['a foreign protocol', { ...envelope, protocol: 'other' }],
+    ['a foreign channel', { ...envelope, channel: 'other' }],
+    ['an empty request id', { ...envelope, requestId: '' }],
+    ['a missing consent value', { ...envelope, consent: undefined }],
+    ['an invalid consent value', { ...envelope, consent: 'maybe' }],
+    ['a missing packet', { ...envelope, payload: {} }],
+    ['an array payload', { ...envelope, payload: [] }],
+  ])('rejects %s', (_label, value) => {
+    expect(isAskableBridgeEnvelope(value)).toBe(false);
   });
 });

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -5,6 +5,8 @@ export const ASKABLE_BRIDGE_PROTOCOL = 'askable.bridge';
 export const ASKABLE_BRIDGE_VERSION = '0.1';
 export const ASKABLE_BRIDGE_CHANNEL = 'askable:bridge';
 
+export type AskableBridgeConsent = WebContextPacket['privacy']['consent'];
+
 export type AskableBridgeDestinationKind =
   | 'app-chat'
   | 'browser-extension'
@@ -32,21 +34,35 @@ export interface AskableBridgePayload {
   packet: WebContextPacket;
   prompt?: string;
   question?: string;
+  /** App-owned metadata. Mirrors `AskableAgentRequest.metadata` from `@askable-ui/core`. */
+  metadata?: Record<string, unknown>;
 }
 
 export interface AskableBridgeEnvelope {
   protocol: typeof ASKABLE_BRIDGE_PROTOCOL;
-  version: typeof ASKABLE_BRIDGE_VERSION;
+  /**
+   * Producer version. Always `ASKABLE_BRIDGE_VERSION` when this package builds
+   * the envelope, but typed as `string` because receivers accept any envelope
+   * from the same major version. Check `isAskableBridgeVersionSupported()` or
+   * compare against `ASKABLE_BRIDGE_VERSION` directly when you need to pin.
+   */
+  version: string;
   channel: typeof ASKABLE_BRIDGE_CHANNEL;
   requestId: string;
   timestamp: string;
   source?: AskableBridgeSource;
   destination?: AskableBridgeDestination;
-  consent: WebContextPacket['privacy']['consent'];
+  consent: AskableBridgeConsent;
   payload: AskableBridgePayload;
 }
 
 export interface AskableBridgeAck {
+  /**
+   * The transport dispatched the envelope without throwing. This is **not**
+   * proof that a receiver consumed it — `postMessage`, function, and extension
+   * transports all resolve `ok: true` even when nothing is listening. Only the
+   * HTTP transport observes a real response from the other side.
+   */
   ok: boolean;
   requestId: string;
   transportId: string;
@@ -60,17 +76,47 @@ export interface AskableBridgeSendOptions {
   destination?: AskableBridgeDestination;
   question?: string;
   prompt?: string;
+  metadata?: Record<string, unknown>;
+  /**
+   * Aborts the send. Honored by every built-in transport before dispatch, and
+   * passed through to `fetch()` by the HTTP transport for in-flight requests.
+   */
   signal?: AbortSignal;
 }
 
 export interface AskableBridgeTransport {
   id: string;
+  /**
+   * Dispatches one envelope. Resolve with `ok: false` for a receiver-reported
+   * failure; throw for a transport-level failure. `createAskableBridge()`
+   * converts thrown errors into `ok: false` acks so one broken transport never
+   * hides the others.
+   */
   send(envelope: AskableBridgeEnvelope, options?: AskableBridgeSendOptions): Promise<AskableBridgeAck>;
 }
 
 export interface AskableBridgeContextProvider {
+  /**
+   * Returns the packet to send. Prefer `ctx.toContextPacketAsync()` over the
+   * synchronous `ctx.toContextPacket()` — only the async form resolves app
+   * registered context sources into `surrounding.sources`.
+   */
   getPacket(): WebContextPacket | Promise<WebContextPacket>;
   formatPrompt?(packet: WebContextPacket, options?: AskableBridgeSendOptions): string | Promise<string>;
+}
+
+/**
+ * Structural shape of `AskableAgentRequest` from `@askable-ui/core`, accepted
+ * by `bridge.sendAgentRequest()`. Duck-typed so this package keeps zero
+ * dependencies on core.
+ */
+export interface AskableBridgeAgentRequestLike {
+  requestId?: string;
+  question: string;
+  /** Prompt-ready context string. Maps to `payload.prompt` on the envelope. */
+  context?: string;
+  packet?: WebContextPacket;
+  metadata?: Record<string, unknown>;
 }
 
 export interface AskableBridgeOptions {
@@ -78,13 +124,40 @@ export interface AskableBridgeOptions {
   transports?: AskableBridgeTransport[];
   source?: AskableBridgeSource;
   destination?: AskableBridgeDestination;
+  /**
+   * Refuse to send packets with `privacy.redacted === false`. Defaults to
+   * `false` to match `@askable-ui/mcp`. Turn it on whenever packets can carry
+   * user-entered or otherwise sensitive content — note that
+   * `ctx.toContextPacket()` only reports `redacted: true` when a `sanitizeMeta`
+   * or `sanitizeText` function is registered on the context.
+   */
+  requireRedacted?: boolean;
+  /**
+   * Only send packets whose `privacy.consent` is in this list. Defaults to
+   * allowing every consent value. `ctx.toContextPacket()` stamps `'implicit'`
+   * unless the caller overrides it, so pass `['explicit']` only when the app
+   * actually sets explicit consent on capture.
+   */
+  allowedConsent?: ReadonlyArray<AskableBridgeConsent>;
+  /**
+   * Reject envelopes whose serialized size exceeds this many bytes. Off by
+   * default. Context packets carrying `target.screenshot.data` are base64 and
+   * can reach multiple megabytes.
+   */
+  maxEnvelopeBytes?: number;
 }
 
 export interface AskableBridge {
   send(packet: WebContextPacket, options?: AskableBridgeSendOptions): Promise<AskableBridgeAck[]>;
   sendCurrent(options?: AskableBridgeSendOptions): Promise<AskableBridgeAck[]>;
   sendPrompt(question: string, options?: AskableBridgeSendOptions): Promise<AskableBridgeAck[]>;
+  /** Sends an existing `ctx.toAgentRequest()` payload without re-resolving context. */
+  sendAgentRequest(
+    request: AskableBridgeAgentRequestLike,
+    options?: AskableBridgeSendOptions,
+  ): Promise<AskableBridgeAck[]>;
   registerTransport(transport: AskableBridgeTransport): () => void;
+  /** Removes every transport and aborts sends that are still in flight. */
   dispose(): void;
 }
 
@@ -95,7 +168,17 @@ export interface AskableFunctionTransportOptions {
 export interface AskablePostMessageTransportOptions {
   id?: string;
   targetWindow?: Window;
+  /**
+   * Target origin for `postMessage`. Required for cross-origin targets. When
+   * omitted, the transport falls back to the sending page's own origin — it
+   * never broadcasts to `'*'` unless `allowAnyOrigin` is set.
+   */
   targetOrigin?: string;
+  /**
+   * Opt in to `targetOrigin: '*'`. Broadcasts the full context packet to any
+   * listener on any origin — only safe when the packet carries nothing private.
+   */
+  allowAnyOrigin?: boolean;
   messageType?: string;
 }
 
@@ -115,6 +198,8 @@ export interface AskableHttpTransportOptions {
   method?: 'POST' | 'PUT' | 'PATCH';
   headers?: HeadersInit | (() => HeadersInit | Promise<HeadersInit>);
   fetch?: typeof fetch;
+  /** Max characters of a failed response body to include on the ack. Defaults to 512. */
+  maxErrorBodyChars?: number;
 }
 
 export type AskableFunctionTransportHandler = (
@@ -139,32 +224,47 @@ export function createAskableBridgeEnvelope(
     consent: packet.privacy.consent,
     payload: {
       packet,
-      ...(options.prompt ? { prompt: options.prompt } : {}),
-      ...(options.question ? { question: options.question } : {}),
+      ...(options.prompt !== undefined ? { prompt: options.prompt } : {}),
+      ...(options.question !== undefined ? { question: options.question } : {}),
+      ...(options.metadata !== undefined ? { metadata: options.metadata } : {}),
     },
   };
+}
+
+/**
+ * True when an envelope version is compatible with this package. Receivers
+ * accept any envelope sharing the current major version so a minor protocol
+ * bump does not break every deployed extension and webhook at once.
+ */
+export function isAskableBridgeVersionSupported(version: unknown): boolean {
+  if (typeof version !== 'string' || version.length === 0) return false;
+  return version.split('.')[0] === ASKABLE_BRIDGE_VERSION.split('.')[0];
 }
 
 export function isAskableBridgeEnvelope(value: unknown): value is AskableBridgeEnvelope {
   if (!isRecord(value)) return false;
   if (value.protocol !== ASKABLE_BRIDGE_PROTOCOL) return false;
-  if (value.version !== ASKABLE_BRIDGE_VERSION) return false;
+  if (!isAskableBridgeVersionSupported(value.version)) return false;
   if (value.channel !== ASKABLE_BRIDGE_CHANNEL) return false;
-  if (typeof value.requestId !== 'string') return false;
+  if (typeof value.requestId !== 'string' || value.requestId.length === 0) return false;
   if (typeof value.timestamp !== 'string') return false;
+  if (!isConsentValue(value.consent)) return false;
   if (!isRecord(value.payload)) return false;
   return isWebContextPacket(value.payload.packet);
 }
 
 export function createAskableBridge(options: AskableBridgeOptions = {}): AskableBridge {
   const transports = new Map<string, AskableBridgeTransport>();
+  const lifecycle = createAbortController();
 
   for (const transport of options.transports ?? []) {
-    transports.set(transport.id, transport);
+    addTransport(transports, transport);
   }
 
   const send = async (packet: WebContextPacket, sendOptions: AskableBridgeSendOptions = {}) => {
     assertWebContextPacket(packet);
+    assertPacketPolicy(packet, options);
+    throwIfAborted(sendOptions.signal);
 
     if (transports.size === 0) {
       throw new Error('Askable bridge has no transports. Register a transport before sending context.');
@@ -176,7 +276,27 @@ export function createAskableBridge(options: AskableBridgeOptions = {}): Askable
       destination: sendOptions.destination ?? options.destination,
     });
 
-    return Promise.all([...transports.values()].map((transport) => transport.send(envelope, sendOptions)));
+    assertEnvelopeSize(envelope, options.maxEnvelopeBytes);
+
+    const signal = mergeSignals(sendOptions.signal, lifecycle?.signal);
+    const transportOptions = signal ? { ...sendOptions, signal } : sendOptions;
+    const entries = [...transports.values()];
+
+    // allSettled, not all: a transport that throws must not discard the acks of
+    // the transports that succeeded.
+    const results = await Promise.allSettled(
+      entries.map((transport) => transport.send(envelope, transportOptions)),
+    );
+
+    return results.map((result, index): AskableBridgeAck => {
+      if (result.status === 'fulfilled') return result.value;
+      return {
+        ok: false,
+        requestId: envelope.requestId,
+        transportId: entries[index].id,
+        message: describeError(result.reason),
+      };
+    });
   };
 
   const sendCurrent = async (sendOptions: AskableBridgeSendOptions = {}) => {
@@ -184,7 +304,10 @@ export function createAskableBridge(options: AskableBridgeOptions = {}): Askable
       throw new Error('Askable bridge sendCurrent() requires a context provider.');
     }
 
+    throwIfAborted(sendOptions.signal);
     const packet = await options.provider.getPacket();
+    throwIfAborted(sendOptions.signal);
+
     const prompt =
       sendOptions.prompt ??
       (options.provider.formatPrompt ? await options.provider.formatPrompt(packet, sendOptions) : undefined);
@@ -196,18 +319,47 @@ export function createAskableBridge(options: AskableBridgeOptions = {}): Askable
     return sendCurrent({ ...sendOptions, question });
   };
 
+  const sendAgentRequest = async (
+    request: AskableBridgeAgentRequestLike,
+    sendOptions: AskableBridgeSendOptions = {},
+  ) => {
+    if (!isRecord(request) || typeof request.question !== 'string') {
+      throw new TypeError('Askable bridge sendAgentRequest() expects an agent request with a question.');
+    }
+
+    const merged: AskableBridgeSendOptions = {
+      ...sendOptions,
+      requestId: sendOptions.requestId ?? request.requestId,
+      question: sendOptions.question ?? request.question,
+      prompt: sendOptions.prompt ?? request.context,
+      metadata: sendOptions.metadata ?? request.metadata,
+    };
+
+    if (request.packet) return send(request.packet, merged);
+    if (!options.provider) {
+      throw new Error(
+        'Askable bridge sendAgentRequest() needs a request built with packet: true, or a context provider.',
+      );
+    }
+
+    return sendCurrent(merged);
+  };
+
   return {
     send,
     sendCurrent,
     sendPrompt,
+    sendAgentRequest,
     registerTransport(transport) {
-      transports.set(transport.id, transport);
+      addTransport(transports, transport);
       return () => {
-        transports.delete(transport.id);
+        // Delete by identity: a later transport may have claimed this id.
+        if (transports.get(transport.id) === transport) transports.delete(transport.id);
       };
     },
     dispose() {
       transports.clear();
+      lifecycle?.abort(new Error('Askable bridge disposed.'));
     },
   };
 }
@@ -221,6 +373,7 @@ export function createFunctionTransport(
   return {
     id,
     async send(envelope, sendOptions) {
+      throwIfAborted(sendOptions?.signal);
       const response = await handler(envelope, sendOptions);
       return { ok: true, requestId: envelope.requestId, transportId: id, response };
     },
@@ -233,13 +386,15 @@ export function createPostMessageTransport(options: AskablePostMessageTransportO
 
   return {
     id,
-    async send(envelope) {
+    async send(envelope, sendOptions) {
+      throwIfAborted(sendOptions?.signal);
+
       const targetWindow = options.targetWindow ?? getWindow();
       if (!targetWindow) {
         throw new Error('PostMessage transport requires a browser window or explicit targetWindow.');
       }
 
-      targetWindow.postMessage({ type: messageType, envelope }, options.targetOrigin ?? '*');
+      targetWindow.postMessage({ type: messageType, envelope }, resolveTargetOrigin(options));
       return { ok: true, requestId: envelope.requestId, transportId: id };
     },
   };
@@ -253,7 +408,9 @@ export function createBrowserExtensionTransport(
 
   return {
     id,
-    async send(envelope) {
+    async send(envelope, sendOptions) {
+      throwIfAborted(sendOptions?.signal);
+
       const runtime = options.runtime ?? getBrowserRuntime();
       if (!runtime) {
         throw new Error('Browser extension transport requires chrome.runtime, browser.runtime, or explicit runtime.');
@@ -268,16 +425,19 @@ export function createBrowserExtensionTransport(
 export function createHttpTransport(options: AskableHttpTransportOptions): AskableBridgeTransport {
   const id = options.id ?? 'http';
   const method = options.method ?? 'POST';
+  const maxErrorBodyChars = options.maxErrorBodyChars ?? 512;
 
   return {
     id,
     async send(envelope, sendOptions) {
+      throwIfAborted(sendOptions?.signal);
+
       const fetchImpl = options.fetch ?? getFetch();
       if (!fetchImpl) {
         throw new Error('HTTP transport requires fetch or an explicit fetch implementation.');
       }
 
-      const headers = await resolveHeaders(options.headers);
+      const headers = normalizeHeaders(await resolveHeaders(options.headers));
       const response = await fetchImpl(options.url, {
         method,
         headers: {
@@ -289,11 +449,15 @@ export function createHttpTransport(options: AskableHttpTransportOptions): Askab
       });
 
       if (!response.ok) {
+        const detail = await readErrorBody(response, maxErrorBodyChars);
+        const status = `HTTP ${response.status} ${response.statusText}`.trim();
+
         return {
           ok: false,
           requestId: envelope.requestId,
           transportId: id,
-          message: `HTTP ${response.status} ${response.statusText}`.trim(),
+          message: detail ? `${status}: ${detail}` : status,
+          ...(detail !== undefined ? { response: detail } : {}),
         };
       }
 
@@ -307,16 +471,110 @@ export function createHttpTransport(options: AskableHttpTransportOptions): Askab
   };
 }
 
+function addTransport(transports: Map<string, AskableBridgeTransport>, transport: AskableBridgeTransport): void {
+  if (transports.has(transport.id)) {
+    throw new Error(
+      `Askable bridge already has a transport with id "${transport.id}". `
+      + 'Pass a unique id when registering more than one transport of the same kind.',
+    );
+  }
+
+  transports.set(transport.id, transport);
+}
+
 function assertWebContextPacket(packet: unknown): asserts packet is WebContextPacket {
   if (!isWebContextPacket(packet)) {
     throw new TypeError('Expected a valid Askable WebContextPacket.');
   }
 }
 
+function assertPacketPolicy(packet: WebContextPacket, options: AskableBridgeOptions): void {
+  if (options.requireRedacted && packet.privacy.redacted === false) {
+    throw new Error(
+      'Askable bridge refused an unredacted context packet. Register sanitizeMeta/sanitizeText on the '
+      + 'context, set privacy.redacted explicitly, or drop requireRedacted.',
+    );
+  }
+
+  if (options.allowedConsent && !options.allowedConsent.includes(packet.privacy.consent)) {
+    throw new Error(
+      `Askable bridge refused a context packet with consent "${packet.privacy.consent}". `
+      + `Allowed: ${options.allowedConsent.join(', ')}.`,
+    );
+  }
+}
+
+function assertEnvelopeSize(envelope: AskableBridgeEnvelope, maxEnvelopeBytes: number | undefined): void {
+  if (maxEnvelopeBytes === undefined) return;
+
+  const size = byteLength(JSON.stringify(envelope));
+  if (size > maxEnvelopeBytes) {
+    throw new Error(
+      `Askable bridge envelope is ${size} bytes, over the ${maxEnvelopeBytes} byte limit. `
+      + 'Drop screenshots, trim surrounding context, or raise maxEnvelopeBytes.',
+    );
+  }
+}
+
+function byteLength(value: string): number {
+  if (typeof TextEncoder === 'undefined') return value.length;
+  return new TextEncoder().encode(value).length;
+}
+
+function resolveTargetOrigin(options: AskablePostMessageTransportOptions): string {
+  if (options.targetOrigin) return options.targetOrigin;
+  if (options.allowAnyOrigin) return '*';
+
+  // Never fall back to '*': context packets must not be broadcast to arbitrary
+  // origins. Mirrors the invariant in @askable-ui/mcp's page bridge.
+  const origin = getWindow()?.location?.origin;
+  if (origin) return origin;
+
+  throw new Error(
+    'PostMessage transport could not determine a target origin. Pass targetOrigin for cross-origin '
+    + 'targets, or set allowAnyOrigin: true to broadcast to every origin.',
+  );
+}
+
 function createRequestId() {
   const cryptoImpl = getCrypto();
   if (cryptoImpl?.randomUUID) return cryptoImpl.randomUUID();
   return `askable_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+}
+
+function createAbortController(): AbortController | undefined {
+  return typeof AbortController === 'undefined' ? undefined : new AbortController();
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error ? signal.reason : new Error('Askable bridge send aborted.');
+}
+
+function mergeSignals(a: AbortSignal | undefined, b: AbortSignal | undefined): AbortSignal | undefined {
+  if (!a) return b;
+  if (!b) return a;
+
+  const anySignal = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
+  if (typeof anySignal === 'function') return anySignal.call(AbortSignal, [a, b]);
+
+  const controller = createAbortController();
+  if (!controller) return a;
+
+  for (const signal of [a, b]) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
+  }
+
+  return controller.signal;
+}
+
+function describeError(reason: unknown): string {
+  if (reason instanceof Error) return reason.message;
+  return typeof reason === 'string' ? reason : 'Transport failed.';
 }
 
 function getWindow(): Window | undefined {
@@ -340,9 +598,29 @@ function getBrowserRuntime(): AskableBrowserRuntime | undefined {
   return globalValue.browser?.runtime ?? globalValue.chrome?.runtime;
 }
 
-async function resolveHeaders(headers: AskableHttpTransportOptions['headers']): Promise<HeadersInit> {
-  if (!headers) return {};
+async function resolveHeaders(headers: AskableHttpTransportOptions['headers']): Promise<HeadersInit | undefined> {
+  if (!headers) return undefined;
   return typeof headers === 'function' ? headers() : headers;
+}
+
+/**
+ * `HeadersInit` covers `Headers` instances and `[key, value][]` arrays, neither
+ * of which survives object spread — spreading a `Headers` yields `{}`, silently
+ * dropping Authorization. Normalize to a plain record first.
+ */
+function normalizeHeaders(init: HeadersInit | undefined): Record<string, string> {
+  if (!init) return {};
+
+  if (typeof Headers === 'undefined') {
+    return Array.isArray(init) ? Object.fromEntries(init) : { ...(init as Record<string, string>) };
+  }
+
+  const normalized: Record<string, string> = {};
+  new Headers(init).forEach((value, key) => {
+    normalized[key] = value;
+  });
+
+  return normalized;
 }
 
 async function readResponseBody(response: Response): Promise<unknown> {
@@ -353,6 +631,22 @@ async function readResponseBody(response: Response): Promise<unknown> {
   return response.text();
 }
 
+async function readErrorBody(response: Response, maxChars: number): Promise<string | undefined> {
+  if (maxChars <= 0) return undefined;
+
+  try {
+    const text = (await response.text()).trim();
+    if (!text) return undefined;
+    return text.length > maxChars ? `${text.slice(0, maxChars)}…` : text;
+  } catch {
+    return undefined;
+  }
+}
+
+function isConsentValue(value: unknown): value is AskableBridgeConsent {
+  return value === 'explicit' || value === 'implicit' || value === 'none';
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/site/docs/api/bridge.md
+++ b/site/docs/api/bridge.md
@@ -24,8 +24,8 @@ import { createAskableBridge, createFunctionTransport } from '@askable-ui/bridge
 
 const bridge = createAskableBridge({
   provider: {
-    getPacket: () => ctx.toContextPacket(),
-    formatPrompt: () => ctx.toPromptContext(),
+    getPacket: () => ctx.toContextPacketAsync(),
+    formatPrompt: () => ctx.toContextAsync(),
   },
   transports: [
     createFunctionTransport(({ payload }) => {
@@ -35,6 +35,17 @@ const bridge = createAskableBridge({
 });
 ```
 
+Options:
+
+| Option | Description |
+|---|---|
+| `provider` | Supplies the current packet and optional prompt text. May return promises — prefer `ctx.toContextPacketAsync()` so registered context sources are included |
+| `transports` | Transports to register up front. Ids must be unique; duplicates throw |
+| `source` / `destination` | Defaults stamped onto every envelope |
+| `requireRedacted` | Refuse packets with `privacy.redacted === false`. Defaults to `false`, matching `@askable-ui/mcp` |
+| `allowedConsent` | Only send packets whose `privacy.consent` is in this list. Defaults to allowing all |
+| `maxEnvelopeBytes` | Refuse envelopes larger than this once serialized. Off by default |
+
 Methods:
 
 | Method | Description |
@@ -42,8 +53,13 @@ Methods:
 | `send(packet, options?)` | Sends a provided `WebContextPacket` |
 | `sendCurrent(options?)` | Reads the provider's current packet and sends it |
 | `sendPrompt(question, options?)` | Sends current context with a user question |
-| `registerTransport(transport)` | Adds a transport and returns an unregister function |
-| `dispose()` | Removes all registered transports |
+| `sendAgentRequest(request, options?)` | Sends an existing `ctx.toAgentRequest()` payload without re-resolving context |
+| `registerTransport(transport)` | Adds a transport and returns an unregister function. The handle removes that transport by identity, never a later one that reused the id |
+| `dispose()` | Removes all transports and aborts sends still in flight |
+
+Every send resolves with one `AskableBridgeAck` per transport, in registration
+order. A transport that throws becomes an `ok: false` ack rather than discarding
+the acks of transports that succeeded.
 
 ## `createAskableBridgeEnvelope(packet, options?)`
 
@@ -60,13 +76,21 @@ const envelope = createAskableBridgeEnvelope(packet, {
 ## `isAskableBridgeEnvelope(value)`
 
 Runtime guard for validating messages at iframe, extension, worker, webhook, and
-storage boundaries.
+storage boundaries. Checks the protocol, channel, request id, consent value, and
+the nested Context packet.
 
 ```ts
 if (isAskableBridgeEnvelope(message.envelope)) {
   consume(message.envelope.payload.packet);
 }
 ```
+
+## `isAskableBridgeVersionSupported(version)`
+
+True when an envelope version shares the current major version. Receivers accept
+the whole major line so a minor protocol bump does not break every deployed
+extension and webhook at once. Compare against `ASKABLE_BRIDGE_VERSION` directly
+when you need to pin an exact version.
 
 ## Transports
 
@@ -91,6 +115,13 @@ createPostMessageTransport({
 });
 ```
 
+| Option | Description |
+|---|---|
+| `targetWindow` | Window to post to. Defaults to the current window |
+| `targetOrigin` | Required for cross-origin targets. Without it the transport uses the sending page's own origin and never `'*'` |
+| `allowAnyOrigin` | Opt in to `'*'`. Broadcasts the packet to any listener on any origin |
+| `messageType` | Message envelope type. Defaults to `askable:bridge:context` |
+
 ### `createBrowserExtensionTransport(options?)`
 
 Sends envelopes through `chrome.runtime.sendMessage()` or
@@ -111,13 +142,20 @@ createHttpTransport({
 });
 ```
 
+`headers` accepts any `HeadersInit` — a plain object, a `Headers` instance, or an
+entry array — plus a function returning one, for rotating tokens. Non-2xx
+responses resolve as `ok: false` with the response body on `message` and
+`response`, truncated to `maxErrorBodyChars` (512 by default).
+
 ## Types
 
 | Type | Description |
 |---|---|
 | `AskableBridgeEnvelope` | Versioned message sent to all transports |
-| `AskableBridgePayload` | Context packet plus optional prompt and question |
+| `AskableBridgePayload` | Context packet plus optional prompt, question, and metadata |
 | `AskableBridgeTransport` | Transport interface |
 | `AskableBridgeContextProvider` | Provider for current packet and optional prompt text |
+| `AskableBridgeAgentRequestLike` | Structural shape of `AskableAgentRequest` accepted by `sendAgentRequest()` |
 | `AskableBridgeAck` | Transport acknowledgement |
-| `AskableBridgeSendOptions` | Per-send request id, source, destination, question, prompt, signal |
+| `AskableBridgeConsent` | Consent values carried on the envelope |
+| `AskableBridgeSendOptions` | Per-send request id, source, destination, question, prompt, metadata, signal |

--- a/site/docs/guide/bridge.md
+++ b/site/docs/guide/bridge.md
@@ -24,8 +24,8 @@ ctx.observe(document);
 
 const bridge = createAskableBridge({
   provider: {
-    getPacket: () => ctx.toContextPacket(),
-    formatPrompt: () => ctx.toPromptContext(),
+    getPacket: () => ctx.toContextPacketAsync({ history: 3, includeViewport: true }),
+    formatPrompt: () => ctx.toContextAsync(),
   },
   transports: [
     createFunctionTransport(async ({ payload }) => {
@@ -45,6 +45,14 @@ const bridge = createAskableBridge({
 await bridge.sendPrompt('Explain this selected account.');
 ```
 
+::: tip Use the async packet methods
+`getPacket` accepts a promise, so prefer `toContextPacketAsync()` over
+`toContextPacket()`. Only the async form resolves context sources registered
+with `ctx.registerSource()` into `surrounding.sources` — the synchronous method
+silently omits them, so the bridge would send a thinner packet than the same app
+exposes over MCP.
+:::
+
 ## Browser extension handoff
 
 A browser extension can receive Askable context without the host app knowing
@@ -54,7 +62,7 @@ which chatbot the user prefers.
 import { createAskableBridge, createBrowserExtensionTransport } from '@askable-ui/bridge';
 
 const bridge = createAskableBridge({
-  provider: { getPacket: () => ctx.toContextPacket() },
+  provider: { getPacket: () => ctx.toContextPacketAsync() },
   transports: [createBrowserExtensionTransport()],
 });
 
@@ -86,7 +94,7 @@ window.
 import { createAskableBridge, createPostMessageTransport } from '@askable-ui/bridge';
 
 const bridge = createAskableBridge({
-  provider: { getPacket: () => ctx.toContextPacket() },
+  provider: { getPacket: () => ctx.toContextPacketAsync() },
   transports: [
     createPostMessageTransport({
       targetWindow: chatFrame.contentWindow!,
@@ -95,6 +103,52 @@ const bridge = createAskableBridge({
   ],
 });
 ```
+
+::: warning Always name the target origin
+Context packets are never broadcast to `'*'`. When `targetOrigin` is omitted the
+transport falls back to the sending page's own origin, which means a
+cross-origin iframe receives nothing until you name its origin. If you genuinely
+want every origin to read the packet, opt in with `allowAnyOrigin: true`.
+:::
+
+## Privacy gates
+
+The bridge is the point where context leaves the page, so it can refuse to send
+packets that fall short of your policy. Both checks run before any transport is
+touched and throw rather than sending.
+
+```ts
+const bridge = createAskableBridge({
+  provider: { getPacket: () => ctx.toContextPacketAsync() },
+  requireRedacted: true,          // refuse packets with privacy.redacted === false
+  allowedConsent: ['explicit'],   // refuse anything not explicitly consented
+  maxEnvelopeBytes: 512 * 1024,   // refuse oversized envelopes (screenshots are base64)
+  transports: [createHttpTransport({ url: '/api/askable/context' })],
+});
+```
+
+`ctx.toContextPacket()` only reports `redacted: true` when a `sanitizeMeta` or
+`sanitizeText` function is registered on the context, and stamps
+`consent: 'implicit'` unless the capture overrides it. Set the packet's
+`privacy` explicitly on capture if you plan to gate on `allowedConsent`.
+
+## Sending an existing agent request
+
+Apps already using `ctx.toAgentRequest()` do not need to resolve context twice.
+`sendAgentRequest()` maps the request onto the envelope directly — `question`,
+`context` (as `payload.prompt`), `packet`, `metadata`, and `requestId`.
+
+```ts
+const request = await ctx.toAgentRequest('Why did this account churn?', {
+  packet: true,
+  metadata: { surface: 'cmd-k' },
+});
+
+await bridge.sendAgentRequest(request);
+```
+
+When the request carries no `packet`, the bridge falls back to the configured
+provider.
 
 ## Webhook or backend handoff
 
@@ -113,6 +167,36 @@ const bridge = createAskableBridge({
     }),
   ],
 });
+```
+
+## Acks and partial failure
+
+Every send resolves with one ack per transport, in registration order. A
+transport that throws becomes an `ok: false` ack — it never discards the acks of
+the transports that succeeded.
+
+```ts
+const acks = await bridge.sendPrompt('Summarize this account.');
+
+for (const ack of acks) {
+  if (!ack.ok) reportBridgeFailure(ack.transportId, ack.message);
+}
+```
+
+`ok: true` means the transport dispatched the envelope without throwing, not
+that a receiver consumed it. `postMessage`, function, and extension transports
+all report success even when nothing is listening; only the HTTP transport
+observes a real response from the other side.
+
+Register more than one transport of the same kind by giving each an explicit
+`id` — duplicate ids throw at registration instead of silently replacing the
+earlier transport.
+
+```ts
+transports: [
+  createHttpTransport({ id: 'chat', url: '/api/askable/context' }),
+  createHttpTransport({ id: 'audit', url: 'https://audit.internal/context' }),
+]
 ```
 
 ## Bridge vs MCP
@@ -142,10 +226,17 @@ Every transport receives the same versioned envelope:
   payload: {
     packet,
     prompt: 'Prompt-ready context',
-    question: 'What should I do next?'
+    question: 'What should I do next?',
+    metadata: { surface: 'cmd-k' }
   }
 }
 ```
 
 Use `isAskableBridgeEnvelope(value)` before trusting messages from extensions,
-iframes, workers, storage, or webhooks.
+iframes, workers, storage, or webhooks. The guard validates the protocol,
+channel, request id, consent value, and the nested packet.
+
+Receivers accept any envelope from the same major version, so a minor protocol
+bump does not break every deployed extension and webhook at once. Call
+`isAskableBridgeVersionSupported(version)` yourself, or compare against
+`ASKABLE_BRIDGE_VERSION` directly, when you need to pin an exact version.


### PR DESCRIPTION
Full review of `@askable-ui/bridge` (#406) and its interaction with `@askable-ui/context`, `@askable-ui/core`, and `@askable-ui/mcp`. Every finding is addressed here.

## Security and correctness

- **`postMessage` no longer defaults to `targetOrigin: '*'`.** It falls back to the sending page's origin and throws when none can be determined — the same invariant `@askable-ui/mcp`'s page bridge already documents in code ("Never fall back to `'*'`: context packets must not be broadcast to arbitrary origins"), which #362 hardened and this package had reintroduced. Broadcasting is now an explicit `allowAnyOrigin` opt-in.
- **HTTP headers are normalized through `Headers` before merging.** `HeadersInit` covers `Headers` instances and entry arrays, and object spread silently drops both — an `Authorization` header supplied in either form never reached the request.
- **Duplicate transport ids throw** instead of silently replacing the earlier transport (every built-in defaults to a per-kind id, so two `createHttpTransport()` calls collided on `'http'`). Unregister handles now delete by identity rather than by id.
- **Sends use `allSettled`.** A throwing transport becomes an `ok: false` ack instead of rejecting the batch and discarding the acks of transports that succeeded.

## Privacy

- `requireRedacted`, `allowedConsent`, and `maxEnvelopeBytes` gate every send before any transport runs. `requireRedacted` mirrors the option in `@askable-ui/mcp` and defaults to `false` for the same reason.

Previously the envelope copied `packet.privacy.consent` and sent unconditionally — and since `toContextPacket()` stamps `consent: 'implicit'` and `redacted: false` unless sanitizers are registered, that field was decorative on the one component that actually crosses the trust boundary.

## API

- **`sendAgentRequest()`** accepts a `ctx.toAgentRequest()` payload directly, so apps no longer resolve context twice to reach the bridge. Duck-typed, so this package keeps zero dependency on core. `payload.metadata` added to carry the request metadata.
- **`isAskableBridgeEnvelope()`** validates `consent` (the field receivers gate on) and rejects arrays; its local `isRecord` had diverged from the one in `@askable-ui/context`.
- **Version compatibility.** Envelopes from the same major version are accepted, so a minor protocol bump no longer breaks every deployed extension and webhook at once. Exposed as `isAskableBridgeVersionSupported()`.
- Abort signals are honored by every transport and by `dispose()`; failed HTTP requests report the response body, truncated at `maxErrorBodyChars`.

## Docs

- Provider examples use `toContextPacketAsync()` — the only form that resolves sources registered with `ctx.registerSource()` into `surrounding.sources`. Every example used the sync method, so bridge consumers were silently sending thinner packets than the same app exposes over MCP.
- Root README gains a Bridge section; the Bridge-vs-MCP table is promoted out of the docs site. The package previously had two table rows and no prose.
- Guide and API pages cover target origins, privacy gates, ack semantics, and agent-request interop.

## Also here

`chore(examples): consume Askable 0.17.1` — examples were pinned `^0.17.0` against published 0.17.1, failing `check-example-askable-versions` on main and turning `static / quality` red on every open PR. npm and pnpm lockfiles refreshed; the pnpm lockfile had drifted to 0.16.0.

## Verification

- `npm run build --workspaces` → 0
- `npm test` → 0, **1216 passed** across 13 workspaces
- `vitepress build` → 0
- `check-example-askable-versions`, `check-publish-package-coverage`, `check-mcp-server-manifest` → all OK
- Bridge package: **36 tests**, up from 5. New coverage for the default target origin, all three `HeadersInit` forms, duplicate ids, partial transport failure, privacy gates, abort/dispose, agent-request interop, and guard rejection cases — each must-fix finding has a test that fails without its fix.

Rebased onto main after #405 and #398 merged, then reinstalled and re-verified against vitest 4.1.10 and @types/node 26.