### PR TITLE
feat(examples): add browser extension companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,7 @@ Or open [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html)
 | [`angular-dashboard`](./examples/angular-dashboard/) | Angular 19 · standalone | Angular signals + injectable services |
 | [`nextjs-app-router`](./examples/nextjs-app-router/) | Next.js 15 · App Router | Vercel AI SDK streaming chat with real-time UI context |
 | [`mcp-server`](./examples/mcp-server/) | Node.js · Express | Standalone MCP server — connect Claude Desktop in 5 min |
+| [`browser-extension`](./examples/browser-extension/) | Manifest V3 · Vite | No-site-code companion for selected, focused, and full-page context |
 | [`vanilla-chat`](./examples/vanilla-chat/) | Vanilla JS | Zero-install HTML demo, opens in a browser |
 | [`react-native-expo`](./examples/react-native-expo/) | React Native · Expo | Mobile scroll context |
 
@@ -873,7 +874,7 @@ Or open [`examples/vanilla-chat/index.html`](./examples/vanilla-chat/index.html)
 
 ## Using with coding agents
 
-[`AGENTS.md`](./AGENTS.md) has copy-pasteable instructions for Claude, Cursor, Codex, and similar tools. Drop it into your project root and your coding agent will annotate elements correctly, avoid common mistakes, and wire up the full context pipeline.
+[`AGENTS.md`](./AGENTS.md) has copy-pasteable instructions for Claude, Cursor, and similar tools. Drop it into your project root and your coding agent will annotate elements correctly, avoid common mistakes, and wire up the full context pipeline.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,5 @@ This directory contains runnable or in-progress example apps for Askable.
 
 - `../packages/create-askable-app/` — starter scaffold that generates a React + Vite + CopilotKit Askable app via `npm create @askable-ui/app my-app`
 - `analytics-dashboard-react/` — runnable Vercel/shadcn-inspired analytics dashboard example with Askable-integrated panels and Ask AI actions ([live preview](https://askable-mu.vercel.app/))
+- `browser-extension/` — Manifest V3 companion that captures selected, focused, or full-page context from any tab and sends it through `@askable-ui/bridge`
 - `react-native-expo/` — runnable Expo example showing screen-aware, visibility-aware, and press-aware mobile context capture

--- a/examples/browser-extension/README.md
+++ b/examples/browser-extension/README.md
@@ -1,0 +1,69 @@
+# Browser Extension Companion
+
+This example shows the no-site-code path for Askable. A Manifest V3 extension
+captures selected text, the last focused/clicked DOM element, or a full-page
+snapshot from any normal web page, then sends it through an
+`@askable-ui/bridge` envelope to the extension background worker.
+
+It is intentionally provider-neutral. The popup shows the prompt context so you
+can paste it into ChatGPT, Claude, Cursor, or your own chat UI. The background
+worker receives the structured envelope and is the place to forward it to a
+side panel, local app, webhook, or MCP companion.
+
+## Run it
+
+```bash
+npm install
+npm run build
+```
+
+Then load the built extension:
+
+1. Open `chrome://extensions`.
+2. Enable Developer mode.
+3. Click **Load unpacked**.
+4. Select `examples/browser-extension/dist`.
+
+Open any `http://` or `https://` page, select some text or click an element,
+then open the extension popup and choose a capture mode.
+
+## What it captures
+
+| Mode | Packet capture | Sources included |
+|---|---|---|
+| Selected text | `text-selection` | selected text, page title, URL |
+| Focused element | `element-focus` | last clicked/focused DOM element plus page summary |
+| Full page | `full-page` | title, URL, headings, links, and bounded page text |
+
+On apps that already use `data-askable`, the same content script also observes
+Askable focus. On arbitrary sites, it falls back to DOM and page sources from
+`@askable-ui/core`.
+
+## Architecture
+
+```text
+popup button
+  -> content script capture command
+  -> @askable-ui/core page/DOM sources
+  -> @askable-ui/bridge browser-extension transport
+  -> background worker validates AskableBridgeEnvelope
+```
+
+The content script uses:
+
+- `createAskableContext()` to keep the current page state.
+- `createAskablePageSource()` for unannotated page text, headings, selected
+  text, and links.
+- `createAskableDOMSource()` for the last clicked or focused element.
+- `createBrowserExtensionTransport()` to send the same envelope any other
+  Askable bridge receiver would get.
+
+## Privacy notes
+
+This example marks captures as explicit because the user presses the popup
+button. It does not redact page text by default, so do not forward envelopes to
+remote services until your extension applies a sanitizer or asks the user for
+the right consent.
+
+Chrome extensions cannot inject content scripts into browser-owned pages such as
+`chrome://extensions`, the Chrome Web Store, or restricted enterprise pages.

--- a/examples/browser-extension/package-lock.json
+++ b/examples/browser-extension/package-lock.json
@@ -1,0 +1,895 @@
+{
+  "name": "@askable-ui/example-browser-extension",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@askable-ui/example-browser-extension",
+      "version": "0.1.0",
+      "dependencies": {
+        "@askable-ui/bridge": "^0.17.1",
+        "@askable-ui/core": "^0.17.1"
+      },
+      "devDependencies": {
+        "@types/chrome": "^0.1.8",
+        "@types/node": "^22.10.2",
+        "typescript": "^6.0.3",
+        "vite": "^8.2.2"
+      }
+    },
+    "node_modules/@askable-ui/bridge": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/bridge/-/bridge-0.17.1.tgz",
+      "integrity": "sha512-Z758S+hHD+9cKnvZ5sJqSUHpFcIS6Knng+FvR9rIt07yUE2y02yGrHEfBjdDgk2uEKziEiJw9nFY/8yHpCEuQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@askable-ui/context": "^0.17.1"
+      }
+    },
+    "node_modules/@askable-ui/context": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/context/-/context-0.17.1.tgz",
+      "integrity": "sha512-Iow8LqDEIyC5HOcRfXU4ecq1SZtK8UnW9vxIgy8X7DAMnWJcIIzKJUsRSB2DZH26cjg4cOV+UqkBRFV743DqQg==",
+      "license": "MIT"
+    },
+    "node_modules/@askable-ui/core": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@askable-ui/core/-/core-0.17.1.tgz",
+      "integrity": "sha512-3qDfHaQ0jgCCJPCXsHfawrRWZ4ef1v48R9E8J6CBgqXXZLj5L9r8y4+LOmAfQ+W0GU7CsU+Qu0+5xANqdBbiYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@askable-ui/context": "^0.17.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
+      "integrity": "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.147.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/browser-extension/package.json
+++ b/examples/browser-extension/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@askable-ui/example-browser-extension",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit && vite build"
+  },
+  "dependencies": {
+    "@askable-ui/bridge": "^0.17.1",
+    "@askable-ui/core": "^0.17.1"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.1.8",
+    "@types/node": "^22.10.2",
+    "typescript": "^6.0.3",
+    "vite": "^8.2.2"
+  }
+}

--- a/examples/browser-extension/popup.html
+++ b/examples/browser-extension/popup.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Askable Browser Companion</title>
+  </head>
+  <body>
+    <main class="shell">
+      <header>
+        <span class="mark">✦</span>
+        <div>
+          <h1>Askable</h1>
+          <p>Send page context to any chat surface.</p>
+        </div>
+      </header>
+
+      <label class="question">
+        <span>Question</span>
+        <textarea id="question" rows="3" placeholder="What should I ask about this page?"></textarea>
+      </label>
+
+      <section class="actions" aria-label="Capture mode">
+        <button data-mode="selected" type="button">Selected text</button>
+        <button data-mode="focus" type="button">Focused element</button>
+        <button data-mode="page" type="button">Full page</button>
+      </section>
+
+      <section class="result">
+        <div class="result-head">
+          <strong id="status">Ready</strong>
+          <button id="copy" type="button" disabled>Copy prompt</button>
+        </div>
+        <textarea id="prompt" rows="8" readonly placeholder="Captured prompt context appears here."></textarea>
+        <details>
+          <summary>Bridge envelope</summary>
+          <pre id="packet">{}</pre>
+        </details>
+      </section>
+    </main>
+    <script type="module" src="/src/popup.ts"></script>
+  </body>
+</html>

--- a/examples/browser-extension/public/manifest.json
+++ b/examples/browser-extension/public/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "Askable Browser Companion",
+  "description": "Capture selected, focused, or full-page context and send it through an Askable bridge envelope.",
+  "version": "0.1.0",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Askable"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": ["activeTab", "storage"],
+  "host_permissions": ["http://*/*", "https://*/*"]
+}

--- a/examples/browser-extension/src/background.ts
+++ b/examples/browser-extension/src/background.ts
@@ -1,0 +1,32 @@
+import { isAskableBridgeEnvelope, type AskableBridgeEnvelope } from '@askable-ui/bridge';
+
+const BRIDGE_MESSAGE_TYPE = 'askable:bridge:context';
+const GET_LAST_MESSAGE_TYPE = 'askable-companion:get-last';
+
+let lastEnvelope: AskableBridgeEnvelope | null = null;
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === BRIDGE_MESSAGE_TYPE) {
+    if (!isAskableBridgeEnvelope(message.envelope)) {
+      sendResponse({ ok: false, error: 'Invalid Askable bridge envelope.' });
+      return true;
+    }
+
+    const envelope = message.envelope;
+    lastEnvelope = envelope;
+    sendResponse({
+      ok: true,
+      requestId: envelope.requestId,
+      tabId: sender.tab?.id,
+      storedAt: new Date().toISOString(),
+    });
+    return true;
+  }
+
+  if (message?.type === GET_LAST_MESSAGE_TYPE) {
+    sendResponse({ ok: true, envelope: lastEnvelope });
+    return true;
+  }
+
+  return false;
+});

--- a/examples/browser-extension/src/content.ts
+++ b/examples/browser-extension/src/content.ts
@@ -1,0 +1,244 @@
+import {
+  createAskableContext,
+  createAskableDOMSource,
+  createAskablePageSource,
+  type AskableAsyncContextPacketOptions,
+  type AskableAsyncContextOutputOptions,
+} from '@askable-ui/core';
+import { createAskableBridge, createBrowserExtensionTransport } from '@askable-ui/bridge';
+import type { WebContextRect, WebContextTarget } from '@askable-ui/context';
+
+type CaptureMode = 'selected' | 'focus' | 'page';
+
+interface CaptureMessage {
+  type: 'askable-companion:capture';
+  mode: CaptureMode;
+  question?: string;
+}
+
+const ctx = createAskableContext({
+  maxHistory: 8,
+  textExtractor: (element) => normalizeText(element.textContent ?? '').slice(0, 2000),
+});
+
+let lastElement: Element | null = document.activeElement instanceof Element ? document.activeElement : null;
+
+ctx.observe(document, {
+  events: ['click', 'focus'],
+  targetStrategy: 'deepest',
+});
+
+document.addEventListener('click', (event) => {
+  lastElement = nearestMeaningfulElement(event.target);
+}, true);
+
+document.addEventListener('focusin', (event) => {
+  lastElement = nearestMeaningfulElement(event.target);
+}, true);
+
+ctx.registerSource('page', createAskablePageSource({
+  includeLinks: true,
+  maxHeadings: 30,
+  maxLinks: 30,
+  maxTextLength: 12_000,
+  sanitizeText: (text) => normalizeText(text),
+}));
+
+ctx.registerSource('element', createAskableDOMSource({
+  getElement: () => lastElement,
+  includeAttributes: ['href', 'aria-label', 'title', 'role', 'placeholder'],
+  maxTextLength: 2500,
+}));
+
+const bridge = createAskableBridge({
+  source: {
+    app: 'Askable Browser Companion',
+    route: location.pathname,
+    url: location.href,
+  },
+  destination: {
+    kind: 'browser-extension',
+    label: 'Askable Browser Companion',
+  },
+  transports: [createBrowserExtensionTransport()],
+});
+
+chrome.runtime.onMessage.addListener((message: CaptureMessage, _sender, sendResponse) => {
+  if (message?.type !== 'askable-companion:capture') return false;
+
+  capture(message)
+    .then((result) => sendResponse({ ok: true, ...result }))
+    .catch((error) => sendResponse({
+      ok: false,
+      error: error instanceof Error ? error.message : 'Capture failed.',
+    }));
+
+  return true;
+});
+
+async function capture(message: CaptureMessage) {
+  const packetOptions = packetOptionsFor(message.mode);
+  const promptOptions = promptOptionsFor(message.mode);
+  const packet = await ctx.toContextPacketAsync(packetOptions);
+  const prompt = await ctx.toContextAsync(promptOptions);
+  const acks = await bridge.send(packet, {
+    question: message.question,
+    prompt,
+  });
+
+  return {
+    prompt,
+    packet,
+    envelopeSent: acks.some((ack) => ack.ok),
+    acks,
+  };
+}
+
+function packetOptionsFor(mode: CaptureMode): AskableAsyncContextPacketOptions {
+  const common = {
+    history: 3,
+    privacy: { consent: 'explicit' as const, redacted: false },
+    provenance: { method: 'extension' as const },
+  };
+
+  if (mode === 'selected') {
+    return {
+      ...common,
+      mode: 'text-selection',
+      gesture: 'custom',
+      target: selectionTarget(),
+      sources: [{ id: 'page', mode: 'selected' }],
+    };
+  }
+
+  if (mode === 'page') {
+    return {
+      ...common,
+      mode: 'full-page',
+      gesture: 'custom',
+      includeViewport: true,
+      sources: [{ id: 'page', mode: 'all', maxTokens: 3000 }],
+    };
+  }
+
+  return {
+    ...common,
+    mode: 'element-focus',
+    gesture: 'custom',
+    target: elementTarget(lastElement),
+    sources: [{ id: 'element', mode: 'summary' }, { id: 'page', mode: 'summary' }],
+  };
+}
+
+function promptOptionsFor(mode: CaptureMode): AskableAsyncContextOutputOptions {
+  if (mode === 'page') {
+    return {
+      includeText: true,
+      history: 3,
+      maxTokens: 3500,
+      sources: [{ id: 'page', mode: 'all', maxTokens: 3000 }],
+      sourceLabel: 'Full page context',
+    };
+  }
+
+  if (mode === 'selected') {
+    return {
+      includeText: true,
+      history: 3,
+      maxTokens: 1800,
+      sources: [{ id: 'page', mode: 'selected' }],
+      sourceLabel: 'Selected page context',
+    };
+  }
+
+  return {
+    includeText: true,
+    history: 3,
+    maxTokens: 1800,
+    sources: [{ id: 'element', mode: 'summary' }, { id: 'page', mode: 'summary' }],
+    sourceLabel: 'Focused page context',
+  };
+}
+
+function selectionTarget(): WebContextTarget | undefined {
+  const selection = document.getSelection();
+  const text = normalizeText(selection?.toString() ?? '');
+  if (!selection || !text) return undefined;
+
+  const range = selection.rangeCount > 0 ? selection.getRangeAt(0) : undefined;
+  const rect = range?.getBoundingClientRect();
+  return {
+    label: 'Selected text',
+    role: 'selection',
+    text,
+    ...(rect ? { bounds: rectToContextRect(rect) } : {}),
+  };
+}
+
+function elementTarget(element: Element | null): WebContextTarget | undefined {
+  if (!element) return undefined;
+  const rect = element.getBoundingClientRect();
+  return {
+    label: readElementLabel(element),
+    role: element.getAttribute('role') ?? element.tagName.toLowerCase(),
+    selector: buildSelector(element),
+    text: normalizeText(element.textContent ?? '').slice(0, 1000) || undefined,
+    bounds: rectToContextRect(rect),
+    metadata: {
+      tag: element.tagName.toLowerCase(),
+      id: element.id || undefined,
+      classes: Array.from(element.classList).slice(0, 8),
+    },
+  };
+}
+
+function nearestMeaningfulElement(target: EventTarget | null): Element | null {
+  if (!(target instanceof Element)) return null;
+  return target.closest(
+    '[data-askable],button,a,input,select,textarea,[role],article,section,main,nav,aside,header,footer,h1,h2,h3,h4,h5,h6,li,td,th,p',
+  ) ?? target;
+}
+
+function readElementLabel(element: Element): string | undefined {
+  return normalizeText(
+    element.getAttribute('aria-label')
+      ?? element.getAttribute('title')
+      ?? element.getAttribute('placeholder')
+      ?? element.textContent
+      ?? '',
+  ).slice(0, 160) || undefined;
+}
+
+function buildSelector(element: Element): string {
+  if (element.id) return `#${CSS.escape(element.id)}`;
+
+  const parts: string[] = [];
+  let current: Element | null = element;
+  while (current && current !== document.documentElement && parts.length < 4) {
+    const tag = current.tagName.toLowerCase();
+    const className = Array.from(current.classList)
+      .slice(0, 2)
+      .map((name) => `.${CSS.escape(name)}`)
+      .join('');
+    parts.unshift(`${tag}${className}`);
+    current = current.parentElement;
+  }
+  return parts.join(' > ');
+}
+
+function readSelectedText(): string {
+  return normalizeText(document.getSelection?.()?.toString() ?? '');
+}
+
+function rectToContextRect(rect: DOMRect): WebContextRect {
+  return {
+    x: Math.round(rect.x),
+    y: Math.round(rect.y),
+    width: Math.round(rect.width),
+    height: Math.round(rect.height),
+  };
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}

--- a/examples/browser-extension/src/popup.css
+++ b/examples/browser-extension/src/popup.css
@@ -1,0 +1,156 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #111317;
+  background: #f6f7f9;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  width: 390px;
+  margin: 0;
+  background: #f6f7f9;
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+.shell {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.mark {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid rgba(17, 19, 23, 0.08);
+  border-radius: 10px;
+  color: #4f46e5;
+  background: #fff;
+  box-shadow: 0 10px 24px rgba(17, 19, 23, 0.08);
+  font-size: 18px;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+p,
+.question span,
+summary {
+  color: #5b6472;
+  font-size: 12px;
+}
+
+.question {
+  display: grid;
+  gap: 6px;
+}
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid rgba(17, 19, 23, 0.12);
+  border-radius: 10px;
+  padding: 10px;
+  color: #111317;
+  background: #fff;
+  outline: none;
+}
+
+textarea:focus {
+  border-color: rgba(79, 70, 229, 0.55);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.12);
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+button {
+  min-height: 34px;
+  border: 1px solid rgba(17, 19, 23, 0.1);
+  border-radius: 9px;
+  color: #111317;
+  background: #fff;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  border-color: rgba(79, 70, 229, 0.34);
+  color: #4f46e5;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.result {
+  display: grid;
+  gap: 8px;
+}
+
+.result-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+#status {
+  min-width: 0;
+  color: #111317;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+#copy {
+  flex: 0 0 auto;
+  padding-inline: 10px;
+}
+
+details {
+  border: 1px solid rgba(17, 19, 23, 0.1);
+  border-radius: 10px;
+  background: #fff;
+}
+
+summary {
+  cursor: pointer;
+  padding: 9px 10px;
+}
+
+pre {
+  max-height: 220px;
+  margin: 0;
+  overflow: auto;
+  border-top: 1px solid rgba(17, 19, 23, 0.08);
+  padding: 10px;
+  font-size: 11px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/examples/browser-extension/src/popup.ts
+++ b/examples/browser-extension/src/popup.ts
@@ -1,0 +1,83 @@
+import './popup.css';
+
+type CaptureMode = 'selected' | 'focus' | 'page';
+
+interface CaptureResponse {
+  ok: boolean;
+  error?: string;
+  prompt?: string;
+  packet?: unknown;
+  acks?: unknown;
+}
+
+const statusEl = document.querySelector<HTMLElement>('#status')!;
+const questionEl = document.querySelector<HTMLTextAreaElement>('#question')!;
+const promptEl = document.querySelector<HTMLTextAreaElement>('#prompt')!;
+const packetEl = document.querySelector<HTMLPreElement>('#packet')!;
+const copyButton = document.querySelector<HTMLButtonElement>('#copy')!;
+const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-mode]'));
+
+for (const button of buttons) {
+  button.addEventListener('click', () => {
+    void capture(button.dataset.mode as CaptureMode);
+  });
+}
+
+copyButton.addEventListener('click', async () => {
+  if (!promptEl.value) return;
+  await navigator.clipboard.writeText(promptEl.value);
+  setStatus('Copied prompt context.');
+});
+
+async function capture(mode: CaptureMode): Promise<void> {
+  setBusy(mode);
+
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) throw new Error('No active tab is available.');
+
+    const response = await chrome.tabs.sendMessage(tab.id, {
+      type: 'askable-companion:capture',
+      mode,
+      question: questionEl.value.trim() || undefined,
+    }) as CaptureResponse;
+
+    if (!response?.ok) {
+      throw new Error(response?.error ?? 'The page did not return Askable context.');
+    }
+
+    promptEl.value = response.prompt ?? '';
+    packetEl.textContent = JSON.stringify({
+      packet: response.packet,
+      acks: response.acks,
+    }, null, 2);
+    copyButton.disabled = !promptEl.value;
+    setStatus(`Captured ${labelFor(mode)} context.`);
+  } catch (error) {
+    promptEl.value = '';
+    packetEl.textContent = '{}';
+    copyButton.disabled = true;
+    setStatus(error instanceof Error ? error.message : 'Capture failed.');
+  } finally {
+    setIdle();
+  }
+}
+
+function setBusy(mode: CaptureMode): void {
+  setStatus(`Capturing ${labelFor(mode)} context...`);
+  for (const button of buttons) button.disabled = true;
+}
+
+function setIdle(): void {
+  for (const button of buttons) button.disabled = false;
+}
+
+function setStatus(message: string): void {
+  statusEl.textContent = message;
+}
+
+function labelFor(mode: CaptureMode): string {
+  if (mode === 'selected') return 'selected text';
+  if (mode === 'page') return 'full page';
+  return 'focused element';
+}

--- a/examples/browser-extension/src/vite-env.d.ts
+++ b/examples/browser-extension/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/browser-extension/tsconfig.json
+++ b/examples/browser-extension/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["chrome", "node"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/browser-extension/vite.config.ts
+++ b/examples/browser-extension/vite.config.ts
@@ -1,0 +1,25 @@
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const rootDir = fileURLToPath(new URL('.', import.meta.url));
+
+export default defineConfig({
+  publicDir: 'public',
+  build: {
+    emptyOutDir: true,
+    outDir: 'dist',
+    rollupOptions: {
+      input: {
+        background: resolve(rootDir, 'src/background.ts'),
+        content: resolve(rootDir, 'src/content.ts'),
+        popup: resolve(rootDir, 'popup.html'),
+      },
+      output: {
+        entryFileNames: '[name].js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: 'assets/[name][extname]',
+      },
+    },
+  },
+});

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -133,6 +133,7 @@ export default defineConfig({
             { text: 'AI SDK Integration', link: '/examples/ai-sdk' },
             { text: 'CopilotKit', link: '/examples/copilotkit' },
             { text: 'Ask AI Button', link: '/examples/ask-ai-button' },
+            { text: 'Browser Extension Companion', link: '/examples/browser-extension' },
           ],
         },
       ],

--- a/site/docs/examples/browser-extension.md
+++ b/site/docs/examples/browser-extension.md
@@ -1,0 +1,90 @@
+# Browser Extension Companion
+
+The browser extension example shows how Askable can capture context without
+requiring the site owner to change their app. It is the starting point for a
+local companion that sends selected or page context into a chat product,
+webhook, or MCP bridge.
+
+## Install and build
+
+```bash
+cd examples/browser-extension
+npm install
+npm run build
+```
+
+Load `examples/browser-extension/dist` as an unpacked extension from
+`chrome://extensions`.
+
+## Flow
+
+```text
+popup capture button
+  -> content script
+  -> page, selection, or DOM source
+  -> @askable-ui/bridge
+  -> extension background worker
+```
+
+The content script creates an Askable context, registers fallback page and DOM
+sources, and sends a bridge envelope:
+
+```ts
+import {
+  createAskableContext,
+  createAskableDOMSource,
+  createAskablePageSource,
+} from '@askable-ui/core';
+import { createAskableBridge, createBrowserExtensionTransport } from '@askable-ui/bridge';
+
+const ctx = createAskableContext();
+ctx.observe(document, { events: ['click', 'focus'] });
+ctx.registerSource('page', createAskablePageSource({ includeLinks: true }));
+ctx.registerSource('element', createAskableDOMSource({ getElement: () => lastElement }));
+
+const bridge = createAskableBridge({
+  transports: [createBrowserExtensionTransport()],
+});
+
+const packet = await ctx.toContextPacketAsync({
+  mode: 'full-page',
+  privacy: { consent: 'explicit', redacted: false },
+  provenance: { method: 'extension' },
+  sources: [{ id: 'page', mode: 'all', maxTokens: 3000 }],
+});
+
+await bridge.send(packet, {
+  prompt: await ctx.toContextAsync({ sources: [{ id: 'page', mode: 'all' }] }),
+});
+```
+
+The background worker validates the envelope before trusting it:
+
+```ts
+import { isAskableBridgeEnvelope } from '@askable-ui/bridge';
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type !== 'askable:bridge:context') return false;
+  if (!isAskableBridgeEnvelope(message.envelope)) {
+    sendResponse({ ok: false });
+    return true;
+  }
+
+  sendResponse({ ok: true, requestId: message.envelope.requestId });
+  return true;
+});
+```
+
+## What works without site code
+
+| Context | Available from extension fallback |
+|---|---|
+| Selected text | Yes |
+| Full page text | Yes, bounded by the extension |
+| Headings and links | Yes |
+| Last clicked or focused DOM element | Yes |
+| Rich app state, hidden table pages, selected rows, filters | Only when the app exposes it through `data-askable` or registered sources |
+
+Use this example for the general browser companion path. Use framework
+integrations or custom sources when you own the app and need precise state such
+as full paginated table data, chart series, or authenticated business objects.

--- a/site/docs/guide/bridge.md
+++ b/site/docs/guide/bridge.md
@@ -85,6 +85,12 @@ chrome.runtime.onMessage.addListener((message) => {
 });
 ```
 
+For a complete Manifest V3 extension, see the
+[Browser Extension Companion example](/examples/browser-extension). It captures
+selected text, the last focused DOM element, or bounded full-page context from
+any normal web page, then sends the same bridge envelope to the extension
+background worker.
+
 ## Iframe or same-window bridge
 
 Use `postMessage` when a chat surface is embedded in an iframe or a sibling


### PR DESCRIPTION
## Summary
- add a Manifest V3 browser extension companion example for the no-site-code path
- capture selected text, focused DOM element, or bounded full-page context from any normal tab
- send the packet through @askable-ui/bridge and validate it in the extension background worker
- document the example from the bridge guide, examples docs, and README indexes

## Notes
- no package version bump; this is an example/docs feature only
- the example is provider-neutral and leaves side panel, local app, webhook, or MCP forwarding to the extension owner

## Verification
- npm run build in examples/browser-extension
- npm run build in site/docs
- node scripts/check-example-askable-versions.mjs
- node scripts/check-publish-package-coverage.mjs
- node scripts/check-mcp-server-manifest.mjs
- git diff --check
