### PR TITLE
chore(deps): ignore majors that need coordinated upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,30 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Majors that need coordinated work before they can land. Each was raised
+      # and closed with the blocking reason on the PR; minor and patch updates
+      # still flow normally. Remove an entry when its upgrade is scheduled.
+      #
+      # Angular 19 -> 22 must move as one PR (#396, #397, #400, #403): Angular 22
+      # requires Node ^22.22.3 || ^24.15.0 || >=26.0.0, so it is blocked on
+      # dropping Node 20 from the published support matrix.
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@analogjs/vite-plugin-angular"
+        update-types: ["version-update:semver-major"]
+      # jsdom 30 (#402) pulls @asamuzakjp/css-color, which requires Node
+      # ^22.13.0 || >=24.0.0 — same Node 20 blocker as the Angular set.
+      - dependency-name: "jsdom"
+        update-types: ["version-update:semver-major"]
+      # jest-dom 7 (#399) fails component and SSR tests; needs a matcher migration.
+      - dependency-name: "@testing-library/jest-dom"
+        update-types: ["version-update:semver-major"]
+      # TypeScript 7 (#401) is the native port. Builds and tests pass, but it
+      # changes declaration emit, so it needs its own PR rather than arriving
+      # with routine dependency updates.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Follow-up to the dependency-PR triage. Seven PRs were closed because they can't land as isolated bumps — without ignore rules, dependabot re-raises every one of them on the next run and the queue fills back up with known-blocked upgrades.

Scoped to `version-update:semver-major` only, so minor and patch updates for these packages keep flowing normally. Each entry carries its blocking reason and PR number inline, and comes out when that upgrade gets scheduled.

| Package | Closed PR | Blocker |
|---|---|---|
| `@angular/*`, `@analogjs/vite-plugin-angular` | #396, #397, #400, #403 | Angular 22 requires Node `^22.22.3 \|\| ^24.15.0 \|\| >=26.0.0`; blocked on dropping Node 20 from the support matrix |
| `jsdom` | #402 | Transitive `@asamuzakjp/css-color` requires Node `^22.13.0 \|\| >=24.0.0` — same Node 20 blocker |
| `@testing-library/jest-dom` | #399 | Real failures in `component.test.ts` and `store.ssr.test.ts`; needs a matcher migration |
| `typescript` | #401 | TS 7 native port changes declaration emit; deserves its own PR |

The existing `dev-dependencies` group is unchanged — it already excludes majors, which is why these arrived as individual PRs in the first place. This stops them arriving at all until someone is ready.

Config parses clean via `js-yaml`.